### PR TITLE
Enable graceful shutdown endpoint

### DIFF
--- a/workflow-examples/start_workflow_service.sh
+++ b/workflow-examples/start_workflow_service.sh
@@ -1,5 +1,4 @@
-export SERVER_PORT=8080
+pushd ../workflow-service
+./start_workflow_service.sh
+popd
 
-java -jar -Dspring.profiles.active=local \
-    -Dloader.path=../workflow-examples/target/workflow-examples-1.0.5-SNAPSHOT-jar-with-dependencies.jar \
-    ../workflow-service/target/workflow-service-1.0.5-SNAPSHOT.jar

--- a/workflow-service/run_workflow_service.sh
+++ b/workflow-service/run_workflow_service.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script starts the workflow service and monitors it.
+# If the service dies, it will be restarted.
+# This script is useful for development and testing.
+# Environment variables:
+#   USER_WORKFLOWS_JAR_FILE - path to the user workflows jar file (optional). If not set, the example workflows jar file
+#   will be used.
+#   SPRING_PROFILES_ACTIVE - Spring profiles to use (optional). If not set, the "local" profile will be used.
+# The script should be executed from the workflow-service directory.
+
+# Define variables
+CHECK_INTERVAL=5
+SERVICE_JAR_FILE=$(ls -1 target/workflow-service-*.jar)
+WORKFLOWS_EXAMPLE_JAR_FILE=$(ls -1 ../workflow-examples/target/workflow-examples-*-jar-with-dependencies.jar)
+WORKFLOWS_JAR_FILE="${USER_WORKFLOWS_JAR_FILE:-$WORKFLOWS_EXAMPLE_JAR_FILE}"
+LOADER_PATH=$WORKFLOWS_JAR_FILE
+SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE:-local}"
+
+# Define function to start Java process
+start_workflow_service_process() {
+  LOADER_PATH=$LOADER_PATH SPRING_PROFILES_ACTIVE=$SPRING_PROFILES_ACTIVE java -jar $SERVICE_JAR_FILE &
+  SERVICE_JAVA_PID=$!
+}
+
+# Define function to stop Java process gracefully
+stop_workflow_service_process() {
+  curl -X POST http://localhost:8080/actuator/shutdown
+  wait $SERVICE_JAVA_PID
+}
+
+# Stop Java process gracefully when script is killed
+trap "stop_workflow_service_process; exit" SIGINT SIGTERM
+
+# Start Java process
+start_workflow_service_process
+
+# Monitor Java process and restart if died
+while true; do
+  # Wait for a few seconds before checking the process status
+  sleep $CHECK_INTERVAL
+
+  # Check if the Java process is still running
+  if ! ps -p $SERVICE_JAVA_PID > /dev/null; then
+    echo "Workflow-service process is not running. Restarting..."
+    stop_workflow_service_process
+    start_workflow_service_process
+  fi
+done

--- a/workflow-service/src/main/java/com/redhat/parodos/security/SecurityConfiguration.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/security/SecurityConfiguration.java
@@ -15,8 +15,7 @@
  */
 package com.redhat.parodos.security;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
+import com.redhat.parodos.config.properties.LdapConnectionProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,11 +29,11 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.stereotype.Component;
 
