### PR TITLE
Fix OkHttp dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.5.13</mockito.version>
         <assertj.version>3.17.2</assertj.version>
+        <okhttp-version>4.9.2</okhttp-version>
     </properties>
     <modules>
         <module>workflow-engine</module>
@@ -107,6 +108,17 @@
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <!--  Needed to avoid conflict with OkHttp being used in auth0-java and okhttp3 being used by spring -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>logging-interceptor</artifactId>
+                <version>${okhttp-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
`auth0-java` library uses `OkHttp` version 4 as the networking client used to make requests to the Auth0 Authentication and Management APIs. When using Spring's depdendency management, `java.lang.NoSuchMethodError` exception is thrown when making requests, related to Spring's dependency management using OkHttp 3.

See [auth0-java readme](https://github.com/auth0/auth0-java/pull/342/files) and [auth0-java issue](https://github.com/auth0/auth0-java/issues/324)