### PR TITLE
combine task status with its checker

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Parameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Parameter.java
@@ -42,4 +42,6 @@ public @interface Parameter {
 
 	boolean optional();
 
+	String[] selectOptions() default {};
+
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/ParodosWorkStatus.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/ParodosWorkStatus.java
@@ -24,6 +24,6 @@ package com.redhat.parodos.workflow.enums;
  */
 public enum ParodosWorkStatus {
 
-	FAILED, COMPLETED, PENDING, IN_PROGRESS
+	FAILED, COMPLETED, PENDING, IN_PROGRESS, REJECTED
 
 }

--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -297,7 +297,7 @@ components:
         outputs:
         - EXCEPTION
         - EXCEPTION
-        processingType: processingType
+        processingType: SEQUENTIAL
         works:
         - null
         - null
@@ -331,6 +331,10 @@ components:
             type: object
           type: object
         processingType:
+          enum:
+          - SEQUENTIAL
+          - PARALLEL
+          - OTHER
           type: string
         workType:
           type: string
@@ -354,12 +358,12 @@ components:
       type: object
     WorkFlowDefinitionResponseDTO:
       example:
-        processingType: processingType
+        processingType: SEQUENTIAL
         works:
         - outputs:
           - EXCEPTION
           - EXCEPTION
-          processingType: processingType
+          processingType: SEQUENTIAL
           works:
           - null
           - null
@@ -373,7 +377,7 @@ components:
         - outputs:
           - EXCEPTION
           - EXCEPTION
-          processingType: processingType
+          processingType: SEQUENTIAL
           works:
           - null
           - null
@@ -416,6 +420,10 @@ components:
             type: object
           type: object
         processingType:
+          enum:
+          - SEQUENTIAL
+          - PARALLEL
+          - OTHER
           type: string
         properties:
           $ref: '#/components/schemas/WorkFlowPropertiesDefinitionDTO'
@@ -766,6 +774,7 @@ components:
           - COMPLETED
           - PENDING
           - IN_PROGRESS
+          - REJECTED
           type: string
         type:
           enum:

--- a/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **name** | **String** |  |  [optional]
 **outputs** | [**List&lt;OutputsEnum&gt;**](#List&lt;OutputsEnum&gt;) |  |  [optional]
 **parameters** | **Map&lt;String, Map&lt;String, Object&gt;&gt;** |  |  [optional]
-**processingType** | **String** |  |  [optional]
+**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional]
 **workType** | **String** |  |  [optional]
 **works** | [**List&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional]
 
@@ -25,6 +25,16 @@ Name | Value
 EXCEPTION | &quot;EXCEPTION&quot;
 HTTP2XX | &quot;HTTP2XX&quot;
 NO_EXCEPTION | &quot;NO_EXCEPTION&quot;
+OTHER | &quot;OTHER&quot;
+
+
+
+## Enum: ProcessingTypeEnum
+
+Name | Value
+---- | -----
+SEQUENTIAL | &quot;SEQUENTIAL&quot;
+PARALLEL | &quot;PARALLEL&quot;
 OTHER | &quot;OTHER&quot;
 
 

--- a/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
@@ -13,10 +13,20 @@ Name | Type | Description | Notes
 **modifyDate** | **Date** |  |  [optional]
 **name** | **String** |  |  [optional]
 **parameters** | **Map&lt;String, Map&lt;String, Object&gt;&gt;** |  |  [optional]
-**processingType** | **String** |  |  [optional]
+**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional]
 **properties** | [**WorkFlowPropertiesDefinitionDTO**](WorkFlowPropertiesDefinitionDTO.md) |  |  [optional]
 **type** | **String** |  |  [optional]
 **works** | [**List&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional]
+
+
+
+## Enum: ProcessingTypeEnum
+
+Name | Value
+---- | -----
+SEQUENTIAL | &quot;SEQUENTIAL&quot;
+PARALLEL | &quot;PARALLEL&quot;
+OTHER | &quot;OTHER&quot;
 
 
 

--- a/workflow-service-sdk/docs/WorkStatusResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkStatusResponseDTO.md
@@ -21,6 +21,7 @@ FAILED | &quot;FAILED&quot;
 COMPLETED | &quot;COMPLETED&quot;
 PENDING | &quot;PENDING&quot;
 IN_PROGRESS | &quot;IN_PROGRESS&quot;
