### PR TITLE
pom.xml: use dependecy management

### DIFF
--- a/notification-service-sdk/pom.xml
+++ b/notification-service-sdk/pom.xml
@@ -305,20 +305,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.5</gson-fire-version>
         <swagger-core-version>1.6.3</swagger-core-version>
         <okhttp-version>4.9.2</okhttp-version>

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -29,7 +29,6 @@
         <postgres.socket.factory.version>1.2.0</postgres.socket.factory.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <springframework.boot.version>2.5.14</springframework.boot.version>
         <openapi.generator.version>5.4.0</openapi.generator.version>
 
         <gson-fire-version>1.8.5</gson-fire-version>
@@ -193,14 +192,6 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <!-- Import dependency management from Spring Boot -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${springframework.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/parodos-model-api/pom.xml
+++ b/parodos-model-api/pom.xml
@@ -27,16 +27,9 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
         <lombok.version>1.18.26</lombok.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.framework.version>5.3.26</spring.framework.version>
         <jackson-databind.version>2.14.2</jackson-databind.version>
-        <junit.version>4.13.1</junit.version>
     </properties>
 
     <dependencies>
@@ -72,14 +65,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <revision>1.0.7-SNAPSHOT</revision>
         <flatten.version>1.3.0</flatten.version>
         <java.version>11</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.plugins.compiler.version>3.8.1</maven.plugins.compiler.version>
         <maven.plugins.release.version>2.5.3</maven.plugins.release.version>
         <maven.plugins.surefire.version>2.22.2</maven.plugins.surefire.version>
@@ -53,7 +54,11 @@
         <maven.plugins.jacoco.version>0.8.8</maven.plugins.jacoco.version>
         <maven.plugins.gpg.version>1.5</maven.plugins.gpg.version>
         <maven.plugin.source>3.2.1</maven.plugin.source>
+        <springframework.boot.version>2.5.14</springframework.boot.version>
+        <spring.javaformat.version>0.0.34</spring.javaformat.version>
+        <junit.version>4.13.1</junit.version>
         <mockito.version>3.5.13</mockito.version>
+        <assertj.version>3.17.2</assertj.version>
     </properties>
     <modules>
         <module>workflow-engine</module>
@@ -68,13 +73,43 @@
         <module>pattern-detection-library</module>
         <module>coverage</module>
     </modules>
-    <dependencies>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
-        </dependency>
-    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${springframework.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>
@@ -134,22 +169,26 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>io.spring.javaformat</groupId>
+                    <artifactId>spring-javaformat-maven-plugin</artifactId>
+                    <version>${spring.javaformat.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <inherited>true</inherited>
+                            <goals>
+                                <goal>apply</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>io.spring.javaformat</groupId>
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
-                <version>0.0.34</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <inherited>true</inherited>
-                        <goals>
-                            <goal>apply</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -12,10 +12,6 @@
     <artifactId>prebuilt-tasks</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <assertj.version>3.19.0</assertj.version>
         <jira-rest-client.version>5.2.4</jira-rest-client.version>
         <attlasian-fugue.version>2.6.1</attlasian-fugue.version>
         <org.json.version>20230227</org.json.version>
@@ -74,20 +70,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/workflow-engine/pom.xml
+++ b/workflow-engine/pom.xml
@@ -19,14 +19,6 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
-        <assertj.version>3.17.2</assertj.version>
-        <junit.version>4.13.1</junit.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
@@ -49,20 +41,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -20,17 +20,9 @@
         <url>http://github.com/parodos-dev/parodos/tree/master</url>
     </scm>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <junit.version>4.13.1</junit.version>
-        <assertj.version>3.17.2</assertj.version>
-        <mockito.version>3.5.13</mockito.version>
         <slf4j.version>1.7.30</slf4j.version>
         <lombok.version>1.18.26</lombok.version>
         <spring.framework.version>5.3.26</spring.framework.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -72,20 +64,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>dev.parodos</groupId>

--- a/workflow-service-sdk/pom.xml
+++ b/workflow-service-sdk/pom.xml
@@ -14,10 +14,6 @@
     <description>Workflow Service SDK for Parodos</description>
     <url>https://github.com/parodos-dev/parodos</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <springframework.boot.version>2.5.14</springframework.boot.version>
         <openapi.generator.version>5.4.0</openapi.generator.version>
         <lombok.version>1.18.26</lombok.version>
     </properties>
@@ -27,10 +23,6 @@
             <plugin>
                 <groupId>io.spring.javaformat</groupId>
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
-                <version>0.0.34</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -182,16 +174,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Import dependency management from Spring Boot -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${springframework.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -28,13 +28,11 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
         <common.io.version>2.11.0</common.io.version>
         <model.mapper.version>3.1.1</model.mapper.version>
         <spring-cloud.version>2020.0.6</spring-cloud.version>
         <springdoc-openapi-ui.version>1.6.4</springdoc-openapi-ui.version>
         <hypersistence-utils.version>3.1.0</hypersistence-utils.version>
-        <springframework.boot.version>2.5.14</springframework.boot.version>
     </properties>
 
     <dependencies>
@@ -193,14 +191,6 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <!-- Import dependency management from Spring Boot -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${springframework.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- declare dependecy at the parent, including version and scope
- use deps at the module level, with only the group and id
- remove conficting declerations, redundant properties

Signed-off-by: Roy Golan <rgolan@redhat.com>
