### PR TITLE
ci: Bump java to 17 in preparation to source/runtime migration

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Maven Verify 
         run: mvn clean verify 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Restore Maven cache
         uses: skjolber/maven-cache-github-action@v1


### PR DESCRIPTION

[FLPATH-296](https://issues.redhat.com//browse/FLPATH-296)
Blocks: #235 
Signed-off-by: Roy Golan <rgolan@redhat.com>


