### PR TITLE
Fix: squash dupicated declaration of `maven-clean-plugin`

### DIFF
--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -157,6 +157,28 @@
                 <version>2.5</version>
                 <executions>
                     <execution>
+                        <id>auto-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.parent.basedir}/notification-service-sdk</directory>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>.openapi-generator-ignore</exclude>
+                                        <exclude>pom.xml</exclude>
+                                    </excludes>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>clean-openapi-json</id>
                         <phase>clean</phase>
                         <goals>
@@ -244,34 +266,6 @@
                     </goals>
                     <phase>generate-test-sources</phase>
                 </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <configuration>
-                            <filesets>
-                                <fileset>
-                                    <directory>${project.parent.basedir}/notification-service-sdk</directory>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
-                                    <excludes>
-                                        <exclude>.openapi-generator-ignore</exclude>
-                                        <exclude>pom.xml</exclude>
-                                    </excludes>
-                                    <followSymlinks>false</followSymlinks>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
When executing command `mvn` goals the following warning come up:

```bash
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for dev.parodos:notification-service:jar:1.0.5-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-clean-plugin @ dev.parodos:notification-service:${revision}, /home/gloria/repos/parodos/notification-service/pom.xml, line 249, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```