### PR TITLE
Fix: change workflow-service openapi generator phases

### DIFF
--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -241,7 +241,6 @@
                     <execution>
                         <configuration>
                             <jvmArguments>-Dspring-boot.run.profiles=local</jvmArguments>
-                            <fork>false</fork>
                         </configuration>
                         <id>pre-openapi-json-gen</id>
                         <goals>
@@ -250,9 +249,6 @@
                         <phase>process-classes</phase>
                     </execution>
                     <execution>
-                        <configuration>
-                            <fork>false</fork>
-                        </configuration>
                         <id>post-openapi-json-gen</id>
                         <goals>
                             <goal>stop</goal>

--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -247,7 +247,7 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
-                        <phase>prepare-package</phase>
+                        <phase>process-classes</phase>
                     </execution>
                     <execution>
                         <configuration>
@@ -257,7 +257,7 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
-                        <phase>pre-integration-test</phase>
+                        <phase>process-test-sources</phase>
                     </execution>
                     <execution>
                         <goals>
@@ -282,7 +282,7 @@
                         <goals>
                             <goal>generate</goal>
                         </goals>
-                        <phase>package</phase>
+                        <phase>generate-test-sources</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
SpringBoot must be started/stopped to create the `openapi.json` file.
Current selected phases generated the file and stopped SpringBoot wrongly.