### PR TITLE
entity: Use Enum WorkflowProcessingType instead of String

### DIFF
--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -398,7 +398,8 @@
             }
           },
           "processingType" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "SEQUENTIAL", "PARALLEL", "OTHER" ]
           },
           "workType" : {
             "type" : "string"
@@ -451,7 +452,8 @@
             }
           },
           "processingType" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "SEQUENTIAL", "PARALLEL", "OTHER" ]
           },
           "properties" : {
             "$ref" : "#/components/schemas/WorkFlowPropertiesDefinitionDTO"

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 
@@ -57,7 +58,7 @@ public class WorkDefinitionResponseDTO {
 	private String workType;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	private String processingType;
+	private WorkFlowProcessingType processingType;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String author;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,7 +52,7 @@ public class WorkFlowDefinitionResponseDTO {
 
 	private String type;
 
-	private String processingType;
+	private WorkFlowProcessingType processingType;
 
 	private String author;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
@@ -16,6 +16,7 @@
 package com.redhat.parodos.workflow.definition.entity;
 
 import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import lombok.AllArgsConstructor;
@@ -71,8 +72,8 @@ public class WorkFlowDefinition extends AbstractEntity {
 	@Column(nullable = false)
 	private String parameters;
 
-	@Column(nullable = false)
-	private String processingType;
+	@Enumerated(EnumType.STRING)
+	private WorkFlowProcessingType processingType;
 
 	@Column(nullable = false)
 	private Integer numberOfWorks;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -118,7 +118,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 		workFlowDefinition.setParameters(stringifyParameters);
 		workFlowDefinition.setModifyDate(new Date());
 		workFlowDefinition.setProperties(propertiesDefinition);
-		workFlowDefinition.setProcessingType(workFlowProcessingType.name());
+		workFlowDefinition.setProcessingType(workFlowProcessingType);
 		workFlowDefinition.setNumberOfWorks(works.size());
 
 		workFlowDefinition = workFlowDefinitionRepository.save(workFlowDefinition);

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTOTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTOTest.java
@@ -3,6 +3,7 @@ package com.redhat.parodos.workflow.definition.dto;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
@@ -52,7 +53,7 @@ class WorkDefinitionResponseDTOTest {
 		wd.setId(id);
 		wd.setName("foo");
 		wd.setParameters(getWorkFlowParameter());
-		wd.setProcessingType("BATCH");
+		wd.setProcessingType(WorkFlowProcessingType.OTHER);
 
 		List<WorkFlowWorkDefinition> dependencies = List.of(new WorkFlowWorkDefinition());
 		// when
@@ -68,7 +69,7 @@ class WorkDefinitionResponseDTOTest {
 		assertEquals(result.getParameters().get("key").get("type"), "string");
 		assertEquals(result.getParameters().get("key").get("required"), true);
 		assertEquals(result.getNumberOfWorkUnits(), dependencies.size());
-		assertEquals(result.getProcessingType(), "BATCH");
+		assertEquals(result.getProcessingType(), WorkFlowProcessingType.OTHER);
 		assertEquals(result.getWorks().size(), 0);
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
@@ -23,6 +23,7 @@ import com.redhat.parodos.workflow.definition.repository.WorkFlowCheckerMappingD
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowWorkRepository;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +74,7 @@ class WorkFlowDefinitionServiceDataTest {
 				new ModelMapper());
 
 		WorkFlowDefinition workFlowDefinition = WorkFlowDefinition.builder().name("test-workflow").numberOfWorks(1)
-				.parameters("{}").processingType(WorkFlowType.INFRASTRUCTURE.name()).type(WorkFlowType.INFRASTRUCTURE)
+				.parameters("{}").processingType(WorkFlowProcessingType.SEQUENTIAL).type(WorkFlowType.INFRASTRUCTURE)
 				.build();
 		WorkFlowTaskDefinition workFlowTaskDefinition = WorkFlowTaskDefinition.builder().name("test-workflow-task")
 				.workFlowDefinition(workFlowDefinition).parameters("{}").outputs("[]").build();

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -127,7 +127,7 @@ class WorkFlowDefinitionServiceImplTest {
 		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(2)).save(argument.capture());
 		assertEquals(argument.getValue().getName(), workFlowName);
 		assertEquals(argument.getValue().getType(), WorkFlowType.ASSESSMENT);
-		assertEquals(argument.getValue().getProcessingType(), WorkFlowProcessingType.SEQUENTIAL.toString());
+		assertEquals(argument.getValue().getProcessingType(), WorkFlowProcessingType.SEQUENTIAL);
 		assertEquals(argument.getValue().getNumberOfWorks(), 1);
 		assertEquals(argument.getValue().getWorkFlowTaskDefinitions().size(), 1);
 		assertEquals(argument.getValue().getWorkFlowTaskDefinitions().stream().findFirst().get().getName(), TEST_TASK);
@@ -328,7 +328,7 @@ class WorkFlowDefinitionServiceImplTest {
 
 		WorkFlowDefinition workFlowDefinition = WorkFlowDefinition.builder().name(name).type(WorkFlowType.ASSESSMENT)
 				.properties(WorkFlowPropertiesDefinition.builder().version("1.0.0").build())
-				.processingType(WorkFlowProcessingType.SEQUENTIAL.name())
+				.processingType(WorkFlowProcessingType.SEQUENTIAL)
 				.parameters(WorkFlowDTOUtil
 						.writeObjectValueAsString(Map.of(workParameter.getKey(), workParameter.getAsJsonSchema())))
 				.numberOfWorks(1).build();


### PR DESCRIPTION
Strong type is preferable where available. Prevents error (like the
uncought one in the test) and more readable code.

JPA performs the conversion for us, and there are no schema
changes.

Signed-off-by: Roy Golan <rgolan@redhat.com>
