### PR TITLE
Unify the setting/getting of project-id from context

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
@@ -21,6 +21,8 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.BeanNameAware;
@@ -58,7 +60,7 @@ public abstract class BaseWorkFlowTask implements WorkFlowTask, BeanNameAware {
 		this.workFlowCheckers = workFlowCheckers;
 	}
 
-	public String getProjectId(WorkContext workContext) {
+	public UUID getProjectId(WorkContext workContext) {
 		return WorkContextUtils.getProjectId(workContext);
 	}
 

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/WorkContextUtils.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/WorkContextUtils.java
@@ -15,14 +15,18 @@
  */
 package com.redhat.parodos.workflow.utils;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflows.work.WorkContext;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import lombok.NonNull;
 
 /**
  * Util Class to parse WorkContext
@@ -40,9 +44,22 @@ public class WorkContextUtils {
 	 * @param workContext
 	 * @return project id
 	 */
-	public static String getProjectId(WorkContext workContext) {
-		return WorkContextDelegate
-				.read(workContext, WorkContextDelegate.ProcessType.PROJECT, WorkContextDelegate.Resource.ID).toString();
+	public static UUID getProjectId(WorkContext workContext) {
+		Object projectId = WorkContextDelegate.read(workContext, WorkContextDelegate.ProcessType.PROJECT,
+				WorkContextDelegate.Resource.ID);
+		projectId = Optional.ofNullable(projectId)
+				.orElseThrow(() -> new NoSuchElementException("Project ID is missing from workContext."));
+		return UUID.fromString(projectId.toString());
+	}
+
+	/**
+	 * method to set project id to workContext
+	 * @param workContext
+	 * @param projectId
+	 */
+	public static void setProjectId(WorkContext workContext, @NonNull UUID projectId) {
+		WorkContextDelegate.write(workContext, WorkContextDelegate.ProcessType.PROJECT, WorkContextDelegate.Resource.ID,
+				projectId.toString());
 	}
 
 	/**

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/WorkContextUtilsTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/WorkContextUtilsTest.java
@@ -1,0 +1,41 @@
+package com.redhat.parodos.workflow.utils;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.Test;
+
+public class WorkContextUtilsTest {
+
+	@Test(expected = NoSuchElementException.class)
+	public void testGetProjectIdWithoutProjectId() {
+		WorkContext context = new WorkContext();
+		WorkContextUtils.getProjectId(context);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetProjectIdWithIllegalProjectId() {
+		WorkContext context = new WorkContext();
+		WorkContextDelegate.write(context, WorkContextDelegate.ProcessType.PROJECT, WorkContextDelegate.Resource.ID,
+				"illegal");
+		WorkContextUtils.getProjectId(context);
+	}
+
+	@Test
+	public void testSetAndGetProjectId() {
+		UUID projectId = UUID.randomUUID();
+		WorkContext context = new WorkContext();
+		WorkContextUtils.setProjectId(context, projectId);
+		assertEquals(projectId, WorkContextUtils.getProjectId(context));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testSetProjectIdWithNullId() {
+		WorkContextUtils.setProjectId(new WorkContext(), null);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTask.java
@@ -73,7 +73,7 @@ public class JiraTicketCreationWorkFlowTask extends BaseInfrastructureWorkFlowTa
 			String urlString = jiraServiceBaseUrl + "/rest/servicedeskapi/request";
 			String serviceDeskId = "1";
 			String requestTypeId = "35";
-			String projectId = getProjectId(workContext);
+			String projectId = getProjectId(workContext).toString();
 			String namespace = getOptionalParameterValue(workContext, NAMESPACE, "demo");
 			log.info("Calling: urlString: {} username: {}", urlString, jiraUsername);
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
@@ -1,5 +1,9 @@
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
@@ -8,9 +12,9 @@ import static org.mockito.Mockito.spy;
 import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
 import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketResponseDto;
 import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -21,8 +25,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Jira Ticket Creation Workflow Task execution test
@@ -39,7 +41,7 @@ public class JiraTicketCreationWorkFlowTaskTest extends BaseInfrastructureWorkFl
 
 	private static final String APPROVER_ID_TEST = "approver-id-test";
 
-	private static final String PROJECT_ID_TEST = "project-id-test";
+	private static final UUID PROJECT_ID_TEST = UUID.randomUUID();
 
 	private static final String ISSUE_ID_TEST = "issue-ID-test";
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
@@ -9,6 +9,7 @@ import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -49,9 +50,7 @@ public abstract class WorkFlowExecutionInterceptor implements WorkFlowIntercepto
 		String arguments = WorkFlowDTOUtil.writeObjectValueAsString(
 				WorkContextDelegate.read(workContext, WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION,
 						workFlowDefinition.getName(), WorkContextDelegate.Resource.ARGUMENTS));
-		UUID projectId = UUID.fromString(WorkContextDelegate
-				.read(workContext, WorkContextDelegate.ProcessType.PROJECT, WorkContextDelegate.Resource.ID)
-				.toString());
+		UUID projectId = WorkContextUtils.getProjectId(workContext);
 		return workFlowService.saveWorkFlow(projectId, workFlowDefinition.getId(), WorkFlowStatus.IN_PROGRESS,
 				mainWorkFlowExecution, arguments);
 	}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -19,6 +19,7 @@ import com.redhat.parodos.workflow.WorkFlowDelegate;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowOptionsResponseDTO;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
@@ -135,8 +136,7 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 	public WorkReport execute(UUID projectId, String workflowName, WorkContext workContext, UUID executionId) {
 		WorkFlow workFlow = workFlowDelegate.getWorkFlowExecutionByName(workflowName);
 		log.info("execute workFlow '{}': {}", workflowName, workFlow);
-		WorkContextDelegate.write(workContext, WorkContextDelegate.ProcessType.PROJECT, WorkContextDelegate.Resource.ID,
-				projectId.toString());
+		WorkContextUtils.setProjectId(workContext, projectId);
 		if (executionId != null)
 			WorkContextDelegate.write(workContext, WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION,
 					WorkContextDelegate.Resource.ID, executionId.toString());

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
@@ -60,6 +60,10 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 		workFlowExecution = workFlowRepository.save(workFlowExecution);
 		WorkContext WorkContext = new WorkContext();
 		WorkContext.put("test_key", "test_value");
+		UUID testUUID = UUID.randomUUID();
+		WorkContext.put("test_uuid", testUUID);
+		List<String> testList = List.of("test1", "test2");
+		WorkContext.put("test_list", testList);
 		WorkFlowExecutionContext workContext = WorkFlowExecutionContext.builder()
 				.mainWorkFlowExecution(workFlowExecution).workContext(WorkContext).build();
 		workFlowExecution.setWorkFlowExecutionContext(workContext);
@@ -73,6 +77,9 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 		assertNotNull(flowExecution.getWorkFlowExecutionContext());
 		assertNotNull(flowExecution.getWorkFlowExecutionContext().getWorkContext());
 		assertEquals("test_value", flowExecution.getWorkFlowExecutionContext().getWorkContext().get("test_key"));
+		assertEquals(testList, flowExecution.getWorkFlowExecutionContext().getWorkContext().get("test_list"));
+		assertEquals(testUUID.toString(),
+				flowExecution.getWorkFlowExecutionContext().getWorkContext().get("test_uuid"));
 	}
 
 	@Test


### PR DESCRIPTION
**What this PR does / why we need it**:
WorkContext allows setting parameters on a map of type `<string,Object>`. This map is being stored in table workflow_execution_context as JSON. When the object is read, fields of type UUID are returned as string.

To make sure we use the same method to read and write the project ID from the context, two methods are added.


**Which issue(s) this PR fixes** :
Partially Fixes #[FLPATH-333](https://issues.redhat.com/browse/FLPATH-333)

**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notifivcation Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
