### PR TITLE
Fix Workflow examples integration tests

### DIFF
--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/ComplexWorkFlow.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/ComplexWorkFlow.java
@@ -62,7 +62,7 @@ public class ComplexWorkFlow {
 		// Define WorkFlowRequest
 		WorkFlowRequestDTO workFlowRequestDTO = new WorkFlowRequestDTO();
 		workFlowRequestDTO.setProjectId(testProject.getId());
-		workFlowRequestDTO.setWorkFlowName("onboardingMasterAssessment_ASSESSMENT_WORKFLOW");
+		workFlowRequestDTO.setWorkFlowName("onboardingComplexAssessment_ASSESSMENT_WORKFLOW");
 		workFlowRequestDTO.setWorks(List.of(WorkRequestDTO.builder()
 				.arguments(List.of(ArgumentRequestDTO.builder().key("GIT_REPO_URL").value("git_repo_url").build()))
 				.build()));

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/PrebuiltWorkFlow.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/PrebuiltWorkFlow.java
@@ -13,7 +13,6 @@ import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
-import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.utils.CredUtils;
@@ -67,7 +66,7 @@ public class PrebuiltWorkFlow {
 
 		assertNotNull(prebuiltWorkFlowDefinition.getId());
 		assertEquals(workFlowName, prebuiltWorkFlowDefinition.getName());
-		assertEquals(WorkFlowProcessingType.SEQUENTIAL.toString(), prebuiltWorkFlowDefinition.getProcessingType());
+		assertEquals(WorkFlowDefinitionResponseDTO.ProcessingTypeEnum.SEQUENTIAL, prebuiltWorkFlowDefinition.getProcessingType());
 		assertEquals(WorkFlowType.INFRASTRUCTURE.toString(), prebuiltWorkFlowDefinition.getType());
 
 		assertNotNull(prebuiltWorkFlowDefinition.getWorks());

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/SimpleWorkFlow.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/SimpleWorkFlow.java
@@ -14,7 +14,6 @@ import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO.WorkStatusEnum;
 import com.redhat.parodos.sdk.model.WorkRequestDTO;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
-import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.utils.CredUtils;
@@ -70,7 +69,7 @@ public class SimpleWorkFlow {
 		assertNotNull(simpleSequentialWorkFlowDefinition.getId());
 		assertEquals("simpleSequentialWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW,
 				simpleSequentialWorkFlowDefinition.getName());
-		assertEquals(WorkFlowProcessingType.SEQUENTIAL.toString(),
+		assertEquals(WorkFlowDefinitionResponseDTO.ProcessingTypeEnum.SEQUENTIAL,
 				simpleSequentialWorkFlowDefinition.getProcessingType());
 		assertEquals(WorkFlowType.INFRASTRUCTURE.toString(), simpleSequentialWorkFlowDefinition.getType());
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/UseSDKExample.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/integration/UseSDKExample.java
@@ -93,7 +93,7 @@ public class UseSDKExample {
 
 			assertEquals("simpleSequentialWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW,
 					simpleSequentialWorkFlowDefinition.getName());
-			assertEquals(WorkFlowProcessingType.SEQUENTIAL.toString(),
+			assertEquals(WorkFlowDefinitionResponseDTO.ProcessingTypeEnum.SEQUENTIAL,
 					simpleSequentialWorkFlowDefinition.getProcessingType());
 			assertEquals(WorkFlowType.INFRASTRUCTURE.toString(), simpleSequentialWorkFlowDefinition.getType());
 


### PR DESCRIPTION
1. Use Enum WorkflowProcessingType instead of String (following to https://github.com/parodos-dev/parodos/pull/255)
2. Change complex workflow name from "onboardingMasterAssessment_ASSESSMENT_WORKFLOW" to "onboardingComplexAssessment_ASSESSMENT_WORKFLOW"