+REJECTED | &quot;REJECTED&quot;
 
 
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
@@ -116,10 +116,63 @@ public class WorkDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_PARAMETERS)
 	private Map<String, Map<String, Object>> parameters = null;
 
+	/**
+	 * Gets or Sets processingType
+	 */
+	@JsonAdapter(ProcessingTypeEnum.Adapter.class)
+	public enum ProcessingTypeEnum {
+
+		SEQUENTIAL("SEQUENTIAL"),
+
+		PARALLEL("PARALLEL"),
+
+		OTHER("OTHER");
+
+		private String value;
+
+		ProcessingTypeEnum(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(value);
+		}
+
+		public static ProcessingTypeEnum fromValue(String value) {
+			for (ProcessingTypeEnum b : ProcessingTypeEnum.values()) {
+				if (b.value.equals(value)) {
+					return b;
+				}
+			}
+			throw new IllegalArgumentException("Unexpected value '" + value + "'");
+		}
+
+		public static class Adapter extends TypeAdapter<ProcessingTypeEnum> {
+
+			@Override
+			public void write(final JsonWriter jsonWriter, final ProcessingTypeEnum enumeration) throws IOException {
+				jsonWriter.value(enumeration.getValue());
+			}
+
+			@Override
+			public ProcessingTypeEnum read(final JsonReader jsonReader) throws IOException {
+				String value = jsonReader.nextString();
+				return ProcessingTypeEnum.fromValue(value);
+			}
+
+		}
+
+	}
+
 	public static final String SERIALIZED_NAME_PROCESSING_TYPE = "processingType";
 
 	@SerializedName(SERIALIZED_NAME_PROCESSING_TYPE)
-	private String processingType;
+	private ProcessingTypeEnum processingType;
 
 	public static final String SERIALIZED_NAME_WORK_TYPE = "workType";
 
@@ -255,7 +308,7 @@ public class WorkDefinitionResponseDTO {
 		this.parameters = parameters;
 	}
 
