### PR TITLE
Enable reload of workflows after restart

### DIFF
--- a/workflow-service/src/main/resources/application.yml
+++ b/workflow-service/src/main/resources/application.yml
@@ -11,6 +11,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+    properties:
+      hibernate:
+        enable_lazy_load_no_trans: true
+        event:
+          merge:
+            entity_copy_observer: allow
 
   datasource:
     type: com.zaxxer.hikari.HikariDataSource


### PR DESCRIPTION
Adding a few hints to enable merge operations of existing workflows in the database.
Without this, the following error appears in the logs:

```
2023-04-04 20:09:49.306 ERROR 1322894 --- [           main] .r.p.w.d.s.WorkFlowDefinitionServiceImpl : Multiple representations of the same entity [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition#8113c0b9-3daa-4d3f-b8d6-4f0acbca78e4] are being merged. Detached: [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition@17043b04]; Detached: [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition@70a898b0]; nested exception is java.lang.IllegalStateException: Multiple representations of the same entity [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition#8113c0b9-3daa-4d3f-b8d6-4f0acbca78e4] are being merged. Detached: [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition@17043b04]; Detached: [com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition@70a898b0]
```