### PR TITLE
Update Jira java-client version

### DIFF
--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <assertj.version>3.19.0</assertj.version>
-        <jira-rest-client.version>4.0.0</jira-rest-client.version>
+        <jira-rest-client.version>5.2.4</jira-rest-client.version>
         <attlasian-fugue.version>2.6.1</attlasian-fugue.version>
         <org.json.version>20230227</org.json.version>
     </properties>


### PR DESCRIPTION
The previous version has introduced an outdated version of guava which failed to start the service when running in a local mode against local Postgres.