### PR TITLE
Add constraints on model entities names

### DIFF
--- a/workflow-examples/run_examples.sh
+++ b/workflow-examples/run_examples.sh
@@ -139,6 +139,8 @@ run_simple_flow() {
 
   echo_blue "******** Create Project ********"
   echo "                                                "
+  # generate random project name
+  PROJECT_NAME="project-$RANDOM"
   PROJECT_ID=$(curl -X 'POST' -s \
     "${TARGET_URL}/api/v1/projects" \
     -H 'accept: */*' \
@@ -147,7 +149,7 @@ run_simple_flow() {
     -H "X-XSRF-TOKEN: ${TOKEN}" \
     -b $COOKIEFP \
     -d '{
-                 "name": "project-1",
+                 "name": "'"${PROJECT_NAME}"'",
                  "description": "an example project"
                }' | jq -r '.id')
   [ ${#PROJECT_ID} -eq "36" ] || @fail "Project ID ${PROJECT_ID} is not present"
@@ -201,6 +203,7 @@ run_complex_flow() {
   echo " "
   echo_blue "******** Create Project ********"
   echo "                                                "
+  PROJECT_NAME="project-$RANDOM"
   PROJECT_ID=$(curl -X 'POST' -s \
     "${TARGET_URL}/api/v1/projects" \
     -H 'accept: */*' \
@@ -209,7 +212,7 @@ run_complex_flow() {
     -b $COOKIEFP \
     -H 'Content-Type: application/json' \
     -d '{
-                 "name": "project-1",
+                 "name": "'"${PROJECT_NAME}"'",
                  "description": "an example project"
                }' | jq -r '.id')
   [ ${#PROJECT_ID} -eq "36" ] || @fail "Project ID ${PROJECT_ID} is not present"
@@ -301,8 +304,8 @@ run_escalation_flow() {
   echo "                                                  "
 
   wait_project_start
-
-   PROJECT_ID=$(curl -X 'POST' -s \
+  PROJECT_NAME="project-$RANDOM"
+  PROJECT_ID=$(curl -X 'POST' -s \
     "${TARGET_URL}/api/v1/projects" \
     -H 'accept: */*' \
     -H 'Authorization: Basic dGVzdDp0ZXN0' \
@@ -310,7 +313,7 @@ run_escalation_flow() {
     -b $COOKIEFP \
     -H 'Content-Type: application/json' \
     -d '{
-                 "name": "project-1",
+                 "name": "'"${PROJECT_NAME}"'",
                  "description": "an example project"
                }' | jq -r '.id')
   echo "Project id is " $(echo_green $PROJECT_ID)

--- a/workflow-service/src/main/java/com/redhat/parodos/project/controller/ProjectController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/controller/ProjectController.java
@@ -15,14 +15,14 @@
  */
 package com.redhat.parodos.project.controller;
 
-import com.redhat.parodos.project.dto.ProjectRequestDTO;
-import com.redhat.parodos.project.dto.ProjectResponseDTO;
-import com.redhat.parodos.project.service.ProjectServiceImpl;
 import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+import com.redhat.parodos.project.dto.ProjectRequestDTO;
+import com.redhat.parodos.project.dto.ProjectResponseDTO;
+import com.redhat.parodos.project.service.ProjectServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/workflow-service/src/main/java/com/redhat/parodos/project/entity/Project.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/entity/Project.java
@@ -15,13 +15,14 @@
  */
 package com.redhat.parodos.project.entity;
 
-import com.redhat.parodos.user.entity.User;
-import com.redhat.parodos.common.AbstractEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.util.Date;
+
+import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +43,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class Project extends AbstractEntity {
 
+	@Column(unique = true)
 	private String name;
 
 	private String description;

--- a/workflow-service/src/main/java/com/redhat/parodos/project/repository/ProjectRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/repository/ProjectRepository.java
@@ -16,6 +16,8 @@
 package com.redhat.parodos.project.repository;
 
 import com.redhat.parodos.project.entity.Project;
+
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -25,5 +27,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author Annel Ketcha (Github: anludke)
  */
 public interface ProjectRepository extends JpaRepository<Project, UUID> {
+
+	Optional<Project> findByNameIgnoreCase(String name);
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
@@ -15,8 +15,10 @@
  */
 package com.redhat.parodos.project.service;
 
+import javax.persistence.EntityExistsException;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -54,6 +56,11 @@ public class ProjectServiceImpl implements ProjectService {
 
 	@Override
 	public ProjectResponseDTO save(ProjectRequestDTO projectRequestDTO) {
+		Optional<Project> projectByName = projectRepository.findByNameIgnoreCase(projectRequestDTO.getName());
+		if (projectByName.isPresent()) {
+			throw new EntityExistsException(
+					String.format("Project with name: %s already exists", projectByName.get().getName()));
+		}
 		// get user from security utils and set on project
 		Project project = projectRepository.save(Project.builder().name(projectRequestDTO.getName())
 				.description(projectRequestDTO.getDescription()).createDate(new Date()).modifyDate(new Date()).build());

--- a/workflow-service/src/main/java/com/redhat/parodos/user/entity/User.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/entity/User.java
@@ -15,20 +15,18 @@
  */
 package com.redhat.parodos.user.entity;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import com.nimbusds.jose.shaded.json.annotate.JsonIgnore;
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.project.entity.Project;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,6 +47,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class User extends AbstractEntity {
 
+	@Column(unique = true)
 	private String username;
 
 	@JsonIgnore

--- a/workflow-service/src/main/java/com/redhat/parodos/user/repository/UserRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/repository/UserRepository.java
@@ -15,9 +15,10 @@
  */
 package com.redhat.parodos.user.repository;
 
-import com.redhat.parodos.user.entity.User;
-import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+
+import com.redhat.parodos.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -28,6 +29,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 
-	List<User> findByUsername(String username);
+	Optional<User> findByUsername(String username);
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
@@ -15,12 +15,14 @@
  */
 package com.redhat.parodos.user.service;
 
+import java.util.Optional;
 import java.util.UUID;
-import org.modelmapper.ModelMapper;
-import org.springframework.stereotype.Service;
+
 import com.redhat.parodos.user.dto.UserResponseDTO;
 import com.redhat.parodos.user.entity.User;
 import com.redhat.parodos.user.repository.UserRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
 
 /**
  * User service implementation
@@ -54,7 +56,11 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public UserResponseDTO getUserByUsername(String username) {
-		return modelMapper.map(userRepository.findByUsername(username).stream().findFirst(), UserResponseDTO.class);
+		Optional<User> user = userRepository.findByUsername(username);
+		if (!user.isPresent()) {
+			throw new RuntimeException(String.format("User with username: %s not found", username));
+		}
+		return modelMapper.map(user.get(), UserResponseDTO.class);
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
@@ -56,7 +56,7 @@ import java.util.List;
 @TypeDef(name = "json", typeClass = JsonType.class)
 public class WorkFlowDefinition extends AbstractEntity {
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String name;
 
 	@Enumerated(EnumType.STRING)

--- a/workflow-service/src/main/resources/db/changelog/tables.xml
+++ b/workflow-service/src/main/resources/db/changelog/tables.xml
@@ -10,7 +10,9 @@
             <column name="id" type="${uuidType}" defaultValue="${uuidFunction}">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="username" type="varchar(255)"/>
+            <column name="username" type="varchar(255)">
+                <constraints unique="true" nullable="false"/>
+            </column>
             <column name="password" type="varchar(255)"/>
             <column name="authority" type="varchar(255)"/>
             <column name="enabled" type="tinyint"/>
@@ -27,7 +29,9 @@
             <column name="id" type="${uuidType}" defaultValue="${uuidFunction}">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="name" type="varchar(255)"/>
+            <column name="name" type="varchar(255)">
+                <constraints unique="true" nullable="false"/>
+            </column>
             <column name="description" type="varchar(255)"/>
             <column name="create_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="modify_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>

--- a/workflow-service/src/test/java/com/redhat/parodos/project/repository/ProjectRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/repository/ProjectRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.redhat.parodos.project.repository;
+
+import javax.persistence.PersistenceException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.parodos.project.entity.Project;
+import com.redhat.parodos.repository.RepositoryTestBase;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProjectRepositoryTest extends RepositoryTestBase {
+
+	@Autowired
+	private ProjectRepository projectRepository;
+
+	@Test
+	public void injectedComponentsAreNotNull() {
+		super.injectedComponentsAreNotNull();
+		assertNotNull(projectRepository);
+	}
+
+	@Test
+	public void testFindAll() {
+		// given
+		createProject(UUID.randomUUID().toString());
+		createProject(UUID.randomUUID().toString());
+
+		// when
+		List<Project> projects = projectRepository.findAll();
+
+		// then
+		assertNotNull(projects);
+		assertEquals(2, projects.size());
+	}
+
+	@Test
+	public void testFindByName() {
+		// given
+		var name = UUID.randomUUID().toString();
+		createProject(name);
+		createProject(UUID.randomUUID().toString());
+
+		// when
+		var project = projectRepository.findByNameIgnoreCase(name);
+
+		// then
+		assertNotNull(project);
+		assertTrue(project.isPresent());
+		assertEquals(name, project.get().getName());
+	}
+
+	@Test
+	public void testSave() {
+		// given
+		Project project = Project.builder().name(UUID.randomUUID().toString()).description("test").build();
+		List<Project> projects = projectRepository.findAll();
+		assertTrue(projects.isEmpty());
+
+		// when
+		Project savedProject = projectRepository.save(project);
+
+		// then
+		savedProject = projectRepository.getById(savedProject.getId());
+		assertNotNull(savedProject);
+		assertNotNull(savedProject.getId());
+		assertEquals(project.getName(), savedProject.getName());
+		assertEquals(project.getDescription(), savedProject.getDescription());
+	}
+
+	@Test
+	public void testUniqueNameConstraint() {
+		// given
+		final var name = UUID.randomUUID().toString();
+		assertEquals(0, projectRepository.count());
+
+		// when
+		createProject(name);
+		assertEquals(1, projectRepository.count());
+
+		// then
+		assertThrows(PersistenceException.class, () -> createProject(name));
+	}
+
+	private void createProject(String name) {
+		Project project = Project.builder().name(name).description(name + " test").build();
+		entityManager.persistAndFlush(project);
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/repository/RepositoryTestBase.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/repository/RepositoryTestBase.java
@@ -1,0 +1,31 @@
+package com.redhat.parodos.repository;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+public abstract class RepositoryTestBase {
+
+	@Autowired
+	protected WorkFlowRepository workFlowRepository;
+
+	@Autowired
+	protected TestEntityManager entityManager;
+
+	protected void injectedComponentsAreNotNull() {
+		assertNotNull(workFlowRepository);
+		assertNotNull(entityManager);
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/user/repository/UserRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/repository/UserRepositoryTest.java
@@ -1,0 +1,59 @@
+package com.redhat.parodos.user.repository;
+
+import javax.persistence.PersistenceException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.parodos.repository.RepositoryTestBase;
+import com.redhat.parodos.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserRepositoryTest extends RepositoryTestBase {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	public void injectedComponentsAreNotNull() {
+		super.injectedComponentsAreNotNull();
+		assertNotNull(userRepository);
+	}
+
+	@Test
+	void findByUsername() {
+		// given
+		final var username = UUID.randomUUID().toString();
+		createUser(username);
+
+		// when
+		var user = userRepository.findByUsername(username);
+
+		// then
+		assertNotNull(user);
+		assertTrue(user.isPresent());
+		assertEquals(user.get().getUsername(), username);
+	}
+
+	@Test
+	public void testUniqueNameConstraint() {
+		// given
+		final var name = UUID.randomUUID().toString();
+
+		// when
+		createUser(name);
+
+		// then
+		assertThrows(PersistenceException.class, () -> createUser(name));
+	}
+
+	private void createUser(String username) {
+		var user = User.builder().username(username).build();
+		entityManager.persistAndFlush(user);
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
@@ -1,15 +1,6 @@
 package com.redhat.parodos.user.service;
 
-import com.redhat.parodos.user.dto.UserResponseDTO;
-import com.redhat.parodos.user.entity.User;
-import com.redhat.parodos.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.modelmapper.ModelMapper;
-
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,6 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.parodos.user.dto.UserResponseDTO;
+import com.redhat.parodos.user.entity.User;
+import com.redhat.parodos.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
 
 class UserServiceImplTest {
 
@@ -87,14 +86,14 @@ class UserServiceImplTest {
 	void GetUserByNameWithValidData() {
 		// given
 		User user = getSampleUser("test");
-		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(List.of(user));
+		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.of(user));
 
 		// when
 		UserResponseDTO res = this.service.getUserByUsername(user.getUsername());
 
 		// then
 		assertNotNull(res);
-		assertEquals(res.getId().toString(), user.getId().toString());
+		assertEquals(res.getId(), user.getId().toString());
 		assertEquals(res.getUsername(), user.getUsername());
 		assertEquals(res.getEmail(), user.getEmail());
 		Mockito.verify(this.userRepository, Mockito.times(1)).findByUsername(Mockito.any());
@@ -104,13 +103,10 @@ class UserServiceImplTest {
 	void GetUserByNameWithInvalidData() {
 		// given
 		User user = getSampleUser("test");
-		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Collections.emptyList());
-
-		// when
-		UserResponseDTO res = this.service.getUserByUsername(user.getUsername());
+		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.empty());
 
 		// then
-		assertNull(res);
+		assertThrows(RuntimeException.class, () -> this.service.getUserByUsername(user.getUsername()));
 		Mockito.verify(this.userRepository, Mockito.times(1)).findByUsername(Mockito.any());
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
@@ -8,38 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.parodos.project.entity.Project;
+import com.redhat.parodos.repository.RepositoryTestBase;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecutionContext;
 import com.redhat.parodos.workflows.work.WorkContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringRunner.class)
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Transactional
-public class WorkFlowRepositoryTest {
-
-	@Autowired
-	private WorkFlowRepository workFlowRepository;
-
-	@Autowired
-	private TestEntityManager entityManager;
-
-	@Test
-	public void injectedComponentsAreNotNull() {
-		assertNotNull(workFlowRepository);
-		assertNotNull(entityManager);
-	}
+public class WorkFlowRepositoryTest extends RepositoryTestBase {
 
 	@Test
 	public void testFindAll() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Users and projects should be uniquely identified by their names in the system.
To enforce this, unique constraints should be implemented at the database level.
When requests are made to the controller's endpoints, they should fail with an HTTP status code of 409 (Conflict) if the constraints are violated.

To simplify JPA testing, `RepositoryTestBase` was added to serve as a base test class for the *Repository test classes.

**Which issue(s) this PR fixes** *:
Fixes: #[FLPATH-341](https://issues.redhat.com/browse/FLPATH-341)

**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notifivcation Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
