### PR TITLE
ci: Use mvn verify to process the generate files as well

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,8 +17,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Maven Build
-        run: mvn clean spring-javaformat:validate package
+      - name: Maven Verify 
+        run: mvn verify 
 
       - name: Check generated files are up to date
         run: |

--- a/notification-service-sdk/pom.xml
+++ b/notification-service-sdk/pom.xml
@@ -184,48 +184,21 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Use spotless plugin to automatically format code, remove unused import, etc
-                 To apply changes directly to the file, run `mvn spotless:apply`
-                 Ref: https://github.com/diffplug/spotless/tree/main/plugin-maven
-            -->
+
             <plugin>
-              <groupId>com.diffplug.spotless</groupId>
-              <artifactId>spotless-maven-plugin</artifactId>
-              <version>${spotless.version}</version>
-              <configuration>
-                <formats>
-                  <!-- you can define as many formats as you want, each is independent -->
-                  <format>
-                    <!-- define the files to apply to -->
-                    <includes>
-                      <include>.gitignore</include>
-                    </includes>
-                    <!-- define the steps to apply to those files -->
-                    <trimTrailingWhitespace/>
-                    <endWithNewline/>
-                    <indent>
-                      <spaces>true</spaces> <!-- or <tabs>true</tabs> -->
-                      <spacesPerTab>4</spacesPerTab> <!-- optional, default is 4 -->
-                    </indent>
-                  </format>
-                </formats>
-                <!-- define a language-specific format -->
-                <java>
-                  <!-- no need to specify files, inferred automatically, but you can if you want -->
-
-                  <!-- apply a specific flavor of google-java-format and reflow long strings -->
-                  <googleJavaFormat>
-                    <version>1.8</version>
-                    <style>AOSP</style>
-                    <reflowLongStrings>true</reflowLongStrings>
-                  </googleJavaFormat>
-
-                  <removeUnusedImports/>
-                  <importOrder/>
-
-                </java>
-              </configuration>
+                <groupId>io.spring.javaformat</groupId>
+                <artifactId>spring-javaformat-maven-plugin</artifactId>
+                <version>${spring.javaformat.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
This fixes the constant failure of `mvn clean spring-javaformat:validate
package` because the generate files where not formatted yet

The default phase of the formatter is on validate phase which is too
early. mvn verify is enough here.

Signed-off-by: Roy Golan <rgolan@redhat.com>
