### PR TITLE
ci: to fix the push action use git-describe always

### DIFF
--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -123,7 +123,7 @@
                     <format>json</format>
                     <gitDescribe>
                         <skip>false</skip>
-                        <always>false</always>
+                        <always>true</always>
                         <dirty>-dirty</dirty>
                     </gitDescribe>
                 </configuration>


### PR DESCRIPTION
For git-commit-id plugin to work also in CI, where a detached head and
no tags are pulled, use git-describ --always, so the output would work
even when there's no tag, and will return the git ref instead of the
closest tag.

Signed-off-by: Roy Golan <rgolan@redhat.com>
