### PR TITLE
ci: add clean before verify

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: '11'
 
       - name: Maven Verify 
-        run: mvn verify 
+        run: mvn clean verify 
 
       - name: Check generated files are up to date
         run: |


### PR DESCRIPTION
Bringing back 'clean' before the verify as we have
1. some pluging relying on that (like in external-dependencies module)
2. this makes sure we verify on a clean state in the running env

note - clean is not part of the verify lifecycle and maybe downloading
jar in external deps doesn't make sense in clean phase. dependency
resolution like this make more sense in 'compile'.

Signed-off-by: Roy Golan <rgolan@redhat.com>
