### PR TITLE
Use time.Instant instead of long

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/checker/BaseWorkFlowCheckerTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/checker/BaseWorkFlowCheckerTask.java
@@ -15,7 +15,7 @@
  */
 package com.redhat.parodos.workflow.task.checker;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskType;
@@ -42,11 +42,11 @@ public abstract class BaseWorkFlowCheckerTask extends BaseWorkFlowTask {
 	 */
 	private WorkFlow escalationWorkflow;
 
-	private long expectedCompletionDate;
+	private Instant deadline;
 
-	protected BaseWorkFlowCheckerTask(WorkFlow escalationWorkflow, long expectedSlaBeforeEscalationInSeconds) {
+	protected BaseWorkFlowCheckerTask(WorkFlow escalationWorkflow, Instant deadline) {
 		super();
-		this.expectedCompletionDate = expectedSlaBeforeEscalationInSeconds;
+		this.deadline = deadline;
 		this.escalationWorkflow = escalationWorkflow;
 	}
 
@@ -72,8 +72,7 @@ public abstract class BaseWorkFlowCheckerTask extends BaseWorkFlowTask {
 		// run the checker
 		WorkReport report = checkWorkFlowStatus(workContext);
 		// determine if there is an escalation path for a failing checker
-		if (escalationWorkflow != null && report.getStatus() == WorkStatus.FAILED
-				&& new Date().getTime() > expectedCompletionDate) {
+		if (escalationWorkflow != null && report.getStatus() == WorkStatus.FAILED && Instant.now().isAfter(deadline)) {
 			// run escalation if SLA is exceeded
 			WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(escalationWorkflow, workContext);
 		}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/EscalationWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/EscalationWorkFlowConfiguration.java
@@ -1,7 +1,7 @@
 package com.redhat.parodos.examples.escalation;
 
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -72,7 +72,7 @@ public class EscalationWorkFlowConfiguration {
 	@Bean
 	public SimpleTaskOneChecker simpleTaskOneCheckerTask(
 			@Qualifier("simpleTaskOneEscalatorWorkflow") WorkFlow simpleTaskOneEscalatorWorkflow) {
-		return new SimpleTaskOneChecker(simpleTaskOneEscalatorWorkflow, new Date().getTime() / 1000 + 30);
+		return new SimpleTaskOneChecker(simpleTaskOneEscalatorWorkflow, Instant.now().plusSeconds(30));
 	}
 
 	@Bean

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/checker/SimpleTaskOneChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/checker/SimpleTaskOneChecker.java
@@ -9,6 +9,8 @@ import com.redhat.parodos.workflows.workflow.WorkFlow;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Instant;
+
 /**
  * A simple WorkflowChecker that will fail 3 times and then succeed every time after
  *
@@ -20,8 +22,8 @@ public class SimpleTaskOneChecker extends BaseWorkFlowCheckerTask {
 
 	private int failCount = 0;
 
-	public SimpleTaskOneChecker(WorkFlow simpleTaskOneEscalatorWorkflow, long sla) {
-		super(simpleTaskOneEscalatorWorkflow, sla);
+	public SimpleTaskOneChecker(WorkFlow simpleTaskOneEscalatorWorkflow, Instant deadline) {
+		super(simpleTaskOneEscalatorWorkflow, deadline);
 	}
 
 	@Override

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
@@ -33,7 +33,8 @@ import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-import java.util.Date;
+
+import java.time.Instant;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -117,7 +118,7 @@ public class OcpOnboardingWorkFlowConfiguration {
 			@Value("${JIRA_URL:test}") String url, @Value("${JIRA_USER:user}") String username,
 			@Value("${JIRA_TOKEN:token}") String password) {
 		return new JiraTicketApprovalWorkFlowCheckerTask(jiraTicketApprovalEscalationWorkFlow,
-				new Date().getTime() / 1000 + 30, url, username, password);
+				Instant.now().plusSeconds(30), url, username, password);
 	}
 
 	@Bean(name = "jiraTicketApprovalWorkFlowChecker")

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/checker/JiraTicketApprovalWorkFlowCheckerTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/checker/JiraTicketApprovalWorkFlowCheckerTask.java
@@ -26,6 +26,8 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseDto;
 import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseValue;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import java.time.Instant;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -56,9 +58,9 @@ public class JiraTicketApprovalWorkFlowCheckerTask extends BaseWorkFlowCheckerTa
 
 	private final String jiraPassword;
 
-	public JiraTicketApprovalWorkFlowCheckerTask(WorkFlow jiraTicketApprovalEscalationWorkFlow, long sla,
+	public JiraTicketApprovalWorkFlowCheckerTask(WorkFlow jiraTicketApprovalEscalationWorkFlow, Instant deadline,
 			String jiraServiceBaseUrl, String jiraUsername, String jiraPassword) {
-		super(jiraTicketApprovalEscalationWorkFlow, sla);
+		super(jiraTicketApprovalEscalationWorkFlow, deadline);
 		this.jiraServiceBaseUrl = jiraServiceBaseUrl;
 		this.jiraUsername = jiraUsername;
 		this.jiraPassword = jiraPassword;


### PR DESCRIPTION
A long for comparing time is ok and very effiecient. However the way to
create one always involes using Date object.
The Instant object is immutable and have much expressive API for points
in time. Also, when using a long, you must name the variable with the
unit used, causing confusion and possibly bugs, and for sure longer var
names.

Signed-off-by: Roy Golan <rgolan@redhat.com>