-	public WorkDefinitionResponseDTO processingType(String processingType) {
+	public WorkDefinitionResponseDTO processingType(ProcessingTypeEnum processingType) {
 
 		this.processingType = processingType;
 		return this;
@@ -268,11 +321,11 @@ public class WorkDefinitionResponseDTO {
 	@javax.annotation.Nullable
 	@ApiModelProperty(value = "")
 
-	public String getProcessingType() {
+	public ProcessingTypeEnum getProcessingType() {
 		return processingType;
 	}
 
-	public void setProcessingType(String processingType) {
+	public void setProcessingType(ProcessingTypeEnum processingType) {
 		this.processingType = processingType;
 	}
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
@@ -70,10 +70,63 @@ public class WorkFlowDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_PARAMETERS)
 	private Map<String, Map<String, Object>> parameters = null;
 
+	/**
+	 * Gets or Sets processingType
+	 */
+	@JsonAdapter(ProcessingTypeEnum.Adapter.class)
+	public enum ProcessingTypeEnum {
+
+		SEQUENTIAL("SEQUENTIAL"),
+
+		PARALLEL("PARALLEL"),
+
+		OTHER("OTHER");
+
+		private String value;
+
+		ProcessingTypeEnum(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return String.valueOf(value);
+		}
+
+		public static ProcessingTypeEnum fromValue(String value) {
+			for (ProcessingTypeEnum b : ProcessingTypeEnum.values()) {
+				if (b.value.equals(value)) {
+					return b;
+				}
+			}
+			throw new IllegalArgumentException("Unexpected value '" + value + "'");
+		}
+
+		public static class Adapter extends TypeAdapter<ProcessingTypeEnum> {
+
+			@Override
+			public void write(final JsonWriter jsonWriter, final ProcessingTypeEnum enumeration) throws IOException {
+				jsonWriter.value(enumeration.getValue());
+			}
+
+			@Override
+			public ProcessingTypeEnum read(final JsonReader jsonReader) throws IOException {
+				String value = jsonReader.nextString();
+				return ProcessingTypeEnum.fromValue(value);
+			}
+
+		}
+
+	}
+
 	public static final String SERIALIZED_NAME_PROCESSING_TYPE = "processingType";
 
 	@SerializedName(SERIALIZED_NAME_PROCESSING_TYPE)
-	private String processingType;
+	private ProcessingTypeEnum processingType;
 
 	public static final String SERIALIZED_NAME_PROPERTIES = "properties";
 
@@ -227,7 +280,7 @@ public class WorkFlowDefinitionResponseDTO {
 		this.parameters = parameters;
 	}
 
-	public WorkFlowDefinitionResponseDTO processingType(String processingType) {
+	public WorkFlowDefinitionResponseDTO processingType(ProcessingTypeEnum processingType) {
 
 		this.processingType = processingType;
 		return this;
@@ -240,11 +293,11 @@ public class WorkFlowDefinitionResponseDTO {
 	@javax.annotation.Nullable
 	@ApiModelProperty(value = "")
 
-	public String getProcessingType() {
+	public ProcessingTypeEnum getProcessingType() {
 		return processingType;
 	}
 
-	public void setProcessingType(String processingType) {
+	public void setProcessingType(ProcessingTypeEnum processingType) {
 		this.processingType = processingType;
 	}
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
@@ -49,7 +49,9 @@ public class WorkStatusResponseDTO {
 
 		PENDING("PENDING"),
 
-		IN_PROGRESS("IN_PROGRESS");
+		IN_PROGRESS("IN_PROGRESS"),
+
+		REJECTED("REJECTED");
 
 		private String value;
 

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -624,7 +624,7 @@
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "FAILED", "COMPLETED", "PENDING", "IN_PROGRESS" ]
+            "enum" : [ "FAILED", "COMPLETED", "PENDING", "IN_PROGRESS", "REJECTED" ]
           },
           "type" : {
             "type" : "string",

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -247,6 +247,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 						return;
 					}
 					responseDTOs.add(WorkDefinitionResponseDTO.fromWorkFlowTaskDefinition(wdt.get()));
+					break;
 				case WORKFLOW:
 					Optional<WorkFlowDefinition> wd = workFlowDefinitionRepository
 							.findById(workFlowWorkDefinition.getWorkDefinitionId());
@@ -260,6 +261,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 
 					responseDTOs.add(WorkDefinitionResponseDTO.fromWorkFlowDefinitionEntity(wd.get(),
 							wdWorkFlowWorkDependencies));
+					break;
 				default:
 					return;
 			}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -117,7 +117,9 @@ public class BeanWorkFlowRegistryImpl implements WorkFlowRegistry<String> {
 					.map(annotationAttribute -> WorkParameter.builder().key(annotationAttribute.getString("key"))
 							.description(annotationAttribute.getString("description"))
 							.type((WorkParameterType) annotationAttribute.get("type"))
-							.optional(annotationAttribute.getBoolean("optional")).build())
+							.optional(annotationAttribute.getBoolean("optional"))
+							.selectOptions(Arrays.stream(annotationAttribute.getStringArray("selectOptions")).toList())
+							.build())
 					.collect(Collectors.toList());
 		}
 		workFlowDefinitionService.save(workFlowBeanName, workFlowType, workFlowBean.getProperties(), workParameters,


### PR DESCRIPTION
[FLPATH-299](https://issues.redhat.com/browse/FLPATH-299)

UI shows task completed even its checker is still running.
this pr will display task in_progress if its checker is not completed.

example:  checker waiting jira approval
<img width="649" alt="Screenshot 2023-04-17 at 5 25 01 PM" src="https://user-images.githubusercontent.com/58698556/232614229-5ed3ef8d-c7aa-452e-9712-fe9d3710e183.png">

getStatus response:
```
{
  "workFlowExecutionId": "27912bce-bcdf-4d32-af32-5587327412c8",
  "workFlowName": "ocpOnboardingWorkFlow",
  "status": "IN_PROGRESS",
  "works": [
    {
      "name": "workFlowA",
      "type": "WORKFLOW",
      "status": "IN_PROGRESS",
      "works": [
        {
          "name": "jiraTicketCreationWorkFlowTask",
          "type": "TASK",
          "status": "IN_PROGRESS"
        },
        {
          "name": "notificationWorkFlowTask",
          "type": "TASK",
          "status": "PENDING"
        },
        {
          "name": "jiraTicketEmailNotificationWorkFlowTask",
          "type": "TASK",
          "status": "PENDING"
        }
      ]
    },
    {
      "name": "workFlowB",
      "type": "WORKFLOW",
      "status": "PENDING"
    }
  ]
}
```
