### PR TITLE
Set scope for workflow-example dependencies

### DIFF
--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -91,11 +91,13 @@
             <groupId>dev.parodos</groupId>
             <artifactId>prebuilt-tasks</artifactId>
             <version>${revision}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>dev.parodos</groupId>
             <artifactId>workflow-service-sdk</artifactId>
             <version>${revision}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Due to the default dependencies scope, too many dependencies were packaged in workflow-example uber jar.

This PR sets proper dependencies for the project:
prebuilt-tasks - needs to be provided by the workflow-service workflow-service-sdk - shouldn't be used in runtime, since the purpose of the SDK is to interact with the service API which isn't in the scope of the workflow itself.

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/work/parodos/workflow-service/../workflow-examples/target/workflow-examples-1.0.6-SNAPSHOT-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
```