-import com.redhat.parodos.config.properties.LdapConnectionProperties;
+import static org.springframework.security.config.Customizer.withDefaults;
 
 /**
  * Security configuration for the application to ensure the main endpoints are locked down
- * and an OAuth2 server is enable. The OAuth2 server details can be found in the
+ * and an OAuth2 server is enabled. The OAuth2 server details can be found in the
  * application.yml file
  *
  * @author Luke Shannon (Github: lshannon)
@@ -59,7 +58,7 @@ public class SecurityConfiguration {
 			.authorizeRequests()
 			.mvcMatchers(HttpMethod.OPTIONS, "/**")
 			.permitAll()
-			.mvcMatchers("/api/**")
+			.mvcMatchers("/api/**", "/actuator/shutdown")
 			.fullyAuthenticated()
 			.and()
 			.httpBasic(withDefaults())

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -43,6 +43,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import javax.annotation.PreDestroy;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -242,6 +243,11 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 
 		// TODO: validate required parameters from definition
 		return null;
+	}
+
+	@PreDestroy
+	public void gracefulShutdown() {
+		log.info(">> Shutting down the workflow service");
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -16,26 +16,19 @@
 package com.redhat.parodos.workflow.registry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
-import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.annotation.Assessment;
 import com.redhat.parodos.workflow.annotation.Checker;
+import com.redhat.parodos.workflow.annotation.Escalation;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
+import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.parameter.WorkFlowParameter;
 import com.redhat.parodos.workflow.parameter.WorkFlowParameterType;
 import com.redhat.parodos.workflow.task.WorkFlowTask;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-import javax.annotation.PostConstruct;
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -44,7 +37,16 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
-import com.redhat.parodos.workflow.annotation.Escalation;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An implementation of the WorkflowRegistry that loads all Bean definitions of type
@@ -178,6 +180,11 @@ public class BeanWorkFlowRegistryImpl implements WorkFlowRegistry<String> {
 				return false;
 			}
 		});
+	}
+
+	@PreDestroy
+	public void gracefulShutdown() {
+		log.info(">> Shutting down the bean workflow registry");
 	}
 
 }

--- a/workflow-service/src/main/resources/application-dev.yml
+++ b/workflow-service/src/main/resources/application-dev.yml
@@ -15,6 +15,21 @@ spring:
       passwordAttribute: "userPassword"
       managerDN: "cn=admin,dc=parodos,dc=dev"
       managerPassword: "admin"
+  lifecycle:
+    timeout-per-shutdown-phase: "25s"
 springdoc:
   writer-with-order-by-keys: true
   writer-with-default-pretty-printer: true
+management:
+  endpoint:
+    shutdown:
+      enabled: true
+    health:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: "health,shutdown"
+server:
+  shutdown: "graceful"

--- a/workflow-service/src/main/resources/application-local.yml
+++ b/workflow-service/src/main/resources/application-local.yml
@@ -15,6 +15,21 @@ spring:
       passwordAttribute: "userPassword"
       managerDN: null
       managerPassword: null
+  lifecycle:
+    timeout-per-shutdown-phase: "25s"
 springdoc:
   writer-with-order-by-keys: true
   writer-with-default-pretty-printer: true
+management:
+  endpoint:
+    shutdown:
+      enabled: true
+    health:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: "health,shutdown"
+server:
+  shutdown: "graceful"

--- a/workflow-service/src/main/resources/application.yml
+++ b/workflow-service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     url: ${DATASOURCE_URL:jdbc:h2:mem:workflow_service}
-    driverClassName:  ${DATASOURCE_DRIVER:org.h2.Driver}
+    driverClassName: ${DATASOURCE_DRIVER:org.h2.Driver}
     username: ${DATASOURCE_USERNAME:postgres}
     password: ${DATASOURCE_PASSWORD:postgres}
     hikari:
@@ -35,6 +35,24 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: ${keycloak_url:http://localhost:3434/realms/Parodos/protocol/openid-connect/certs}
+
+  lifecycle:
+    timeout-per-shutdown-phase: "25s"
+
+management:
+  endpoint:
+    shutdown:
+      enabled: true
+    health:
+      enabled: true
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: "health,shutdown"
+
+server:
+  shutdown: "graceful"
 
 springdoc:
   swagger-ui:

--- a/workflow-service/start_workflow_service.sh
+++ b/workflow-service/start_workflow_service.sh
@@ -1,3 +1,5 @@
-java -jar -Dspring.profiles.active=local \
-    -Dloader.path=../workflow-examples/target/workflow-examples-1.0.5-SNAPSHOT-jar-with-dependencies.jar \
-    target/workflow-service-1.0.5-SNAPSHOT.jar
+SERVICE_JAR_FILE=$(ls -1 ../workflow-service/target/workflow-service-*.jar)
+WORKFLOWS_EXAMPLE_JAR_FILE=$(ls -1 ../workflow-examples/target/workflow-examples-*-jar-with-dependencies.jar)
+SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE:-local}"
+LOADER_PATH=$WORKFLOWS_EXAMPLE_JAR_FILE
+SERVER_PORT=8080 LOADER_PATH=$LOADER_PATH SPRING_PROFILES_ACTIVE=$SPRING_PROFILES_ACTIVE java -jar $SERVICE_JAR_FILE


### PR DESCRIPTION
The PR enables the shutdown endpoint which can be triggered by:
(for `local` profile)
```
curl -u test:test -X POST  localhost:8080/actuator/shutdown
```

In addition, a script for local invocation of the `workflow-service` is added. If the service dies, the script will relaunch it. It may be useful for testing/development locally when there is a need to replace only the workflows jar.

The graceful shutdown timeout (`spring.lifecycle.timeout-per-shutdown-phase`) is set to 25s, since the default timeout for K8s pods is 30s. This can be revisited and tuned by changing the `workflow-service` deployment to specify a different timeout by terminationGracePeriodSeconds.


The graceful shutdown sequence should look as:
```
2023-03-27 22:54:55.497  INFO 861119 --- [       Thread-7] o.s.b.w.e.tomcat.GracefulShutdown        : Commencing graceful shutdown. Waiting for active requests to complete
2023-03-27 22:54:55.507  INFO 861119 --- [tomcat-shutdown] o.s.b.w.e.tomcat.GracefulShutdown        : Graceful shutdown complete
2023-03-27 22:54:55.571  INFO 861119 --- [       Thread-7] c.r.p.w.e.service.WorkFlowServiceImpl    :  >>>>>>>>> Shutting down the workflow service <<<<<<<<<<<
2023-03-27 22:54:55.571  INFO 861119 --- [       Thread-7] c.r.p.w.r.BeanWorkFlowRegistryImpl       :  >>>>>>>>> Shutting down the bean registry <<<<<<<<<<<
2023-03-27 22:54:55.572  INFO 861119 --- [       Thread-7] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2023-03-27 22:54:55.574  INFO 861119 --- [       Thread-7] com.zaxxer.hikari.HikariDataSource       : ${DATASOURCE_NAME} - Shutdown initiated...
2023-03-27 22:54:55.578  INFO 861119 --- [       Thread-7] com.zaxxer.hikari.HikariDataSource       : ${DATASOURCE_NAME} - Shutdown completed.
```