### PR TITLE
Feat: add git prebuilt-tasks

### DIFF
--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -15,6 +15,7 @@
         <jira-rest-client.version>5.2.4</jira-rest-client.version>
         <attlasian-fugue.version>2.6.1</attlasian-fugue.version>
         <org.json.version>20230227</org.json.version>
+        <jgit-version>6.5.0.202303070854-r</jgit-version>
     </properties>
 
     <repositories>
@@ -94,6 +95,40 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>${jgit-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
+            <version>${jgit-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.gpg.bc</artifactId>
+            <version>${jgit-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.archive</artifactId>
+            <version>${jgit-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitArchiveTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitArchiveTask.java
@@ -1,0 +1,99 @@
+package com.redhat.parodos.tasks.git;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.google.common.io.Files;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.ArchiveCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.archive.ZipFormat;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+@Slf4j
+@AllArgsConstructor
+public class GitArchiveTask extends BaseWorkFlowTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return List.of(WorkParameter.builder().key(GitUtils.getGitRepoPath()).type(WorkParameterType.TEXT)
+				.optional(true).description("path where the git repo is located").build());
+	}
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		String path = GitUtils.getRepoPath(workContext);
+		if (Strings.isNullOrEmpty(path)) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new IllegalArgumentException("The path parameter cannot be null or empty"));
+		}
+		Repository repo = null;
+		try {
+			repo = getRepo(path);
+			Path archivePath = archive(repo);
+			workContext.put(GitUtils.getContextArchivePath(), archivePath.toAbsolutePath().toString());
+		}
+		catch (FileNotFoundException | GitAPIException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("Cannot archive the repository:" + e));
+		}
+		catch (IOException e) {
+			// This is the catch for Repository clone call or archive, we don't really
+			// know.
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("No repository at " + path + " Error:" + e.getMessage()));
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("Cannot archive the repository:" + e));
+		}
+		finally {
+			if (repo != null) {
+				repo.close();
+			}
+		}
+
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+	}
+
+	private Repository getRepo(String path) throws IOException {
+		Path gitDir = Paths.get(path);
+		return new FileRepositoryBuilder().setGitDir(gitDir.toFile()).build();
+	}
+
+	private Path archive(Repository repo) throws FileNotFoundException, IOException, GitAPIException {
+
+		// Create a Git instance
+		Git git = new Git(repo);
+		ArchiveCommand.registerFormat("zip", new ZipFormat());
+
+		// Create a ZipFormat instance
+		String tmpdir = Files.createTempDir().getAbsolutePath();
+		Path zipFile = Paths.get(tmpdir + "/output.zip");
+
+		try (FileOutputStream out = new FileOutputStream(zipFile.toAbsolutePath().toString())) {
+			git.archive().setTree(repo.resolve("HEAD")).setFormat("zip").setOutputStream(out).call();
+		}
+		finally {
+			git.close();
+		}
+		return zipFile;
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
@@ -1,0 +1,83 @@
+package com.redhat.parodos.tasks.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.api.errors.TransportException;
+
+@AllArgsConstructor
+@Slf4j
+public class GitCloneTask extends BaseWorkFlowTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return List.of(
+				WorkParameter.builder().key(GitUtils.getUri()).type(WorkParameterType.TEXT).optional(false)
+						.description("Url to clone from").build(),
+				WorkParameter.builder().key(GitUtils.getBranch()).type(WorkParameterType.TEXT).optional(true)
+						.description("Branch to clone from, default main").build(),
+				WorkParameter.builder().key("credentials").type(WorkParameterType.TEXT).optional(false)
+						.description("Git credential").build());
+	}
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		String gitUri = null;
+		String destination = null;
+		String gitBranch = null;
+
+		try {
+			gitUri = WorkContextDelegate.getRequiredValueFromRequestParams(workContext, GitUtils.getUri());
+			gitBranch = WorkContextDelegate.getOptionalValueFromRequestParams(workContext, GitUtils.getBranch(),
+					"main");
+			destination = cloneRepo(gitUri, gitBranch);
+		}
+		catch (MissingParameterException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+		catch (TransportException e) {
+			log.debug("Cannot connect to repository server '{}' error: {}", gitUri, e.getMessage());
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("cannot connect to the repository server"));
+		}
+		catch (InvalidRemoteException e) {
+			log.debug("remote repository server '{}' is not available, error: {}", gitUri, e.getMessage());
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("Remote repository " + gitUri + " is not available"));
+		}
+		catch (IOException | GitAPIException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new Exception("cannot clone repository, error: " + e.getMessage()));
+		}
+
+		workContext.put(GitUtils.getContextUri(), gitUri);
+		workContext.put(GitUtils.getContextDestination(), destination);
+		workContext.put(GitUtils.getContextBranch(), gitBranch);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+	}
+
+	private String cloneRepo(String gitUri, String gitBranch)
+			throws InvalidRemoteException, TransportException, IOException, GitAPIException {
+		String tmpDir = Files.createTempDirectory("GitTaskClone").toAbsolutePath().toString();
+		Git.cloneRepository().setURI(gitUri).setBranch("refs/heads/" + gitBranch).setDirectory(new File(tmpDir)).call();
+		return tmpDir;
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
@@ -1,0 +1,41 @@
+package com.redhat.parodos.tasks.git;
+
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflows.work.WorkContext;
+import lombok.Getter;
+
+public abstract class GitUtils {
+
+	private GitUtils() {
+	}
+
+	@Getter
+	static final String gitRepoPath = "path";
+
+	@Getter
+	static final String uri = "uri";
+
+	@Getter
+	static final String branch = "branch";
+
+	@Getter
+	static final String ContextUri = "gitUri";
+
+	@Getter
+	static final String ContextBranch = "gitBranch";
+
+	@Getter
+	static final String contextDestination = "gitDestination";
+
+	@Getter
+	static final String contextArchivePath = "gitArchivePath";
+
+	public static String getRepoPath(WorkContext workContext) {
+		var dest = workContext.get(contextDestination);
+		if (dest == null) {
+			return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, getGitRepoPath(), "");
+		}
+		return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, getGitRepoPath(), dest.toString());
+	}
+
+}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitArchiveTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitArchiveTaskTest.java
@@ -1,0 +1,132 @@
+package com.redhat.parodos.tasks.git;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Slf4j
+public class GitArchiveTaskTest {
+
+	private GitArchiveTask gitArchiveTask;
+
+	private Path gitRepoPath;
+
+	private Repository repository;
+
+	private Path tempDir;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		gitArchiveTask = new GitArchiveTask();
+		tempDir = Files.createTempDirectory("git-repo");
+
+		gitRepoPath = tempDir.resolve(".git");
+
+		this.repository = FileRepositoryBuilder.create(gitRepoPath.toFile());
+		this.repository.create();
+		log.info("Created a new repository at {} ", this.repository.getDirectory());
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		assertDoesNotThrow(() -> {
+			repository.close();
+		});
+		try (Stream<Path> walk = Files.walk(tempDir)) {
+			walk.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile).forEach(p -> {
+				assertDoesNotThrow(() -> Files.delete(p.toPath()));
+			});
+		}
+	}
+
+	@Test
+	public void testWithValidData() {
+		// given
+		createSingleFileInRepo();
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", this.repository.getDirectory().toString());
+
+		// when
+		var result = this.gitArchiveTask.execute(workContext);
+
+		// then
+		assertNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.COMPLETED);
+		assertThat(result.getWorkContext().get("gitArchivePath").toString()).contains("output.zip");
+	}
+
+	@Test
+	public void testWithContextFromAnotherGit() {
+		// given
+		createSingleFileInRepo();
+		WorkContext workContext = new WorkContext();
+		workContext.put("gitDestination", this.repository.getDirectory().toString());
+
+		// when
+		var result = this.gitArchiveTask.execute(workContext);
+
+		// then
+		assertNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.COMPLETED);
+		assertThat(result.getWorkContext().get("gitArchivePath").toString()).contains("output.zip");
+	}
+
+	@Test
+	public void testWithInvalidParameters() {
+		// given
+		createSingleFileInRepo();
+		WorkContext workContext = new WorkContext();
+
+		// when
+		var result = this.gitArchiveTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertThat(result.getError().toString()).contains("The path parameter cannot be null or empty");
+	}
+
+	@Test
+	public void testWithInvalidRepo() {
+		// given
+		createSingleFileInRepo();
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", "noexists");
+
+		// when
+		var result = this.gitArchiveTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertThat(result.getError().toString()).contains("Cannot archive the repository");
+	}
+
+	private void createSingleFileInRepo() {
+		Path filePath = tempDir.resolve("file.txt");
+		assertDoesNotThrow(() -> {
+			Files.write(filePath, "Hello, world!".getBytes());
+			Git git = Git.init().setDirectory(tempDir.toFile()).call();
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("Initial commit").setSign(false).call();
+		});
+
+	}
+
+}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitCloneTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitCloneTaskTest.java
@@ -1,0 +1,123 @@
+package com.redhat.parodos.tasks.git;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Slf4j
+public class GitCloneTaskTest {
+
+	private GitCloneTask gitCloneTask;
+
+	private Path gitRepoPath;
+
+	private Repository repository;
+
+	private Path tempDir;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		gitCloneTask = new GitCloneTask();
+		tempDir = Files.createTempDirectory("git-repo");
+
+		gitRepoPath = tempDir.resolve(".git");
+
+		this.repository = FileRepositoryBuilder.create(gitRepoPath.toFile());
+		this.repository.create();
+		log.info("Created a new repository at '{}'", this.repository.getDirectory());
+		this.createSingleFileInRepo();
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		assertDoesNotThrow(() -> {
+			repository.close();
+		});
+		try (Stream<Path> walk = Files.walk(tempDir)) {
+			walk.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile).forEach(p -> {
+				assertDoesNotThrow(() -> Files.delete(p.toPath()));
+			});
+		}
+	}
+
+	@Test
+	public void testWithValidClone() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("uri", this.repository.getDirectory().toString());
+		workContext.put("branch", "master");
+
+		// then
+		var result = this.gitCloneTask.execute(workContext);
+
+		// when
+		assertNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.COMPLETED);
+		assertNotNull(result.getWorkContext().get("gitDestination"));
+		assertNotNull(result.getWorkContext().get("gitUri"));
+	}
+
+	@Test
+	public void testWithInValidClone() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("uri", "InvalidFolder");
+		workContext.put("branch", "master");
+
+		// then
+		var result = this.gitCloneTask.execute(workContext);
+
+		// when
+		assertNotNull(result.getError());
+		assertThat(result.getError().toString()).contains("Remote repository InvalidFolder is not available");
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertNull(result.getWorkContext().get("gitDestination"));
+		assertNull(result.getWorkContext().get("gitUri"));
+	}
+
+	@Test
+	public void testWithInValidBranch() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("uri", this.repository.getDirectory().toString());
+		workContext.put("branch", "fooBranch");
+
+		// then
+		var result = this.gitCloneTask.execute(workContext);
+
+		// when
+		assertNotNull(result.getError());
+		assertThat(result.getError().toString()).contains("cannot connect to the repository server");
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertNull(result.getWorkContext().get("gitDestination"));
+		assertNull(result.getWorkContext().get("gitUri"));
+	}
+
+	private void createSingleFileInRepo() {
+		Path filePath = tempDir.resolve("file.txt");
+		assertDoesNotThrow(() -> {
+			Files.write(filePath, "Hello, world!".getBytes());
+			Git git = Git.init().setDirectory(tempDir.toFile()).call();
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("Initial commit").setSign(false).call();
+		});
+
+	}
+
+}


### PR DESCRIPTION
This commit addressed a new way to clone and archive git repositories inside Parodos.

The main objective for these tasks is to implement work on top of Move2kube.