### PR TITLE
Introduce Jira Tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.plugins.jacoco.version>0.8.8</maven.plugins.jacoco.version>
         <maven.plugins.gpg.version>1.5</maven.plugins.gpg.version>
         <maven.plugin.source>3.2.1</maven.plugin.source>
+        <mockito.version>3.5.13</mockito.version>
     </properties>
     <modules>
         <module>workflow-engine</module>

--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -15,7 +15,20 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <assertj.version>3.19.0</assertj.version>
+        <jira-rest-client.version>4.0.0</jira-rest-client.version>
+        <attlasian-fugue.version>2.6.1</attlasian-fugue.version>
+        <org.json.version>20230227</org.json.version>
     </properties>
+
+    <repositories>
+        <!-- Needed for Jira Task -->
+        <repository>
+            <id>atlassian-public</id>
+            <url>https://packages.atlassian.com/maven/repository/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>dev.parodos</groupId>
@@ -44,6 +57,21 @@
             <version>10.2</version>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-rest-java-client-core</artifactId>
+            <version>${jira-rest-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.fugue</groupId>
+            <artifactId>fugue</artifactId>
+            <version>${attlasian-fugue.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${org.json.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
@@ -52,7 +80,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.9.0</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraIssue.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraIssue.java
@@ -1,0 +1,26 @@
+package com.redhat.parodos.tasks.jira;
+
+import java.util.List;
+
+/**
+ * JiraIssue is a DTO representing a subset of an issue, and used as an input and output
+ * to/from a {@link JiraTask}
+ *
+ */
+public class JiraIssue {
+
+	String id, project, description, summary, status;
+
+	List<String> comments;
+
+	public JiraIssue(String id, String project, String summary, String description, String status,
+			List<String> comments) {
+		this.id = id;
+		this.project = project;
+		this.summary = summary;
+		this.description = description;
+		this.status = status;
+		this.comments = comments;
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
@@ -1,0 +1,280 @@
+package com.redhat.parodos.tasks.jira;
+
+import com.atlassian.jira.rest.client.api.IssueRestClient;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.atlassian.jira.rest.client.api.domain.Comment;
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.Transition;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
+import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
+import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.StreamSupport;
+
+import static com.redhat.parodos.workflow.context.WorkContextDelegate.getOptionalValueFromRequestParams;
+import static com.redhat.parodos.workflow.context.WorkContextDelegate.getRequiredValueFromRequestParams;
+
+/**
+ * JiraTask can create/retrieve/update/delete a jira task depending on the fields passed
+ * in the context of the execution. #excute returns an extended work report containing a
+ * jira issue, and/or the api respond Any 2xx return code is COMPLETED, and anything else
+ * is FAILED
+ *
+ *
+ */
+@Slf4j
+public class JiraTask extends BaseWorkFlowTask {
+
+	// The jira client to work with. If nothing is passed then a default client
+	// implementation is used, using the context params serverURL and bearerToken
+	// during execution time.
+	protected JiraIssueClient jiraClient;
+
+	public static final int DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS = 600;
+
+	@Override
+	public @NonNull List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
+		return List.of(
+				WorkFlowTaskParameter.builder().key("serverURL").type(WorkFlowTaskParameterType.TEXT).optional(false)
+						.description("Base URL of the Jira instance - e.g https://jira.example.org").build(),
+				WorkFlowTaskParameter.builder().key("bearerToken").type(WorkFlowTaskParameterType.TEXT).optional(false)
+						.description("Bearer token to authenticate Jira server requests").build());
+	}
+
+	/**
+	 * @param workContext optional context values: serverURL, and bearerToken for the
+	 * Jira's client auth. Other optional context values and how they affect execution:
+	 * Create: id: do not exist in the context map title: value of title comments: [ list
+	 * of comments to add ] Retrieve: id: valid ticket id all title, status, comments do
+	 * not exist in the map Update: id: valid ticket id status: new ticket status (allows
+	 * closing) title: new title comments: new comment to add If none of the context
+	 * params passed then this execution is invalid and returns a failure.
+	 * @return
+	 */
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		if (jiraClient == null) {
+			// allow initiating the jira client without a context param.
+			// Usefull for testing and initiating the client details directly
+			/// by flow authors (for security reasons, it prevents the invoker
+			// changing the server URL and the token)
+			try {
+				var serverUrl = getRequiredValueFromRequestParams(workContext, "serverURL");
+				var bearerToken = getOptionalValueFromRequestParams(workContext, "bearerToken", null);
+				this.jiraClient = new JiraClient(URI.create(serverUrl), bearerToken);
+			}
+			catch (MissingParameterException e) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+			}
+		}
+		var id = getOptionalValueFromRequestParams(workContext, "id", "");
+		var summary = getOptionalValueFromRequestParams(workContext, "summary", "");
+		var project = getOptionalValueFromRequestParams(workContext, "project", "");
+		var status = getOptionalValueFromRequestParams(workContext, "status", "");
+		var description = getOptionalValueFromRequestParams(workContext, "description", "");
+		var comment = getOptionalValueFromRequestParams(workContext, "comment", "");
+
+		if (id.isBlank()) {
+			try {
+				JiraIssue issue = createIssue(new JiraIssue("", project, summary, description, "", List.of(comment)));
+				WorkReport report = new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext(), null);
+				report.getWorkContext().put("issue", issue);
+				return report;
+			}
+			catch (Exception e) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+			}
+
+		}
+		else {
+			try {
+				JiraIssue issue = getIssueByID(id);
+
+				if (summary.isBlank() && description.isBlank() && comment.isBlank()) {
+					// this is just a fetch, return the issue
+
+					var context = new WorkContext();
+					context.put("issue", issue);
+					return new DefaultWorkReport(WorkStatus.COMPLETED, context, null);
+				}
+				if (!summary.isBlank() && !issue.summary.equals(summary)) {
+					issue.summary = summary;
+				}
+				if (!description.isBlank() && !issue.description.equals(description)) {
+					issue.description = description;
+				}
+				if (!status.isBlank() && !issue.status.equals(status)) {
+					issue.status = status;
+				}
+
+				updateIssue(issue);
+
+				// adding comments?
+				if (!comment.isBlank()) {
+					jiraClient.addComment(id, comment);
+				}
+				var context = new WorkContext();
+				context.put("issue", issue);
+				return new DefaultWorkReport(WorkStatus.COMPLETED, context, null);
+			}
+			catch (Exception e) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+			}
+		}
+	}
+
+	private JiraIssue createIssue(JiraIssue issue) throws Exception {
+		try {
+			JSONObject jsonObject = jiraClient.create(issue.project, issue.summary, issue.description);
+			return new JiraIssue(jsonObject.getString("id").toString(), null, null, null, null, null);
+		}
+		catch (Exception e) {
+			throw new Exception(e);
+		}
+	}
+
+	private void updateIssue(JiraIssue issue) throws Exception {
+		try {
+			jiraClient.update(issue.id, issue.summary, issue.description, issue.status);
+		}
+		catch (JSONException e) {
+			throw new Exception(e);
+		}
+	}
+
+	private JiraIssue getIssueByID(String id) throws Exception {
+		try {
+			JSONObject o = jiraClient.get(id);
+			return new JiraIssue(o.getString("id"), o.getString("project"), o.getString("summary"),
+					o.getString("description"), o.getString("status"), Collections.emptyList());
+		}
+		catch (JSONException e) {
+			throw new Exception(e);
+		}
+	}
+
+	interface JiraIssueClient {
+
+		JSONObject get(String id) throws Exception;
+
+		void update(String id, String summary, String description, String status) throws Exception;
+
+		void addComment(String id, String comment) throws Exception;
+
+		JSONObject create(String project, String summary, String description) throws Exception;
+
+	}
+
+	static class JiraClient implements JiraIssueClient {
+
+		private IssueRestClient restClient;
+
+		private JiraClient(URI serverURI, String bearerToken) {
+			restClient = new AsynchronousJiraRestClientFactory()
+					.create(serverURI, r -> r.setHeader("Authorization", bearerToken)).getIssueClient();
+		}
+
+		@Override
+		public JSONObject get(String id) throws Exception {
+			Issue issue;
+			try {
+				issue = restClient.getIssue(id).get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new Exception(e);
+			}
+			return new JSONObject().put("id", issue.getId()).put("summary", issue.getSummary())
+					.put("description", issue.getDescription()).put("status", issue.getStatus())
+					.put("comments", issue.getComments());
+		}
+
+		@Override
+		public void update(String id, String summary, String description, String status) throws Exception {
+			var issueInputBuilder = new IssueInputBuilder();
+			if (description != null && !description.isBlank()) {
+				issueInputBuilder.setDescription(description);
+			}
+			if (summary != null && !summary.isBlank()) {
+				issueInputBuilder.setSummary(summary);
+			}
+
+			try {
+				restClient.updateIssue(id, issueInputBuilder.build()).get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS,
+						TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new Exception(e);
+			}
+
+			Issue issue;
+			try {
+				issue = restClient.getIssue(id).get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+				Iterable<Transition> transitions = restClient.getTransitions(issue)
+						.get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+
+				Optional<Transition> transition = StreamSupport.stream(transitions.spliterator(), false)
+						.filter(t -> t.getName().equals(status)).findFirst();
+				if (transition.isPresent()) {
+					restClient.transition(issue, new TransitionInput(transition.get().getId()))
+							.get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+				}
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public void addComment(String id, String comment) throws Exception {
+			Issue issue;
+			try {
+				issue = restClient.getIssue(id).get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new Exception(e);
+			}
+
+			try {
+				restClient.addComment(issue.getCommentsUri(), Comment.valueOf(comment))
+						.get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public JSONObject create(String project, String summary, String description) throws Exception {
+			IssueInput input = new IssueInputBuilder().setSummary(summary).setProjectKey(project)
+					.setDescription(description).build();
+			try {
+				BasicIssue issue = restClient.createIssue(input).get(DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS,
+						TimeUnit.SECONDS);
+				return new JSONObject().put("id", issue.getId());
+			}
+			catch (InterruptedException | ExecutionException | TimeoutException e) {
+				throw new Exception(e);
+			}
+		}
+
+	}
+
+}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
@@ -1,0 +1,165 @@
+package com.redhat.parodos.tasks.jira;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.SneakyThrows;
+import org.assertj.core.api.Assertions;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JiraTaskTest {
+
+	JiraTask underTest;
+
+	@Mock
+	JiraTask.JiraClient mockClient;
+
+	WorkContext ctx;
+
+	@Before
+	public void setUp() {
+		underTest = new JiraTask();
+		underTest.setBeanName("jiraTask");
+		underTest.jiraClient = mockClient;
+		ctx = new WorkContext();
+	}
+
+	@Test
+	@SneakyThrows
+	public void failsNotFound() {
+		ctx.put("id", "non-existing");
+		when(mockClient.get(anyString())).thenThrow(new Exception("not found"));
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
+		verify(mockClient, Mockito.times(1)).get(anyString());
+		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void createFails() {
+		ctx.put("id", "");
+		when(mockClient.create(anyString(), anyString(), anyString()))
+				.thenThrow(new Exception("Missing mandatory params to create a ticket"));
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
+		verify(mockClient, Mockito.times(0)).get(anyString());
+		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(1)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void updateFails() {
+		ctx.put("id", "123");
+		ctx.put("description", "new description");
+		when(mockClient.get(anyString())).thenReturn(
+				new JSONObject().put("id", "123").put("project", "parodos").put("summary", "some issue summary")
+						.put("description", "issue description").put("status", "in-progress"));
+		doThrow(new Exception()).when(mockClient).update(anyString(), anyString(), anyString(), anyString());
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		Assertions.assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
+		verify(mockClient, Mockito.times(1)).get(anyString());
+		verify(mockClient, Mockito.times(1)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void getById() {
+		ctx.put("id", "123");
+
+		when(mockClient.get(anyString())).thenReturn(
+				new JSONObject().put("id", "123").put("project", "parodos").put("summary", "some issue summary")
+						.put("description", "issue description").put("status", "in-progress"));
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+		verify(mockClient, Mockito.times(1)).get(anyString());
+		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void createCompletes() {
+		ctx.put("id", "");
+
+		when(mockClient.create(anyString(), anyString(), anyString())).thenReturn(
+				new JSONObject().put("id", "123").put("project", "parodos").put("summary", "some issue summary")
+						.put("description", "issue description").put("status", "in-progress"));
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+		verify(mockClient, Mockito.times(0)).get(anyString());
+		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(1)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void updateCompletes() {
+		ctx.put("id", "123");
+		ctx.put("description", "new description");
+		when(mockClient.get(anyString())).thenReturn(
+				new JSONObject().put("id", "123").put("project", "parodos").put("summary", "some issue summary")
+						.put("description", "issue description").put("status", "in-progress"));
+		doThrow(new Exception()).when(mockClient).update(anyString(), anyString(), anyString(), anyString());
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		Assertions.assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
+		verify(mockClient, Mockito.times(1)).get(anyString());
+		verify(mockClient, Mockito.times(1)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	@SneakyThrows
+	public void AddCommentCompletes() {
+		ctx.put("id", "123");
+		ctx.put("comment", "new comment");
+		when(mockClient.get(anyString())).thenReturn(
+				new JSONObject().put("id", "123").put("project", "parodos").put("summary", "some issue summary")
+						.put("description", "issue description").put("status", "in-progress"));
+		doNothing().when(mockClient).update(anyString(), anyString(), anyString(), anyString());
+		doNothing().when(mockClient).addComment(anyString(), anyString());
+
+		WorkReport execute = underTest.execute(ctx);
+
+		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+		verify(mockClient, Mockito.times(1)).get("123");
+		verify(mockClient, Mockito.times(1)).addComment("123", "new comment");
+		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+	}
+
+}

--- a/workflow-engine/pom.xml
+++ b/workflow-engine/pom.xml
@@ -26,7 +26,6 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <mockito.version>3.5.13</mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>


### PR DESCRIPTION
Introduce Jira tasks that supports the following behaviour:
- create:
    pass empty ID, with details:
    { id: "" , title: "title", description: "description" }
- update:
    specify ID, specify new title, new status, and new comments to add:
    {
      id: "PROJECT-123",
      title: "edited title",
      status: "new status (in-progress, refinement, closed, etc)",
      comments: [ "new comment to add" ],
    }

Returned value: new work report of type JiraWorkReport containing the
json object of the response (and the actual ticket)

Signed-off-by: Roy Golan <rgolan@redhat.com>

[FLPATH-175](https://issues.redhat.com//browse/FLPATH-175)
