### PR TITLE
Use the WorkFlowStatus instance instead of name()

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/WorkFlowStatus.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/WorkFlowStatus.java
@@ -26,12 +26,4 @@ public enum WorkFlowStatus {
 
 	FAILED, IN_PROGRESS, COMPLETED, PENDING, REJECTED;
 
-	public boolean isFailed() {
-		return FAILED.name().equals(name());
-	}
-
-	public boolean isRejected() {
-		return REJECTED.name().equals(name());
-	}
-
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
@@ -77,13 +77,13 @@ public class AssessmentInfrastructureWorkFlowPostInterceptor implements WorkFlow
 				.collect(Collectors.toList());
 
 		for (WorkFlowExecution checkerExecution : checkerExecutions)
-			if (checkerExecution != null && checkerExecution.getStatus().isRejected()) {
+			if (checkerExecution != null && checkerExecution.getStatus() == WorkFlowStatus.FAILED) {
 				log.info("fail workflow: {} because it has declined checker(s)", workFlowDefinition.getName());
 				workFlowExecution.setStatus(WorkFlowStatus.FAILED);
 				report = new DefaultWorkReport(WorkStatus.FAILED, workContext);
 				break;
 			}
-			else if (checkerExecution == null || checkerExecution.getStatus().isFailed()) {
+			else if (checkerExecution == null || checkerExecution.getStatus() == WorkFlowStatus.FAILED) {
 				log.info("workflow: {} has a pending/running checker: {}", workFlowDefinition.getName(),
 						checkerExecution == null ? "checker is pending"
 								: checkerExecution.getWorkFlowDefinitionId().toString());


### PR DESCRIPTION
This should be as clear and as simple intead of comparing strings.

Signed-off-by: Roy Golan <rgolan@redhat.com>
