### PR TITLE
Organize imports according to spring formatter

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/ComplexWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/ComplexWorkFlow.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.flows;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
 import com.redhat.parodos.sdk.invoker.ApiClient;
@@ -16,10 +19,8 @@ import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpHeaders;
 
-import java.util.Arrays;
-import java.util.List;
+import org.springframework.http.HttpHeaders;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static com.redhat.parodos.sdkutils.SdkUtils.waitWorkflowStatusAsync;

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlow.java
@@ -12,6 +12,7 @@ import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.http.HttpHeaders;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlow.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.flows;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
 import com.redhat.parodos.sdk.invoker.ApiClient;
@@ -18,11 +21,9 @@ import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static org.junit.Assert.assertEquals;

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlow.java
@@ -1,5 +1,9 @@
 package com.redhat.parodos.flows;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
 import com.redhat.parodos.sdk.invoker.ApiClient;
@@ -18,12 +22,9 @@ import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static org.junit.Assert.assertEquals;

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiCallback.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiCallback.java
@@ -12,10 +12,8 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import java.io.IOException;
-
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Callback for asynchronous API call.

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiClient.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiClient.java
@@ -12,16 +12,6 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import okhttp3.*;
-import okhttp3.internal.http.HttpMethod;
-import okhttp3.internal.tls.OkHostnameVerifier;
-import okhttp3.logging.HttpLoggingInterceptor;
-import okhttp3.logging.HttpLoggingInterceptor.Level;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.Okio;
-
-import javax.net.ssl.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,19 +30,25 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.*;
+
+import com.redhat.parodos.notification.sdk.api.auth.ApiKeyAuth;
 import com.redhat.parodos.notification.sdk.api.auth.Authentication;
 import com.redhat.parodos.notification.sdk.api.auth.HttpBasicAuth;
-import com.redhat.parodos.notification.sdk.api.auth.HttpBearerAuth;
-import com.redhat.parodos.notification.sdk.api.auth.ApiKeyAuth;
+import okhttp3.*;
+import okhttp3.internal.http.HttpMethod;
+import okhttp3.internal.tls.OkHostnameVerifier;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.Okio;
 
 /**
  * <p>

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiException.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ApiException.java
@@ -12,10 +12,8 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import java.util.Map;
 import java.util.List;
-
-import javax.ws.rs.core.GenericType;
+import java.util.Map;
 
 /**
  * <p>

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/GzipRequestInterceptor.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/GzipRequestInterceptor.java
@@ -12,13 +12,13 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
+import java.io.IOException;
+
 import okhttp3.*;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-
-import java.io.IOException;
 
 /**
  * Encodes request bodies using gzip.

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/JSON.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/JSON.java
@@ -12,32 +12,25 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.internal.bind.util.ISO8601Utils;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.google.gson.JsonElement;
-import io.gsonfire.GsonFireBuilder;
-import io.gsonfire.TypeSelector;
-
-import okio.ByteString;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Map;
-import java.util.HashMap;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.util.ISO8601Utils;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import io.gsonfire.GsonFireBuilder;
+import okio.ByteString;
 
 /*
  * A JSON utility class

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationMessageApi.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationMessageApi.java
@@ -12,27 +12,12 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import com.redhat.parodos.notification.sdk.api.ApiCallback;
-import com.redhat.parodos.notification.sdk.api.ApiClient;
-import com.redhat.parodos.notification.sdk.api.ApiException;
-import com.redhat.parodos.notification.sdk.api.ApiResponse;
-import com.redhat.parodos.notification.sdk.api.Configuration;
-import com.redhat.parodos.notification.sdk.api.Pair;
-import com.redhat.parodos.notification.sdk.api.ProgressRequestBody;
-import com.redhat.parodos.notification.sdk.api.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
-import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
-
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+
+import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
 
 public class NotificationMessageApi {
 

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationRecordApi.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationRecordApi.java
@@ -12,30 +12,17 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import com.redhat.parodos.notification.sdk.api.ApiCallback;
-import com.redhat.parodos.notification.sdk.api.ApiClient;
-import com.redhat.parodos.notification.sdk.api.ApiException;
-import com.redhat.parodos.notification.sdk.api.ApiResponse;
-import com.redhat.parodos.notification.sdk.api.Configuration;
-import com.redhat.parodos.notification.sdk.api.Pair;
-import com.redhat.parodos.notification.sdk.api.ProgressRequestBody;
-import com.redhat.parodos.notification.sdk.api.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
-import com.redhat.parodos.notification.sdk.model.NotificationRecordResponseDTO;
-import com.redhat.parodos.notification.sdk.model.PageNotificationRecordResponseDTO;
-import com.redhat.parodos.notification.sdk.model.Pageable;
-import java.util.UUID;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
+import java.util.UUID;
+
+import com.google.gson.reflect.TypeToken;
+import com.redhat.parodos.notification.sdk.model.NotificationRecordResponseDTO;
+import com.redhat.parodos.notification.sdk.model.PageNotificationRecordResponseDTO;
+import com.redhat.parodos.notification.sdk.model.Pageable;
 
 public class NotificationRecordApi {
 

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ProgressRequestBody.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ProgressRequestBody.java
@@ -12,11 +12,10 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-
 import java.io.IOException;
 
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.ForwardingSink;

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ProgressResponseBody.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/ProgressResponseBody.java
@@ -12,11 +12,10 @@
 
 package com.redhat.parodos.notification.sdk.api;
 
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
-
 import java.io.IOException;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/ApiKeyAuth.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/ApiKeyAuth.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.notification.sdk.api.auth;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.notification.sdk.api.ApiException;
 import com.redhat.parodos.notification.sdk.api.Pair;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiKeyAuth implements Authentication {

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/Authentication.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/Authentication.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.notification.sdk.api.auth;
 
-import com.redhat.parodos.notification.sdk.api.Pair;
-import com.redhat.parodos.notification.sdk.api.ApiException;
-
 import java.net.URI;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+
+import com.redhat.parodos.notification.sdk.api.ApiException;
+import com.redhat.parodos.notification.sdk.api.Pair;
 
 public interface Authentication {
 

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/HttpBasicAuth.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/HttpBasicAuth.java
@@ -12,16 +12,13 @@
 
 package com.redhat.parodos.notification.sdk.api.auth;
 
-import com.redhat.parodos.notification.sdk.api.Pair;
-import com.redhat.parodos.notification.sdk.api.ApiException;
-
-import okhttp3.Credentials;
-
 import java.net.URI;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
-import java.io.UnsupportedEncodingException;
+import com.redhat.parodos.notification.sdk.api.ApiException;
+import com.redhat.parodos.notification.sdk.api.Pair;
+import okhttp3.Credentials;
 
 public class HttpBasicAuth implements Authentication {
 

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/HttpBearerAuth.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/auth/HttpBearerAuth.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.notification.sdk.api.auth;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.notification.sdk.api.ApiException;
 import com.redhat.parodos.notification.sdk.api.Pair;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class HttpBearerAuth implements Authentication {

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/AbstractOpenApiSchema.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/AbstractOpenApiSchema.java
@@ -12,10 +12,9 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import com.redhat.parodos.notification.sdk.api.ApiException;
-import java.util.Objects;
-import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
+
 import javax.ws.rs.core.GenericType;
 
 //import com.fasterxml.jackson.annotation.JsonValue;

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Link.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Link.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/NotificationMessageCreateRequestDTO.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/NotificationMessageCreateRequestDTO.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/NotificationRecordResponseDTO.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/NotificationRecordResponseDTO.java
@@ -12,39 +12,26 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.notification.sdk.model.Link;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/PageNotificationRecordResponseDTO.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/PageNotificationRecordResponseDTO.java
@@ -12,39 +12,24 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.notification.sdk.model.NotificationRecordResponseDTO;
-import com.redhat.parodos.notification.sdk.model.PageableObject;
-import com.redhat.parodos.notification.sdk.model.Sort;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Pageable.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Pageable.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/PageableObject.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/PageableObject.java
@@ -12,35 +12,21 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.notification.sdk.model.Sort;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Sort.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/model/Sort.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.notification.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.notification.sdk.api.JSON;
 
 /**

--- a/notification-service/src/main/java/com/redhat/parodos/notification/config/ModelMapperConfig.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/config/ModelMapperConfig.java
@@ -4,6 +4,7 @@ import com.redhat.parodos.notification.dto.NotificationRecordResponseDTO;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.PropertyMap;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/notification-service/src/main/java/com/redhat/parodos/notification/config/SecurityProperties.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/config/SecurityProperties.java
@@ -1,8 +1,9 @@
 package com.redhat.parodos.notification.config;
 
+import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import lombok.Data;
 
 @ConfigurationProperties(prefix = "spring.security")
 @ConfigurationPropertiesScan

--- a/notification-service/src/main/java/com/redhat/parodos/notification/config/SwaggerConfiguration.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/config/SwaggerConfiguration.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.notification.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/controller/NotificationMessageController.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/controller/NotificationMessageController.java
@@ -18,6 +18,7 @@ package com.redhat.parodos.notification.controller;
 import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.notification.service.NotificationMessageService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/notification-service/src/main/java/com/redhat/parodos/notification/controller/NotificationRecordController.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/controller/NotificationRecordController.java
@@ -17,31 +17,30 @@ package com.redhat.parodos.notification.controller;
 
 import java.util.UUID;
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.redhat.parodos.notification.dto.NotificationRecordResponseDTO;
 import com.redhat.parodos.notification.enums.Operation;
 import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.service.NotificationRecordService;
 import com.redhat.parodos.notification.util.SecurityUtil;
-
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Notification record controller

--- a/notification-service/src/main/java/com/redhat/parodos/notification/dto/NotificationMessageCreateRequestDTO.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/dto/NotificationMessageCreateRequestDTO.java
@@ -15,9 +15,9 @@
  */
 package com.redhat.parodos.notification.dto;
 
-import lombok.Data;
-
 import java.util.List;
+
+import lombok.Data;
 
 /**
  * Notification message create request DTO

--- a/notification-service/src/main/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTO.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTO.java
@@ -21,11 +21,11 @@ import java.util.UUID;
 
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
-import org.springframework.hateoas.RepresentationModel;
-import org.springframework.hateoas.server.core.Relation;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.hateoas.server.core.Relation;
 
 /**
  * Notification record response DTO

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationGroup.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationGroup.java
@@ -15,7 +15,8 @@
  */
 package com.redhat.parodos.notification.jpa.entity;
 
-import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,8 +24,8 @@ import javax.persistence.FetchType;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
 
 /**
  * Users belong to zero or more groups.

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationMessage.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationMessage.java
@@ -15,7 +15,8 @@
  */
 package com.redhat.parodos.notification.jpa.entity;
 
-import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
+import java.time.Instant;
+import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -23,8 +24,8 @@ import javax.persistence.Entity;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import java.time.Instant;
-import java.util.List;
+
+import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
 
 /**
  * The message associated with a notification. Want to ensure that the potentially large

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationRecord.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationRecord.java
@@ -17,6 +17,7 @@ package com.redhat.parodos.notification.jpa.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -27,6 +28,7 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
 import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationUser.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/NotificationUser.java
@@ -15,10 +15,8 @@
  */
 package com.redhat.parodos.notification.jpa.entity;
 
-import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -29,8 +27,11 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.redhat.parodos.notification.jpa.entity.base.AbstractEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * Represents a user in the system, not definitive owner, can create a record per user

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/base/AbstractEntity.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/entity/base/AbstractEntity.java
@@ -15,14 +15,15 @@
  */
 package com.redhat.parodos.notification.jpa.entity.base;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Version;
-import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationGroupRepository.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationGroupRepository.java
@@ -15,13 +15,14 @@
  */
 package com.redhat.parodos.notification.jpa.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.notification.jpa.entity.NotificationGroup;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationMessageRepository.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationMessageRepository.java
@@ -15,12 +15,13 @@
  */
 package com.redhat.parodos.notification.jpa.repository;
 
+import java.util.UUID;
+
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationRecordRepository.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationRecordRepository.java
@@ -15,8 +15,11 @@
  */
 package com.redhat.parodos.notification.jpa.repository;
 
+import java.util.UUID;
+
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,8 +27,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationUserRepository.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/jpa/repository/NotificationUserRepository.java
@@ -15,13 +15,14 @@
  */
 package com.redhat.parodos.notification.jpa.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/security/LdapConnectionProperties.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/security/LdapConnectionProperties.java
@@ -15,10 +15,10 @@
  */
 package com.redhat.parodos.notification.security;
 
+import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-
-import lombok.Data;
 
 @ConfigurationProperties(prefix = "spring.ldap.connection")
 @ConfigurationPropertiesScan

--- a/notification-service/src/main/java/com/redhat/parodos/notification/security/SecurityConfiguration.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/security/SecurityConfiguration.java
@@ -15,9 +15,8 @@
  */
 package com.redhat.parodos.notification.security;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import com.redhat.parodos.notification.config.SecurityProperties;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +29,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 /**
  * Security configuration for the application to ensure the main endpoints are locked down

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/NotificationRecordService.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/NotificationRecordService.java
@@ -15,13 +15,15 @@
  */
 package com.redhat.parodos.notification.service;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.notification.enums.Operation;
 import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
-import java.util.List;
-import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/NotificationUserService.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/NotificationUserService.java
@@ -15,8 +15,9 @@
  */
 package com.redhat.parodos.notification.service;
 
-import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import java.util.List;
+
+import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationMessageServiceImpl.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationMessageServiceImpl.java
@@ -15,7 +15,9 @@
  */
 package com.redhat.parodos.notification.service.impl;
 
-import com.redhat.parodos.notification.util.SecurityUtil;
+import java.time.Instant;
+import java.util.List;
+
 import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
@@ -23,8 +25,8 @@ import com.redhat.parodos.notification.jpa.repository.NotificationMessageReposit
 import com.redhat.parodos.notification.service.NotificationMessageService;
 import com.redhat.parodos.notification.service.NotificationRecordService;
 import com.redhat.parodos.notification.service.NotificationUserService;
-import java.time.Instant;
-import java.util.List;
+import com.redhat.parodos.notification.util.SecurityUtil;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
@@ -19,13 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.http.HttpStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
-
 import com.redhat.parodos.notification.enums.Operation;
 import com.redhat.parodos.notification.enums.SearchCriteria;
 import com.redhat.parodos.notification.enums.State;
@@ -38,8 +31,14 @@ import com.redhat.parodos.notification.jpa.repository.NotificationRecordReposito
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
 import com.redhat.parodos.notification.service.NotificationRecordService;
 import com.redhat.parodos.notification.util.SearchUtil;
-
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationUserServiceImpl.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationUserServiceImpl.java
@@ -15,11 +15,13 @@
  */
 package com.redhat.parodos.notification.service.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
 import com.redhat.parodos.notification.service.NotificationUserService;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/notification-service/src/main/java/com/redhat/parodos/notification/util/SearchUtil.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/util/SearchUtil.java
@@ -1,10 +1,10 @@
 package com.redhat.parodos.notification.util;
 
-import static java.util.Objects.isNull;
-
 import com.redhat.parodos.notification.enums.SearchCriteria;
 import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.exceptions.SearchByStateAndTermNotSupportedException;
+
+import static java.util.Objects.isNull;
 
 /**
  * Notification records search util

--- a/notification-service/src/main/java/com/redhat/parodos/notification/util/SecurityUtil.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/util/SecurityUtil.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.notification.util;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
 import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility method to get the Username from the Authenticated Session

--- a/notification-service/src/test/java/com/redhat/parodos/notification/controller/AbstractControllerTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/controller/AbstractControllerTests.java
@@ -17,13 +17,15 @@ package com.redhat.parodos.notification.controller;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
+import com.redhat.parodos.notification.jpa.NotificationsDataCreator;
 import org.junit.jupiter.api.BeforeEach;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
-import com.redhat.parodos.notification.jpa.NotificationsDataCreator;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/test/java/com/redhat/parodos/notification/controller/AbstractNotificationsIntegrationTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/controller/AbstractNotificationsIntegrationTest.java
@@ -15,11 +15,10 @@
  */
 package com.redhat.parodos.notification.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +28,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/test/java/com/redhat/parodos/notification/controller/NotificationRecordControllerTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/controller/NotificationRecordControllerTests.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.notification.controller;
 
+import javax.transaction.Transactional;
+
 import com.jayway.jsonpath.JsonPath;
 import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.notification.enums.Operation;
@@ -26,6 +28,7 @@ import com.redhat.parodos.notification.util.SecurityUtil;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -38,8 +41,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import javax.transaction.Transactional;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTOTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTOTest.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.notification.dto;
 
-import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
-import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
+import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NotificationRecordResponseDTOTest {
 

--- a/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationGroupRepositoryTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationGroupRepositoryTests.java
@@ -18,9 +18,9 @@ package com.redhat.parodos.notification.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.entity.NotificationGroup;
 import com.redhat.parodos.notification.jpa.repository.NotificationGroupRepository;
-import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationMessageRecordRelationshipTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationMessageRecordRelationshipTests.java
@@ -17,11 +17,11 @@ package com.redhat.parodos.notification.jpa;
 
 import java.util.List;
 
+import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.repository.NotificationMessageRepository;
 import com.redhat.parodos.notification.jpa.repository.NotificationRecordRepository;
-import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserGroupRelationshipTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserGroupRelationshipTests.java
@@ -18,11 +18,11 @@ package com.redhat.parodos.notification.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.entity.NotificationGroup;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationGroupRepository;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
-import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserRecordRelationshipTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserRecordRelationshipTests.java
@@ -18,11 +18,11 @@ package com.redhat.parodos.notification.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationRecordRepository;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
-import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserRepositoryTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/jpa/NotificationUserRepositoryTests.java
@@ -18,9 +18,9 @@ package com.redhat.parodos.notification.jpa;
 import java.util.List;
 import java.util.Optional;
 
+import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
-import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationMessageServiceTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationMessageServiceTest.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.notification.service;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.redhat.parodos.notification.dto.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
@@ -8,11 +11,6 @@ import com.redhat.parodos.notification.service.impl.NotificationMessageServiceIm
 import com.redhat.parodos.notification.util.SecurityUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class NotificationMessageServiceTest {
 

--- a/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationRecordServiceTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationRecordServiceTests.java
@@ -15,24 +15,10 @@
  */
 package com.redhat.parodos.notification.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.redhat.parodos.notification.enums.Operation;
 import com.redhat.parodos.notification.enums.State;
@@ -45,6 +31,20 @@ import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationRecordRepository;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
 import com.redhat.parodos.notification.service.impl.NotificationRecordServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * @author Nir Argaman (Github: nirarg)

--- a/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationUserServiceTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationUserServiceTests.java
@@ -15,19 +15,21 @@
  */
 package com.redhat.parodos.notification.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+
 import com.redhat.parodos.notification.controller.AbstractNotificationsIntegrationTest;
 import com.redhat.parodos.notification.jpa.NotificationsDataCreator;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
 import com.redhat.parodos.notification.jpa.repository.NotificationGroupRepository;
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Richard Wang (Github: RichardW98)

--- a/notification-service/src/test/java/com/redhat/parodos/notification/util/SearchUtilTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/util/SearchUtilTest.java
@@ -5,7 +5,8 @@ import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.exceptions.SearchByStateAndTermNotSupportedException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SearchUtilTest {
 

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Assessment.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Assessment.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.workflow.annotation;
 
-import static java.lang.annotation.ElementType.METHOD;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Assessment Annotation

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Checker.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Checker.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.workflow.annotation;
 
-import static java.lang.annotation.ElementType.METHOD;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Checker Annotation

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Escalation.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Escalation.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.workflow.annotation;
 
-import static java.lang.annotation.ElementType.METHOD;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Escalation Annotation

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Infrastructure.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Infrastructure.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.workflow.annotation;
 
-import static java.lang.annotation.ElementType.METHOD;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Infrastructure Annotation

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Parameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Parameter.java
@@ -15,14 +15,14 @@
  */
 package com.redhat.parodos.workflow.annotation;
 
-import com.redhat.parodos.workflow.parameter.WorkParameterType;
-
-import static java.lang.annotation.ElementType.METHOD;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+
+import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * Parameter annotation

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/option/WorkFlowOption.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/option/WorkFlowOption.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.workflow.option;
 
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * An WorkFlowOption is an identifier for a collection of @see WorkFlowTasks that can be

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameter.java
@@ -15,13 +15,13 @@
  */
 package com.redhat.parodos.workflow.parameter;
 
+import java.util.List;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Workflow parameter type

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameterValueProvider.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameterValueProvider.java
@@ -15,10 +15,10 @@
  */
 package com.redhat.parodos.workflow.parameter;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Collections;
 import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Workflow Parameter Value Provider

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameterValueResponse.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkParameterValueResponse.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.workflow.parameter;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 /**
  * Work Parameter Value response

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
@@ -15,16 +15,17 @@
  */
 package com.redhat.parodos.workflow.task;
 
-import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.utils.WorkContextUtils;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.workflow.WorkFlow;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.BeanNameAware;
 
 /**

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
@@ -15,15 +15,15 @@
  */
 package com.redhat.parodos.workflow.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflows.work.Work;
-import lombok.NonNull;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflows.work.Work;
+import lombok.NonNull;
 
 /**
  * Basic Contract for Work in the Infrastructure Service

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/assessment/BaseAssessmentTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/assessment/BaseAssessmentTask.java
@@ -16,6 +16,7 @@
 package com.redhat.parodos.workflow.task.assessment;
 
 import java.util.List;
+
 import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskType;

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/shell/ShellRunnerTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/shell/ShellRunnerTask.java
@@ -1,5 +1,17 @@
 package com.redhat.parodos.workflow.task.shell;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
 import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
@@ -7,14 +19,9 @@ import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import static java.nio.file.attribute.PosixFilePermission.*;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 /**
  * ShellRunnerTask takes a script and an optional env and runs them to completion and

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/WorkContextUtils.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/WorkContextUtils.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
-import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflows.work.WorkContext;
 import lombok.NonNull;
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/context/ResourceTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/context/ResourceTest.java
@@ -1,9 +1,9 @@
 package com.redhat.parodos.workflow.context;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
 
 public class ResourceTest {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/option/WorkFlowOptionsTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/option/WorkFlowOptionsTest.java
@@ -15,13 +15,13 @@
  */
 package com.redhat.parodos.workflow.option;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
 
 public class WorkFlowOptionsTest {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkParameterTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkParameterTest.java
@@ -1,8 +1,8 @@
 package com.redhat.parodos.workflow.parameter;
 
-import junit.framework.TestCase;
-
 import java.util.Map;
+
+import junit.framework.TestCase;
 
 public class WorkParameterTest extends TestCase {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkParameterTypeTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkParameterTypeTest.java
@@ -1,12 +1,12 @@
 package com.redhat.parodos.workflow.parameter;
 
-import junit.framework.TestCase;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import junit.framework.TestCase;
+import org.junit.Test;
 
 public class WorkParameterTypeTest extends TestCase {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/WorkFlowTaskTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/WorkFlowTaskTest.java
@@ -15,31 +15,29 @@
  */
 package com.redhat.parodos.workflow.task;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
-import org.junit.Test;
 
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
-
 import lombok.NonNull;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class WorkFlowTaskTest {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/shell/ShellRunnerTaskTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/shell/ShellRunnerTaskTest.java
@@ -1,11 +1,11 @@
 package com.redhat.parodos.workflow.task.shell;
 
+import java.util.UUID;
+
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/WorkContextUtilsTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/WorkContextUtilsTest.java
@@ -3,11 +3,11 @@ package com.redhat.parodos.workflow.utils;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class WorkContextUtilsTest {
 

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflows/common/context/WorkContextDelegateTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflows/common/context/WorkContextDelegateTest.java
@@ -15,14 +15,13 @@
  */
 package com.redhat.parodos.workflows.common.context;
 
-import static java.util.UUID.randomUUID;
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.Assert.assertEquals;
 
 public class WorkContextDelegateTest {
 

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/PatternDetector.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/PatternDetector.java
@@ -16,6 +16,7 @@
 package com.redhat.parodos.patterndetection;
 
 import java.util.Date;
+
 import com.redhat.parodos.patterndetection.context.WorkContextDelegate;
 import com.redhat.parodos.patterndetection.exceptions.PatternDetectionConfigurationException;
 import com.redhat.parodos.patterndetection.pattern.Pattern;

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/ScanningThreadPool.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/ScanningThreadPool.java
@@ -18,8 +18,8 @@ package com.redhat.parodos.patterndetection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides access to the ThreadPool executor for all Scans to share.

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/AbstractClue.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/AbstractClue.java
@@ -16,6 +16,7 @@
 package com.redhat.parodos.patterndetection.clue;
 
 import java.util.UUID;
+
 import com.redhat.parodos.patterndetection.clue.delegate.NameMatchingDelegate;
 import com.redhat.parodos.patterndetection.context.WorkContextDelegate;
 import lombok.Data;

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/ContentsClueImpl.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/ContentsClueImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import com.redhat.parodos.patterndetection.clue.delegate.FileContentsDelegate;
 import com.redhat.parodos.patterndetection.exceptions.PatternDetectionConfigurationException;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/NameClueImpl.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/NameClueImpl.java
@@ -18,6 +18,7 @@ package com.redhat.parodos.patterndetection.clue;
 import java.io.File;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import com.redhat.parodos.patterndetection.clue.delegate.FileContentsDelegate;
 import com.redhat.parodos.patterndetection.exceptions.ClueConfigurationException;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/delegate/NameMatchingDelegate.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/clue/delegate/NameMatchingDelegate.java
@@ -18,6 +18,7 @@ package com.redhat.parodos.patterndetection.clue.delegate;
 import java.io.File;
 import java.util.Optional;
 import java.util.regex.Pattern;
+
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/context/WorkContextDelegate.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/context/WorkContextDelegate.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import com.redhat.parodos.patterndetection.clue.Clue;
 import com.redhat.parodos.patterndetection.pattern.Pattern;
 import com.redhat.parodos.workflows.work.WorkContext;

--- a/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/results/DetectionResults.java
+++ b/pattern-detection-library/src/main/java/com/redhat/parodos/patterndetection/results/DetectionResults.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
 import com.redhat.parodos.patterndetection.clue.Clue;
 import com.redhat.parodos.patterndetection.pattern.Pattern;
 import lombok.Builder;

--- a/pattern-detection-library/src/test/java/com/redhat/parodos/patterndetection/PatternDetectorTest.java
+++ b/pattern-detection-library/src/test/java/com/redhat/parodos/patterndetection/PatternDetectorTest.java
@@ -15,13 +15,8 @@
  */
 package com.redhat.parodos.patterndetection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
 import com.redhat.parodos.patterndetection.clue.ContentsClueImpl;
 import com.redhat.parodos.patterndetection.clue.NameClueImpl;
 import com.redhat.parodos.patterndetection.context.WorkContextDelegate;
@@ -30,6 +25,12 @@ import com.redhat.parodos.patterndetection.pattern.BasicPatternImpl;
 import com.redhat.parodos.patterndetection.pattern.Pattern;
 import com.redhat.parodos.patterndetection.results.DetectionResults;
 import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  *

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,26 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>1.8.0</version>
+                    <configuration>
+                        <groups>java.,javax.,jakarta.,*,org.springframework.</groups>
+                        <staticGroups>*</staticGroups>
+                        <staticAfter>true</staticAfter>
+                        <removeUnused>true</removeUnused>
+                        <compliance>${java.version}</compliance>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>sort-imports</id>
+                            <goals>
+                                <goal>sort</goal><!-- runs at process-sources phase by default -->
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>io.spring.javaformat</groupId>
                     <artifactId>spring-javaformat-maven-plugin</artifactId>
                     <version>${spring.javaformat.version}</version>
@@ -205,6 +225,10 @@
             <plugin>
                 <groupId>io.spring.javaformat</groupId>
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>impsort-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
@@ -1,5 +1,14 @@
 package com.redhat.parodos.tasks.jira;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.StreamSupport;
+
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Comment;
@@ -10,9 +19,9 @@ import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -21,13 +30,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.net.URI;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.StreamSupport;
 
 import static com.redhat.parodos.workflow.context.WorkContextDelegate.getOptionalValueFromRequestParams;
 import static com.redhat.parodos.workflow.context.WorkContextDelegate.getRequiredValueFromRequestParams;

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTask.java
@@ -1,5 +1,10 @@
 package com.redhat.parodos.tasks.kubeapi;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
@@ -17,11 +22,6 @@ import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.dynamic.Dynamics;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * KubeapiWorkFlowTask A task for get/create/update Kubernetes resource User provides

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubernetesApi.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubernetesApi.java
@@ -1,9 +1,9 @@
 package com.redhat.parodos.tasks.kubeapi;
 
+import java.io.IOException;
+
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
-
-import java.io.IOException;
 
 interface KubernetesApi {
 

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubernetesApiImpl.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/kubeapi/KubernetesApiImpl.java
@@ -1,14 +1,14 @@
 package com.redhat.parodos.tasks.kubeapi;
 
+import java.io.IOException;
+import java.io.StringReader;
+
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
-
-import java.io.IOException;
-import java.io.StringReader;
 
 class KubernetesApiImpl implements KubernetesApi {
 

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTask.java
@@ -1,29 +1,30 @@
 package com.redhat.parodos.tasks.notification;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.notification.sdk.api.ApiClient;
 import com.redhat.parodos.notification.sdk.api.ApiException;
 import com.redhat.parodos.notification.sdk.api.Configuration;
 import com.redhat.parodos.notification.sdk.api.NotificationMessageApi;
 import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import org.springframework.http.HttpHeaders;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.util.CollectionUtils;
 
-import java.util.List;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Arrays;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.CollectionUtils;
 
 @Slf4j
 public class NotificationWorkFlowTask extends BaseWorkFlowTask {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTask.java
@@ -2,10 +2,11 @@ package com.redhat.parodos.tasks.tibco;
 
 import java.util.LinkedList;
 import java.util.List;
-import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
@@ -16,7 +16,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraTaskTest {

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTaskTest.java
@@ -1,24 +1,25 @@
 package com.redhat.parodos.tasks.kubeapi;
 
+import java.io.IOException;
+import java.util.HashMap;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.dynamic.Dynamics;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
-import java.util.HashMap;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class KubeapiWorkFlowTaskTest {
 

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
@@ -1,5 +1,9 @@
 package com.redhat.parodos.tasks.notification;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
 import com.redhat.parodos.notification.sdk.api.ApiException;
 import com.redhat.parodos.notification.sdk.api.NotificationMessageApi;
 import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
@@ -13,13 +17,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 public class NotificationWorkFlowTaskTest {
 

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTaskTest.java
@@ -1,24 +1,23 @@
 package com.redhat.parodos.tasks.tibco;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import java.util.HashMap;
 
 import javax.jms.JMSException;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TibcoWorkFlowTaskTest {
 

--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/CustomPropertiesReader.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/CustomPropertiesReader.java
@@ -1,13 +1,14 @@
 package com.redhat.parodos.sdkutils;
 
+import java.util.Properties;
+
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ClassPathResource;
-
-import java.util.Properties;
 
 /**
  * @author Gloria Ciavarrini (Github: gciavarrini)

--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
@@ -1,6 +1,15 @@
 package com.redhat.parodos.sdkutils;
 
-import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nullable;
+
 import com.redhat.parodos.sdk.api.ProjectApi;
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.invoker.ApiCallback;
@@ -13,17 +22,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.MissingRequiredPropertiesException;
-
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
 
 /***
  * A utility class to ease the writing of new examples.

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImpl.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImpl.java
@@ -23,11 +23,11 @@
  */
 package com.redhat.parodos.workflows.engine;
 
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
 
 class WorkFlowEngineImpl implements WorkFlowEngine {
 

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ConditionalFlow.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ConditionalFlow.java
@@ -25,10 +25,10 @@ package com.redhat.parodos.workflows.workflow;
 
 import java.util.UUID;
 
-import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.NoOpWork;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkReportPredicate;
 
 /**

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlow.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlow.java
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
-import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
 
 /**
  * A parallel flow executes a set of work units in parallel. A {@link ParallelFlow}

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 
 /**

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImplTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImplTest.java
@@ -23,21 +23,11 @@
  */
 package com.redhat.parodos.workflows.engine;
 
-import static com.redhat.parodos.workflows.engine.WorkFlowEngineBuilder.aNewWorkFlowEngine;
-import static com.redhat.parodos.workflows.work.WorkReportPredicate.COMPLETED;
-import static com.redhat.parodos.workflows.workflow.ConditionalFlow.Builder.aNewConditionalFlow;
-import static com.redhat.parodos.workflows.workflow.ParallelFlow.Builder.aNewParallelFlow;
-import static com.redhat.parodos.workflows.workflow.RepeatFlow.Builder.aNewRepeatFlow;
-import static com.redhat.parodos.workflows.workflow.SequentialFlow.Builder.aNewSequentialFlow;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.Test;
-import org.mockito.Mockito;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
@@ -48,6 +38,16 @@ import com.redhat.parodos.workflows.workflow.ParallelFlow;
 import com.redhat.parodos.workflows.workflow.RepeatFlow;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static com.redhat.parodos.workflows.engine.WorkFlowEngineBuilder.aNewWorkFlowEngine;
+import static com.redhat.parodos.workflows.work.WorkReportPredicate.COMPLETED;
+import static com.redhat.parodos.workflows.workflow.ConditionalFlow.Builder.aNewConditionalFlow;
+import static com.redhat.parodos.workflows.workflow.ParallelFlow.Builder.aNewParallelFlow;
+import static com.redhat.parodos.workflows.workflow.RepeatFlow.Builder.aNewRepeatFlow;
+import static com.redhat.parodos.workflows.workflow.SequentialFlow.Builder.aNewSequentialFlow;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WorkFlowEngineImplTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ConditionalFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ConditionalFlowTest.java
@@ -23,12 +23,11 @@
  */
 package com.redhat.parodos.workflows.workflow;
 
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReportPredicate;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ConditionalFlowTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowExecutorTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowExecutorTest.java
@@ -28,15 +28,14 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ParallelFlowExecutorTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
@@ -23,13 +23,12 @@
  */
 package com.redhat.parodos.workflows.workflow;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ParallelFlowReportTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowTest.java
@@ -26,12 +26,11 @@ package com.redhat.parodos.workflows.workflow;
 import java.util.Arrays;
 import java.util.List;
 
+import com.redhat.parodos.workflows.work.Work;
+import com.redhat.parodos.workflows.work.WorkContext;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import com.redhat.parodos.workflows.work.Work;
-import com.redhat.parodos.workflows.work.WorkContext;
 
 public class ParallelFlowTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/RepeatFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/RepeatFlowTest.java
@@ -23,12 +23,11 @@
  */
 package com.redhat.parodos.workflows.workflow;
 
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReportPredicate;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class RepeatFlowTest {
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/SequentialFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/SequentialFlowTest.java
@@ -26,7 +26,11 @@ package com.redhat.parodos.workflows.workflow;
 import java.util.Arrays;
 import java.util.List;
 
-import com.redhat.parodos.workflows.work.*;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.Work;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/KubeapiWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/KubeapiWorkFlowConfiguration.java
@@ -1,17 +1,16 @@
 package com.redhat.parodos.examples;
 
+import java.io.IOException;
+
 import com.redhat.parodos.tasks.kubeapi.KubeapiWorkFlowTask;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 
 /**
  *

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/ComplexWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/ComplexWorkFlowConfiguration.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.examples.complex;
 
+import java.util.Arrays;
+import java.util.concurrent.Executors;
+
 import com.redhat.parodos.examples.complex.checker.NamespaceApprovalWorkFlowCheckerTask;
 import com.redhat.parodos.examples.complex.checker.SslCertificationApprovalWorkFlowCheckerTask;
 import com.redhat.parodos.examples.complex.parameter.ComplexWorkParameterValueProvider;
@@ -16,17 +19,15 @@ import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflow.annotation.Parameter;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
-import com.redhat.parodos.workflow.parameter.WorkParameterValueProvider;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.parameter.WorkParameterValueProvider;
 import com.redhat.parodos.workflows.workflow.ParallelFlow;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.Arrays;
-import java.util.concurrent.Executors;
 
 @Configuration
 public class ComplexWorkFlowConfiguration {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.checker;
 
-import com.redhat.parodos.workflows.work.WorkStatus;
+import java.util.Collections;
+import java.util.List;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Collections;
-import java.util.List;
 
 @Slf4j
 public class NamespaceApprovalWorkFlowCheckerTask extends BaseWorkFlowCheckerTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/checker/SslCertificationApprovalWorkFlowCheckerTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/checker/SslCertificationApprovalWorkFlowCheckerTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.checker;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
+import java.util.Collections;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Collections;
-import java.util.List;
 
 @Slf4j
 public class SslCertificationApprovalWorkFlowCheckerTask extends BaseWorkFlowCheckerTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/parameter/ComplexWorkParameterValueProvider.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/parameter/ComplexWorkParameterValueProvider.java
@@ -15,12 +15,12 @@
  */
 package com.redhat.parodos.examples.complex.parameter;
 
-import com.redhat.parodos.workflow.parameter.WorkParameterValueRequest;
-import com.redhat.parodos.workflow.parameter.WorkParameterValueProvider;
-import com.redhat.parodos.workflow.parameter.WorkParameterValueResponse;
-
 import java.util.Collections;
 import java.util.List;
+
+import com.redhat.parodos.workflow.parameter.WorkParameterValueProvider;
+import com.redhat.parodos.workflow.parameter.WorkParameterValueRequest;
+import com.redhat.parodos.workflow.parameter.WorkParameterValueResponse;
 
 /**
  * Complex Workflow Parameter Value Provider

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/AdGroupsWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/AdGroupsWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class AdGroupsWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/LoadBalancerWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/LoadBalancerWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class LoadBalancerWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/NamespaceWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/NamespaceWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class NamespaceWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTask.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.examples.complex.task;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.option.WorkFlowOptions;
@@ -26,9 +29,6 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Simple Assessment to determine if an Onboarding Workflow is appropriate. It returns a

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SingleSignOnWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SingleSignOnWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class SingleSignOnWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SplunkMonitoringWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SplunkMonitoringWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class SplunkMonitoringWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SslCertificationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/task/SslCertificationWorkFlowTask.java
@@ -1,16 +1,16 @@
 package com.redhat.parodos.examples.complex.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
 
 @Slf4j
 public class SslCertificationWorkFlowTask extends BaseInfrastructureWorkFlowTask {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/EscalationWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/EscalationWorkFlowConfiguration.java
@@ -3,10 +3,6 @@ package com.redhat.parodos.examples.escalation;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import com.redhat.parodos.examples.escalation.checker.SimpleTaskOneChecker;
 import com.redhat.parodos.examples.escalation.task.SimpleTaskOne;
 import com.redhat.parodos.examples.escalation.task.SimpleTaskOneEscalator;
@@ -16,6 +12,10 @@ import com.redhat.parodos.workflow.annotation.Escalation;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  *

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/checker/SimpleTaskOneChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/checker/SimpleTaskOneChecker.java
@@ -6,7 +6,6 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskOne.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskOne.java
@@ -5,7 +5,6 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskOneEscalator.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskOneEscalator.java
@@ -5,7 +5,6 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskTwo.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/escalation/task/SimpleTaskTwo.java
@@ -5,7 +5,6 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.examples.ocponboarding;
 
+import java.util.Date;
+import java.util.List;
+
 import com.redhat.parodos.examples.ocponboarding.checker.JiraTicketApprovalWorkFlowCheckerTask;
 import com.redhat.parodos.examples.ocponboarding.escalation.JiraTicketApprovalEscalationWorkFlowTask;
 import com.redhat.parodos.examples.ocponboarding.task.AppLinkEmailNotificationWorkFlowTask;
@@ -33,8 +36,7 @@ import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-import java.util.Date;
-import java.util.List;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/checker/JiraTicketApprovalWorkFlowCheckerTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/checker/JiraTicketApprovalWorkFlowCheckerTask.java
@@ -15,6 +15,10 @@
  */
 package com.redhat.parodos.examples.ocponboarding.checker;
 
+import java.util.List;
+
+import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseDto;
+import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseValue;
 import com.redhat.parodos.examples.utils.RestUtils;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
@@ -23,11 +27,9 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseDto;
-import com.redhat.parodos.examples.ocponboarding.task.dto.jira.GetJiraTicketResponseValue;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTask.java
@@ -15,7 +15,9 @@
  */
 package com.redhat.parodos.examples.ocponboarding.escalation;
 
-import static java.util.Objects.isNull;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import com.redhat.parodos.examples.ocponboarding.task.dto.email.MessageRequestDTO;
 import com.redhat.parodos.examples.utils.RestUtils;
@@ -26,12 +28,12 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+
+import static java.util.Objects.isNull;
 
 /**
  * An example of a task that send an escalation email notification for a pending Jira

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTask.java
@@ -15,7 +15,11 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task;
 
-import static java.util.Objects.isNull;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.redhat.parodos.examples.ocponboarding.task.dto.email.MessageRequestDTO;
 import com.redhat.parodos.examples.utils.RestUtils;
@@ -26,17 +30,15 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+
+import static java.util.Objects.isNull;
 
 /**
  * An example of a task that send an app link email notification

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTask.java
@@ -15,6 +15,12 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.List;
+import java.util.Objects;
+
+import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketRequestDto;
+import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketResponseDto;
+import com.redhat.parodos.examples.ocponboarding.task.dto.jira.RequestFieldValues;
 import com.redhat.parodos.examples.utils.RestUtils;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
@@ -22,12 +28,8 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketRequestDto;
-import com.redhat.parodos.examples.ocponboarding.task.dto.jira.RequestFieldValues;
-import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketResponseDto;
-import java.util.List;
-import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTask.java
@@ -15,7 +15,7 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task;
 
-import static java.util.Objects.isNull;
+import java.util.List;
 
 import com.redhat.parodos.examples.ocponboarding.task.dto.email.MessageRequestDTO;
 import com.redhat.parodos.examples.utils.RestUtils;
@@ -26,10 +26,12 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+
+import static java.util.Objects.isNull;
 
 /**
  * An example of a task that send a Jira ticket email notification

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTask.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.List;
+
 import com.redhat.parodos.examples.ocponboarding.task.dto.notification.NotificationRequest;
 import com.redhat.parodos.examples.utils.RestUtils;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
@@ -23,8 +25,8 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/OcpAppDeploymentWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/OcpAppDeploymentWorkFlowTask.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.Collections;
+
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
@@ -37,7 +39,6 @@ import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.RoutePortBuilder;
 import io.fabric8.openshift.api.model.RouteTargetReferenceBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
-import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/assessment/OnboardingOcpAssessmentTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/assessment/OnboardingOcpAssessmentTask.java
@@ -15,20 +15,21 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task.assessment;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.option.WorkFlowOptions;
-import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.Collections;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/CreateJiraTicketResponseDto.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/CreateJiraTicketResponseDto.java
@@ -15,12 +15,13 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task.dto.jira;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.util.Map;
 
 @Data
 @Builder

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/GetJiraTicketResponseDto.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/GetJiraTicketResponseDto.java
@@ -15,14 +15,14 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task.dto.jira;
 
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
 
 @Data
 @AllArgsConstructor

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/RequestFieldValues.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/jira/RequestFieldValues.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.examples.ocponboarding.task.dto.jira;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.List;
 
 @Builder
 @Data

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/notification/NotificationRequest.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/task/dto/notification/NotificationRequest.java
@@ -1,12 +1,12 @@
 package com.redhat.parodos.examples.ocponboarding.task.dto.notification;
 
+import java.io.Serializable;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-import java.util.List;
 
 /**
  * request DTO of notification service

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/prebuilt/PrebuiltWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/prebuilt/PrebuiltWorkFlowConfiguration.java
@@ -6,6 +6,7 @@ import com.redhat.parodos.workflow.consts.WorkFlowConstants;
 import com.redhat.parodos.workflow.utils.CredUtils;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SimpleWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SimpleWorkFlowConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.examples.simple;
 
+import java.util.concurrent.Executors;
+
 import com.redhat.parodos.examples.simple.task.LoggingWorkFlowTask;
 import com.redhat.parodos.examples.simple.task.RestAPIWorkFlowTask;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
@@ -23,10 +25,8 @@ import com.redhat.parodos.workflow.consts.WorkFlowConstants;
 import com.redhat.parodos.workflows.workflow.ParallelFlow;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-
-import java.util.concurrent.Executors;
-
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTask.java
@@ -18,18 +18,17 @@ package com.redhat.parodos.examples.simple.task;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.stereotype.Component;
-
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
 
 /**
  * logging task execution

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTask.java
@@ -15,19 +15,20 @@
  */
 package com.redhat.parodos.examples.simple.task;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import java.util.List;
+
 import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 
-import java.util.List;
+import org.springframework.http.ResponseEntity;
 
 /**
  * rest api task execution

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTask.java
@@ -18,20 +18,21 @@ package com.redhat.parodos.examples.simple.task;
 import java.util.List;
 
 import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.utils.CredUtils;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflow.utils.CredUtils;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
 /**
  * An example of a task that calls a Rest Endpoint with a BasicAuth Header

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/tibco/TibcoWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/tibco/TibcoWorkFlowConfiguration.java
@@ -1,14 +1,15 @@
 // @formatter:off
 package com.redhat.parodos.examples.tibco;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import com.redhat.parodos.tasks.tibco.TibcoWorkFlowTask;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
  * 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
@@ -1,12 +1,13 @@
 package com.redhat.parodos.examples.utils;
 
+import java.net.URI;
+import java.util.Base64;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
-import java.net.URI;
-import java.util.Base64;
 
 /**
  * RestUtils is a utility class. All its methods must be declared as static so they can't

--- a/workflow-examples/src/main/java/org/parodos/workflow/examples/custom/CustomWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/org/parodos/workflow/examples/custom/CustomWorkFlowConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.parodos.workflow.examples.custom;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.annotation.Checker;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflow.annotation.Parameter;
@@ -24,11 +26,10 @@ import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import org.parodos.workflow.examples.custom.task.CustomWorkFlowTask;
 import org.parodos.workflow.examples.custom.task.SimpleWorkFlowCheckerTask;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 /**
  * Very simple workflow configurations in different package from Parodos main class

--- a/workflow-examples/src/main/java/org/parodos/workflow/examples/custom/task/CustomWorkFlowTask.java
+++ b/workflow-examples/src/main/java/org/parodos/workflow/examples/custom/task/CustomWorkFlowTask.java
@@ -20,6 +20,7 @@ import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
+
 import org.springframework.stereotype.Component;
 
 /**

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseAssessmentTaskTest.java
@@ -1,10 +1,11 @@
 package com.redhat.parodos.examples.base;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskType;
 import org.junit.Before;
-import java.util.List;
 
 public abstract class BaseAssessmentTaskTest {
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
@@ -2,10 +2,11 @@ package com.redhat.parodos.examples.base;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Before;
-import org.mockito.Mockito;
+
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+import org.junit.Before;
+import org.mockito.Mockito;
 
 public abstract class BaseInfrastructureWorkFlowTaskTest {
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseWorkFlowCheckerTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseWorkFlowCheckerTaskTest.java
@@ -1,11 +1,11 @@
 package com.redhat.parodos.examples.base;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskType;
 import org.junit.Before;
-
-import java.util.List;
 
 public abstract class BaseWorkFlowCheckerTaskTest {
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTaskTest.java
@@ -1,17 +1,17 @@
 package com.redhat.parodos.examples.complex.checker;
 
+import java.util.List;
+
 import com.redhat.parodos.examples.base.BaseWorkFlowCheckerTaskTest;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/parameter/ComplexWorkParameterValueProviderTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/parameter/ComplexWorkParameterValueProviderTest.java
@@ -1,9 +1,9 @@
 package com.redhat.parodos.examples.complex.parameter;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.parameter.WorkParameterValueRequest;
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTaskTest.java
@@ -1,19 +1,19 @@
 package com.redhat.parodos.examples.complex.task;
 
+import java.util.List;
+
 import com.redhat.parodos.examples.base.BaseAssessmentTaskTest;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
-import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/kubeapi/KubeapiWorkFlow.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/kubeapi/KubeapiWorkFlow.java
@@ -1,5 +1,10 @@
 package com.redhat.parodos.examples.kubeapi;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
 import com.redhat.parodos.sdk.invoker.ApiClient;
@@ -12,12 +17,8 @@ import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkRequestDTO;
 import com.redhat.parodos.workflow.utils.CredUtils;
 import org.junit.Test;
-import org.springframework.http.HttpHeaders;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
+import org.springframework.http.HttpHeaders;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static org.junit.Assert.assertEquals;

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTaskTest.java
@@ -1,27 +1,29 @@
 package com.redhat.parodos.examples.ocponboarding.escalation;
 
+import java.util.List;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
-import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.ResponseEntity;
 
 /**
  * Jira Ticket Email Notification Workflow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTaskTest.java
@@ -1,27 +1,29 @@
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.List;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
-import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.ResponseEntity;
 
 /**
  * App Link Email Notification Workflow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
@@ -4,11 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.spy;
-
 import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
 import com.redhat.parodos.examples.ocponboarding.task.dto.jira.CreateJiraTicketResponseDto;
 import com.redhat.parodos.examples.utils.RestUtils;
@@ -23,8 +18,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.spy;
 
 /**
  * Jira Ticket Creation Workflow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTaskTest.java
@@ -1,27 +1,29 @@
 package com.redhat.parodos.examples.ocponboarding.task;
 
+import java.util.List;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
-import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.ResponseEntity;
 
 /**
  * Jira Ticket Email Notification Workflow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTaskTest.java
@@ -1,11 +1,6 @@
 package com.redhat.parodos.examples.ocponboarding.task;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+import java.util.List;
 
 import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
 import com.redhat.parodos.examples.ocponboarding.task.dto.notification.NotificationRequest;
@@ -16,14 +11,21 @@ import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlo
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 /**
  * Notification Workflow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTaskTest.java
@@ -1,19 +1,19 @@
 package com.redhat.parodos.examples.simple.task;
 
+import java.util.HashMap;
+import java.util.List;
+
 import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
@@ -1,29 +1,29 @@
 package com.redhat.parodos.examples.simple.task;
 
+import java.util.List;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.http.ResponseEntity;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.http.ResponseEntity;
-
-import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
-import com.redhat.parodos.examples.utils.RestUtils;
-import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflow.parameter.WorkParameterType;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
 
 /**
  * Rest API WorkFlow Task execution test

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTaskTest.java
@@ -1,12 +1,14 @@
 package com.redhat.parodos.examples.simple.task;
 
+import java.util.List;
+
 import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
 import com.redhat.parodos.examples.utils.RestUtils;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.utils.CredUtils;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -15,10 +17,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.util.List;
+
 import static com.redhat.parodos.examples.simple.task.SecureAPIGetTestTask.PASSWORD;
 import static com.redhat.parodos.examples.simple.task.SecureAPIGetTestTask.SECURED_URL;
 import static com.redhat.parodos.examples.simple.task.SecureAPIGetTestTask.USERNAME;

--- a/workflow-examples/src/test/java/com/redhat/parodos/notification/integration/NotificationRecord.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/notification/integration/NotificationRecord.java
@@ -1,5 +1,9 @@
 package com.redhat.parodos.notification.integration;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
 import com.redhat.parodos.notification.sdk.api.*;
 import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.notification.sdk.model.NotificationRecordResponseDTO;
@@ -9,11 +13,8 @@ import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpHeaders;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
+import org.springframework.http.HttpHeaders;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/LoginApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/LoginApi.java
@@ -12,25 +12,17 @@
 
 package com.redhat.parodos.sdk.api;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.sdk.invoker.ApiCallback;
 import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ProgressRequestBody;
-import com.redhat.parodos.sdk.invoker.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 public class LoginApi {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/ProjectApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/ProjectApi.java
@@ -12,29 +12,22 @@
 
 package com.redhat.parodos.sdk.api;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.gson.reflect.TypeToken;
 import com.redhat.parodos.sdk.invoker.ApiCallback;
 import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ProgressRequestBody;
-import com.redhat.parodos.sdk.invoker.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
 import com.redhat.parodos.sdk.model.ProjectRequestDTO;
 import com.redhat.parodos.sdk.model.ProjectResponseDTO;
-import java.util.UUID;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 public class ProjectApi {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowApi.java
@@ -12,33 +12,26 @@
 
 package com.redhat.parodos.sdk.api;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.gson.reflect.TypeToken;
 import com.redhat.parodos.sdk.invoker.ApiCallback;
 import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ProgressRequestBody;
-import com.redhat.parodos.sdk.invoker.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
 import com.redhat.parodos.sdk.model.GetStatusByProjectId200Response;
-import java.util.UUID;
 import com.redhat.parodos.sdk.model.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowContextResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 public class WorkflowApi {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowDefinitionApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowDefinitionApi.java
@@ -12,30 +12,23 @@
 
 package com.redhat.parodos.sdk.api;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.gson.reflect.TypeToken;
 import com.redhat.parodos.sdk.invoker.ApiCallback;
 import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ProgressRequestBody;
-import com.redhat.parodos.sdk.invoker.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
-import java.util.UUID;
 import com.redhat.parodos.sdk.model.UpdateParameter200Response;
 import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.sdk.model.WorkParameterValueRequestDTO;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 public class WorkflowDefinitionApi {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiCallback.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiCallback.java
@@ -12,10 +12,8 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import java.io.IOException;
-
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Callback for asynchronous API call.

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiClient.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiClient.java
@@ -12,16 +12,6 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import okhttp3.*;
-import okhttp3.internal.http.HttpMethod;
-import okhttp3.internal.tls.OkHostnameVerifier;
-import okhttp3.logging.HttpLoggingInterceptor;
-import okhttp3.logging.HttpLoggingInterceptor.Level;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.Okio;
-
-import javax.net.ssl.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,19 +30,25 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.*;
+
+import com.redhat.parodos.sdk.invoker.auth.ApiKeyAuth;
 import com.redhat.parodos.sdk.invoker.auth.Authentication;
 import com.redhat.parodos.sdk.invoker.auth.HttpBasicAuth;
-import com.redhat.parodos.sdk.invoker.auth.HttpBearerAuth;
-import com.redhat.parodos.sdk.invoker.auth.ApiKeyAuth;
+import okhttp3.*;
+import okhttp3.internal.http.HttpMethod;
+import okhttp3.internal.tls.OkHostnameVerifier;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.Okio;
 
 /**
  * <p>

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiException.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ApiException.java
@@ -12,10 +12,8 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import java.util.Map;
 import java.util.List;
-
-import javax.ws.rs.core.GenericType;
+import java.util.Map;
 
 /**
  * <p>

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/GzipRequestInterceptor.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/GzipRequestInterceptor.java
@@ -12,13 +12,13 @@
 
 package com.redhat.parodos.sdk.invoker;
 
+import java.io.IOException;
+
 import okhttp3.*;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-
-import java.io.IOException;
 
 /**
  * Encodes request bodies using gzip.

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/JSON.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/JSON.java
@@ -12,32 +12,25 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.internal.bind.util.ISO8601Utils;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.google.gson.JsonElement;
-import io.gsonfire.GsonFireBuilder;
-import io.gsonfire.TypeSelector;
-
-import okio.ByteString;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Map;
-import java.util.HashMap;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.util.ISO8601Utils;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import io.gsonfire.GsonFireBuilder;
+import okio.ByteString;
 
 /*
  * A JSON utility class

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ProgressRequestBody.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ProgressRequestBody.java
@@ -12,11 +12,10 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-
 import java.io.IOException;
 
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.ForwardingSink;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ProgressResponseBody.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/ProgressResponseBody.java
@@ -12,11 +12,10 @@
 
 package com.redhat.parodos.sdk.invoker;
 
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
-
 import java.io.IOException;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ForwardingSource;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/ApiKeyAuth.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/ApiKeyAuth.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.sdk.invoker.auth;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.Pair;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiKeyAuth implements Authentication {

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/Authentication.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/Authentication.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.sdk.invoker.auth;
 
-import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ApiException;
-
 import java.net.URI;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+
+import com.redhat.parodos.sdk.invoker.ApiException;
+import com.redhat.parodos.sdk.invoker.Pair;
 
 public interface Authentication {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/HttpBasicAuth.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/HttpBasicAuth.java
@@ -12,16 +12,13 @@
 
 package com.redhat.parodos.sdk.invoker.auth;
 
-import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.invoker.ApiException;
-
-import okhttp3.Credentials;
-
 import java.net.URI;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
-import java.io.UnsupportedEncodingException;
+import com.redhat.parodos.sdk.invoker.ApiException;
+import com.redhat.parodos.sdk.invoker.Pair;
+import okhttp3.Credentials;
 
 public class HttpBasicAuth implements Authentication {
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/HttpBearerAuth.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/auth/HttpBearerAuth.java
@@ -12,12 +12,12 @@
 
 package com.redhat.parodos.sdk.invoker.auth;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.Pair;
-
-import java.net.URI;
-import java.util.Map;
-import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class HttpBearerAuth implements Authentication {

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/AbstractOpenApiSchema.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/AbstractOpenApiSchema.java
@@ -12,10 +12,9 @@
 
 package com.redhat.parodos.sdk.model;
 
-import com.redhat.parodos.sdk.invoker.ApiException;
-import java.util.Objects;
-import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
+
 import javax.ws.rs.core.GenericType;
 
 //import com.fasterxml.jackson.annotation.JsonValue;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ArgumentRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ArgumentRequestDTO.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/GetStatusByProjectId200Response.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/GetStatusByProjectId200Response.java
@@ -12,38 +12,25 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkStatusResponseDTO;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ProjectRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ProjectRequestDTO.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ProjectResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/ProjectResponseDTO.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/UpdateParameter200Response.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/UpdateParameter200Response.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
@@ -12,39 +12,28 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowCheckerTaskRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowCheckerTaskRequestDTO.java
@@ -12,34 +12,22 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowContextResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowContextResponseDTO.java
@@ -12,36 +12,22 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkFlowOptionsResponseDTO;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
@@ -12,42 +12,29 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkDefinitionResponseDTO;
-import com.redhat.parodos.sdk.model.WorkFlowPropertiesDefinitionDTO;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOption.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOption.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOptions.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOptions.java
@@ -12,37 +12,24 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkFlowOption;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOptionsResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowOptionsResponseDTO.java
@@ -12,37 +12,24 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkFlowOption;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowPropertiesDefinitionDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowPropertiesDefinitionDTO.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowRequestDTO.java
@@ -12,39 +12,25 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
-import com.redhat.parodos.sdk.model.WorkRequestDTO;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowResponseDTO.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkFlowOptions;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowStatusResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowStatusResponseDTO.java
@@ -12,38 +12,25 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.WorkStatusResponseDTO;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueRequestDTO.java
@@ -12,34 +12,21 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueResponseDTO.java
@@ -12,36 +12,23 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkRequestDTO.java
@@ -12,37 +12,24 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
@@ -12,34 +12,22 @@
 
 package com.redhat.parodos.sdk.model;
 
-import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.redhat.parodos.sdk.invoker.JSON;
 
 /**

--- a/workflow-service-sdk/src/test/java/com/redhat/parodos/sdk/api/WorkflowApiTest.java
+++ b/workflow-service-sdk/src/test/java/com/redhat/parodos/sdk/api/WorkflowApiTest.java
@@ -12,17 +12,17 @@
 
 package com.redhat.parodos.sdk.api;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.model.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowContextResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
-import org.junit.Test;
 import org.junit.Ignore;
-
-import java.util.List;
-import java.util.UUID;
+import org.junit.Test;
 
 /**
  * API tests for WorkflowApi

--- a/workflow-service/src/main/java/com/redhat/parodos/common/AbstractEntity.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/AbstractEntity.java
@@ -15,13 +15,14 @@
  */
 package com.redhat.parodos.common;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.UUID;
+
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.Version;
-import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * Base class for persisting and Entity

--- a/workflow-service/src/main/java/com/redhat/parodos/config/MetricsConfig.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/config/MetricsConfig.java
@@ -2,6 +2,7 @@ package com.redhat.parodos.config;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/config/ModelMapperConfig.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/config/ModelMapperConfig.java
@@ -15,15 +15,16 @@
  */
 package com.redhat.parodos.config;
 
-import org.modelmapper.ModelMapper;
-import org.modelmapper.PropertyMap;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.entity.Project;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.converter.WorkFlowTaskDefinitionDTOConverter;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Model mapper configuration

--- a/workflow-service/src/main/java/com/redhat/parodos/config/SwaggerConfig.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/config/SwaggerConfig.java
@@ -17,6 +17,7 @@ package com.redhat.parodos.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/config/properties/LdapConnectionProperties.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/config/properties/LdapConnectionProperties.java
@@ -1,9 +1,9 @@
 package com.redhat.parodos.config.properties;
 
+import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-
-import lombok.Data;
 
 @ConfigurationProperties(prefix = "spring.ldap.connection")
 @ConfigurationPropertiesScan

--- a/workflow-service/src/main/java/com/redhat/parodos/config/properties/SecurityProperties.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/config/properties/SecurityProperties.java
@@ -1,8 +1,9 @@
 package com.redhat.parodos.config.properties;
 
+import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import lombok.Data;
 
 @ConfigurationProperties(prefix = "spring.security")
 @ConfigurationPropertiesScan

--- a/workflow-service/src/main/java/com/redhat/parodos/project/controller/ProjectController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/controller/ProjectController.java
@@ -15,10 +15,11 @@
  */
 package com.redhat.parodos.project.controller;
 
-import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
+
+import javax.validation.Valid;
 
 import com.redhat.parodos.project.dto.ProjectRequestDTO;
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
@@ -30,6 +31,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/workflow-service/src/main/java/com/redhat/parodos/project/entity/Project.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/entity/Project.java
@@ -15,11 +15,12 @@
  */
 package com.redhat.parodos.project.entity;
 
+import java.util.Date;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import java.util.Date;
 
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.user.entity.User;

--- a/workflow-service/src/main/java/com/redhat/parodos/project/repository/ProjectRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/repository/ProjectRepository.java
@@ -15,11 +15,12 @@
  */
 package com.redhat.parodos.project.repository;
 
-import com.redhat.parodos.project.entity.Project;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.redhat.parodos.project.entity.Project;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectService.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.project.service;
 
-import com.redhat.parodos.project.dto.ProjectRequestDTO;
-import com.redhat.parodos.project.dto.ProjectResponseDTO;
-
 import java.util.List;
 import java.util.UUID;
+
+import com.redhat.parodos.project.dto.ProjectRequestDTO;
+import com.redhat.parodos.project.dto.ProjectResponseDTO;
 
 /**
  * Project service

--- a/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
@@ -15,6 +15,13 @@
  */
 package com.redhat.parodos.project.service;
 
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.persistence.EntityExistsException;
+
 import com.redhat.parodos.project.dto.ProjectRequestDTO;
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.entity.Project;
@@ -24,15 +31,10 @@ import com.redhat.parodos.user.service.UserService;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import javax.persistence.EntityExistsException;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * Project service implementation

--- a/workflow-service/src/main/java/com/redhat/parodos/security/LoginController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/security/LoginController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/workflow-service/src/main/java/com/redhat/parodos/security/SecurityConfiguration.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/security/SecurityConfiguration.java
@@ -17,6 +17,7 @@ package com.redhat.parodos.security;
 
 import com.redhat.parodos.config.properties.LdapConnectionProperties;
 import com.redhat.parodos.config.properties.SecurityProperties;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/workflow-service/src/main/java/com/redhat/parodos/security/SecurityUtils.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/security/SecurityUtils.java
@@ -15,13 +15,10 @@
  */
 package com.redhat.parodos.security;
 
-import org.springframework.security.core.Authentication;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.stereotype.Component;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility Method for assessing the Username and Accesstoken fron the authenticated

--- a/workflow-service/src/main/java/com/redhat/parodos/user/entity/User.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/entity/User.java
@@ -15,14 +15,15 @@
  */
 package com.redhat.parodos.user.entity;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 import com.nimbusds.jose.shaded.json.annotate.JsonIgnore;
 import com.redhat.parodos.common.AbstractEntity;

--- a/workflow-service/src/main/java/com/redhat/parodos/user/repository/UserRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/repository/UserRepository.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.redhat.parodos.user.entity.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/user/service/UserService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/service/UserService.java
@@ -15,9 +15,10 @@
  */
 package com.redhat.parodos.user.service;
 
+import java.util.UUID;
+
 import com.redhat.parodos.user.dto.UserResponseDTO;
 import com.redhat.parodos.user.entity.User;
-import java.util.UUID;
 
 /**
  * User service

--- a/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
@@ -15,16 +15,17 @@
  */
 package com.redhat.parodos.user.service;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.user.dto.UserResponseDTO;
 import com.redhat.parodos.user.entity.User;
 import com.redhat.parodos.user.repository.UserRepository;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * User service implementation

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/WorkFlowDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/WorkFlowDelegate.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.workflow;
 
+import java.util.Optional;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
@@ -24,10 +26,9 @@ import com.redhat.parodos.workflow.registry.BeanWorkFlowRegistryImpl;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-
-import java.util.Optional;
 
 /**
  * Provides functionality that is common to any WorkFlow composition in Parodos

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.definition.controller;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueResponseDTO;
@@ -29,6 +32,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,9 +42,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.UUID;
 
 import static java.util.Objects.isNull;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -15,6 +15,11 @@
  */
 package com.redhat.parodos.workflow.definition.dto;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -25,12 +30,6 @@ import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -15,14 +15,13 @@
  */
 package com.redhat.parodos.workflow.definition.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowPropertiesDefinitionDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowPropertiesDefinitionDTO.java
@@ -2,7 +2,6 @@ package com.redhat.parodos.workflow.definition.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowPropertiesDefinition;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkParameterValueResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkParameterValueResponseDTO.java
@@ -1,13 +1,13 @@
 package com.redhat.parodos.workflow.definition.dto;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.redhat.parodos.workflow.parameter.WorkParameterValueResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Data
 @Builder

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
@@ -15,13 +15,14 @@
  */
 package com.redhat.parodos.workflow.definition.dto.converter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
-import java.util.List;
-import java.util.stream.Collectors;
 import com.redhat.parodos.workflow.exceptions.WorkflowDefinitionException;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkParametersConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkParametersConverter.java
@@ -15,12 +15,14 @@
  */
 package com.redhat.parodos.workflow.definition.dto.converter;
 
+import java.util.List;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
-import java.util.List;
 
 /**
  * Workflow parameters converter

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowCheckerMappingDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowCheckerMappingDefinition.java
@@ -15,12 +15,8 @@
  */
 package com.redhat.parodos.workflow.definition.entity;
 
-import com.redhat.parodos.common.AbstractEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -29,8 +25,13 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.redhat.parodos.common.AbstractEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Workflow checker definition entity

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
@@ -15,6 +15,19 @@
  */
 package com.redhat.parodos.workflow.definition.entity;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
@@ -26,18 +39,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
-
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 /**
  * Workflow definition entity

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowTaskDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowTaskDefinition.java
@@ -15,8 +15,8 @@
  */
 package com.redhat.parodos.workflow.definition.entity;
 
-import com.redhat.parodos.common.AbstractEntity;
 import java.util.Date;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -25,6 +25,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 
+import com.redhat.parodos.common.AbstractEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowWorkDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowWorkDefinition.java
@@ -15,13 +15,8 @@
  */
 package com.redhat.parodos.workflow.definition.entity;
 
-import com.redhat.parodos.common.AbstractEntity;
-import com.redhat.parodos.workflow.enums.WorkType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.util.Date;
+import java.util.UUID;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -30,8 +25,14 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import java.util.Date;
-import java.util.UUID;
+
+import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.workflow.enums.WorkType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * workflow work mapping entity

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterService.java
@@ -1,10 +1,9 @@
 package com.redhat.parodos.workflow.definition.parameter;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueResponseDTO;
-
-import java.util.List;
-import java.util.UUID;
 
 public interface WorkParameterService {
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImpl.java
@@ -1,5 +1,10 @@
 package com.redhat.parodos.workflow.definition.parameter;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueResponseDTO;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
@@ -8,12 +13,8 @@ import com.redhat.parodos.workflow.parameter.WorkParameterValueProvider;
 import com.redhat.parodos.workflow.parameter.WorkParameterValueRequest;
 import com.redhat.parodos.workflow.parameter.WorkParameterValueResponse;
 import org.modelmapper.ModelMapper;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import org.springframework.stereotype.Service;
 
 @Service
 public class WorkParameterServiceImpl implements WorkParameterService {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowCheckerMappingDefinitionRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowCheckerMappingDefinitionRepository.java
@@ -15,11 +15,12 @@
  */
 package com.redhat.parodos.workflow.definition.repository;
 
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * workflow checker definition repository

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowDefinitionRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowDefinitionRepository.java
@@ -15,11 +15,12 @@
  */
 package com.redhat.parodos.workflow.definition.repository;
 
-import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import java.util.List;
 import java.util.UUID;
 
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowTaskDefinitionRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowTaskDefinitionRepository.java
@@ -17,9 +17,10 @@ package com.redhat.parodos.workflow.definition.repository;
 
 import java.util.UUID;
 
-import com.redhat.parodos.workflow.enums.WorkFlowType;
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
+import com.redhat.parodos.workflow.enums.WorkFlowType;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * workflow task definition repository

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowWorkRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowWorkRepository.java
@@ -15,11 +15,12 @@
  */
 package com.redhat.parodos.workflow.definition.repository;
 
-import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.UUID;
+
+import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * workflow work mapping repository

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
@@ -15,18 +15,18 @@
  */
 package com.redhat.parodos.workflow.definition.service;
 
-import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
-import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
-import com.redhat.parodos.workflow.enums.WorkFlowType;
-import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
-import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflows.work.Work;
-import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
+import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
+import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
+import com.redhat.parodos.workflow.enums.WorkFlowType;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflows.work.Work;
+import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 
 /**
  * workflow definition service

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -15,6 +15,16 @@
  */
 package com.redhat.parodos.workflow.definition.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
@@ -40,17 +50,8 @@ import com.redhat.parodos.workflows.workflow.WorkFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Service;
 
 /**
  * workflow definition service implementation

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
@@ -1,5 +1,11 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
@@ -13,12 +19,6 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.isMainWorkFlow;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/ContinuedWorkFlowExecutionInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/ContinuedWorkFlowExecutionInterceptor.java
@@ -2,8 +2,6 @@ package com.redhat.parodos.workflow.execution.aspect;
 
 import java.util.Optional;
 
-import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.getMainWorkFlowExecutionId;
-
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.exceptions.WorkflowExecutionNotFoundException;
 import com.redhat.parodos.workflow.execution.continuation.WorkFlowContinuationServiceImpl;
@@ -12,6 +10,8 @@ import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflows.work.WorkContext;
+
+import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.getMainWorkFlowExecutionId;
 
 public class ContinuedWorkFlowExecutionInterceptor extends WorkFlowExecutionInterceptor {
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/MainWorkFlowExecutionInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/MainWorkFlowExecutionInterceptor.java
@@ -1,7 +1,5 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
-import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.getMainWorkFlowExecutionId;
-
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.exceptions.WorkflowExecutionNotFoundException;
 import com.redhat.parodos.workflow.execution.continuation.WorkFlowContinuationServiceImpl;
@@ -10,6 +8,8 @@ import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflows.work.WorkContext;
+
+import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.getMainWorkFlowExecutionId;
 
 public class MainWorkFlowExecutionInterceptor extends WorkFlowExecutionInterceptor {
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
@@ -31,6 +31,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+
 import org.springframework.stereotype.Component;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionFactory.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionFactory.java
@@ -10,6 +10,7 @@ import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflows.work.WorkContext;
+
 import org.springframework.stereotype.Service;
 
 @Service

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.util.Date;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
@@ -14,9 +17,6 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
-
-import java.util.Date;
-import java.util.UUID;
 
 public abstract class WorkFlowExecutionInterceptor implements WorkFlowInterceptor {
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspect.java
@@ -1,5 +1,7 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.io.IOException;
+
 import com.redhat.parodos.workflow.annotation.WorkFlowProperties;
 import com.redhat.parodos.workflow.version.WorkFlowVersionServiceImpl;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
@@ -9,12 +11,11 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.core.env.Environment;
-
-import java.io.IOException;
+import org.springframework.stereotype.Component;
 
 @Aspect
 @Component

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
@@ -43,6 +43,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+
 import org.springframework.stereotype.Component;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/AsyncWorkFlowContinuer.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/AsyncWorkFlowContinuer.java
@@ -3,6 +3,7 @@ package com.redhat.parodos.workflow.execution.continuation;
 import java.util.UUID;
 
 import com.redhat.parodos.workflows.work.WorkContext;
+
 import org.springframework.scheduling.annotation.Async;
 
 public interface AsyncWorkFlowContinuer {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/AsyncWorkFlowContinuerImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/AsyncWorkFlowContinuerImpl.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflows.work.WorkContext;
+
 import org.springframework.stereotype.Service;
 
 @Service

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationService.java
@@ -15,8 +15,9 @@
  */
 package com.redhat.parodos.workflow.execution.continuation;
 
-import com.redhat.parodos.workflows.work.WorkContext;
 import java.util.UUID;
+
+import com.redhat.parodos.workflows.work.WorkContext;
 
 /**
  * When the application starts up it will run any workflows in Progress @see

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImpl.java
@@ -25,6 +25,7 @@ import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflows.work.WorkContext;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
@@ -15,6 +15,16 @@
  */
 package com.redhat.parodos.workflow.execution.controller;
 
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
@@ -31,6 +41,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -42,15 +53,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Workflow controller to execute workflow and get status

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowRequestDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowRequestDTO.java
@@ -15,15 +15,15 @@
  */
 package com.redhat.parodos.workflow.execution.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Workflow request dto

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.workflow.execution.dto;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.redhat.parodos.workflow.enums.ParodosWorkStatus;
@@ -24,8 +26,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 /**
  * Workflow response dto

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
@@ -15,8 +15,11 @@
  */
 package com.redhat.parodos.workflow.execution.entity;
 
-import com.redhat.parodos.common.AbstractEntity;
-import com.redhat.parodos.workflow.enums.WorkFlowStatus;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -25,10 +28,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+
+import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecutionContext.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecutionContext.java
@@ -15,6 +15,12 @@
  */
 package com.redhat.parodos.workflow.execution.entity;
 
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.workflow.execution.entity.converter.WorkContextConverter;
 import com.redhat.parodos.workflows.work.WorkContext;
@@ -23,12 +29,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 
 /**
  * WorkFlow Context Entity

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowTaskExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowTaskExecution.java
@@ -15,12 +15,14 @@
  */
 package com.redhat.parodos.workflow.execution.entity;
 
-import com.redhat.parodos.common.AbstractEntity;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
-import javax.persistence.Column;
-import javax.persistence.Entity;
 import java.util.Date;
 import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkContextConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkContextConverter.java
@@ -15,14 +15,15 @@
  */
 package com.redhat.parodos.workflow.execution.entity.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
-import com.redhat.parodos.workflows.work.WorkContext;
+import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
-import java.util.Map;
-import java.util.Set;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
+import com.redhat.parodos.workflows.work.WorkContext;
 
 /**
  * Converts WorkContext into values that can be persisted into a DB column

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkFlowStatusConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkFlowStatusConverter.java
@@ -15,9 +15,10 @@
  */
 package com.redhat.parodos.workflow.execution.entity.converter;
 
-import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+
+import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 
 /**
  * Converts WorkFlow status into values that can be persisted into a DB column

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkFlowTaskStatusConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/converter/WorkFlowTaskStatusConverter.java
@@ -15,9 +15,10 @@
  */
 package com.redhat.parodos.workflow.execution.entity.converter;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 
 /**
  * Converts WorkFlow task status into values that can be persisted into a DB column

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepository.java
@@ -15,14 +15,15 @@
  */
 package com.redhat.parodos.workflow.execution.repository;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.UUID;
 
 /**
  * workflow execution repository

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowTaskRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowTaskRepository.java
@@ -15,9 +15,11 @@
  */
 package com.redhat.parodos.workflow.execution.repository;
 
-import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import java.util.List;
 import java.util.UUID;
+
+import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ScheduledFuture;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowService.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
@@ -25,9 +28,6 @@ import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 import com.redhat.parodos.workflows.work.WorkReport;
-
-import java.util.List;
-import java.util.UUID;
 
 /**
  * Workflow execution service

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
@@ -15,6 +15,14 @@
  */
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
@@ -29,15 +37,8 @@ import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowTaskRepository;
-import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Service;
 
 /**
  * Workflow execution service delegate

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -15,16 +15,19 @@
  */
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.annotation.PreDestroy;
+
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.service.ProjectService;
 import com.redhat.parodos.security.SecurityUtils;
 import com.redhat.parodos.workflow.WorkFlowDelegate;
-import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
-import com.redhat.parodos.workflow.execution.dto.WorkFlowOptionsResponseDTO;
-import com.redhat.parodos.workflow.option.WorkFlowOption;
-import com.redhat.parodos.workflow.utils.WorkContextUtils;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
@@ -35,6 +38,8 @@ import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionService;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.exceptions.WorkflowPersistenceFailedException;
+import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
+import com.redhat.parodos.workflow.execution.dto.WorkFlowOptionsResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowStatusResponseDTO;
@@ -43,28 +48,25 @@ import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowTaskRepository;
+import com.redhat.parodos.workflow.option.WorkFlowOption;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.engine.WorkFlowEngineBuilder;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import javax.annotation.PreDestroy;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 import static java.util.Objects.isNull;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/validation/PubliclyVisible.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/validation/PubliclyVisible.java
@@ -1,11 +1,12 @@
 package com.redhat.parodos.workflow.execution.validation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
 
 @Target({ ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -15,6 +15,15 @@
  */
 package com.redhat.parodos.workflow.registry;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.annotation.Assessment;
 import com.redhat.parodos.workflow.annotation.Checker;
@@ -29,6 +38,7 @@ import com.redhat.parodos.workflow.task.WorkFlowTask;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -36,14 +46,6 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * An implementation of the WorkflowRegistry that loads all Bean definitions of type

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/WorkFlowRegistryDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/WorkFlowRegistryDelegate.java
@@ -1,13 +1,14 @@
 package com.redhat.parodos.workflow.registry;
 
-import com.redhat.parodos.workflow.parameter.WorkParameter;
-import com.redhat.parodos.workflow.parameter.WorkParameterType;
-import lombok.NonNull;
-import org.springframework.core.annotation.AnnotationAttributes;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import lombok.NonNull;
+
+import org.springframework.core.annotation.AnnotationAttributes;
 
 public class WorkFlowRegistryDelegate {
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/util/WorkFlowDTOUtil.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/util/WorkFlowDTOUtil.java
@@ -15,17 +15,17 @@
  */
 package com.redhat.parodos.workflow.util;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.Optional;
 
 /**
  * DTO util class for request and response objects conversion

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/version/WorkFlowVersionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/version/WorkFlowVersionServiceImpl.java
@@ -15,10 +15,12 @@
  */
 package com.redhat.parodos.workflow.version;
 
-import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.io.InputStream;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
+
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 

--- a/workflow-service/src/test/java/com/redhat/parodos/ControllerMockClient.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/ControllerMockClient.java
@@ -3,6 +3,7 @@ package com.redhat.parodos;
 import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.Getter;
 import lombok.Setter;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 

--- a/workflow-service/src/test/java/com/redhat/parodos/project/controller/ProjectControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/controller/ProjectControllerTest.java
@@ -11,6 +11,7 @@ import com.redhat.parodos.project.service.ProjectServiceImpl;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/workflow-service/src/test/java/com/redhat/parodos/project/repository/ProjectRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/repository/ProjectRepositoryTest.java
@@ -1,15 +1,16 @@
 package com.redhat.parodos.project.repository;
 
+import java.util.List;
+import java.util.UUID;
+
+import javax.persistence.PersistenceException;
+
 import com.redhat.parodos.project.entity.Project;
 import com.redhat.parodos.repository.RepositoryTestBase;
 import com.redhat.parodos.user.entity.User;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import javax.persistence.PersistenceException;
-import java.util.List;
-import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/workflow-service/src/test/java/com/redhat/parodos/project/service/ProjectServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/service/ProjectServiceImplTest.java
@@ -1,5 +1,12 @@
 package com.redhat.parodos.project.service;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.project.dto.ProjectRequestDTO;
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.entity.Project;
@@ -15,16 +22,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/workflow-service/src/test/java/com/redhat/parodos/repository/RepositoryTestBase.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/repository/RepositoryTestBase.java
@@ -2,6 +2,7 @@ package com.redhat.parodos.repository;
 
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/workflow-service/src/test/java/com/redhat/parodos/user/repository/UserRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/repository/UserRepositoryTest.java
@@ -1,17 +1,19 @@
 package com.redhat.parodos.user.repository;
 
-import javax.persistence.PersistenceException;
 import java.util.UUID;
+
+import javax.persistence.PersistenceException;
+
+import com.redhat.parodos.repository.RepositoryTestBase;
+import com.redhat.parodos.user.entity.User;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.redhat.parodos.repository.RepositoryTestBase;
-import com.redhat.parodos.user.entity.User;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 class UserRepositoryTest extends RepositoryTestBase {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
@@ -3,11 +3,6 @@ package com.redhat.parodos.user.service;
 import java.util.Optional;
 import java.util.UUID;
 
-import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.redhat.parodos.user.dto.UserResponseDTO;
 import com.redhat.parodos.user.entity.User;
 import com.redhat.parodos.user.repository.UserRepository;
@@ -15,6 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserServiceImplTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
@@ -15,6 +15,10 @@
  */
 package com.redhat.parodos.workflow;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
@@ -27,11 +31,8 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
@@ -9,7 +9,7 @@ import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +19,12 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @DirtiesContext
@@ -37,7 +43,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 		// given
 		WorkFlowDefinitionResponseDTO WFDefFoo = createSampleWorkFlowDefinition("workflow-foo");
 		WorkFlowDefinitionResponseDTO WFDefBar = createSampleWorkFlowDefinition("workflow-bar");
-		Mockito.when(workFlowDefinitionService.getWorkFlowDefinitions()).thenReturn(List.of(WFDefFoo, WFDefBar));
+		when(workFlowDefinitionService.getWorkFlowDefinitions()).thenReturn(List.of(WFDefFoo, WFDefBar));
 
 		// when
 		this.mockMvc.perform(this.getRequestWithValidCredentials("/api/v1/workflowdefinitions"))
@@ -54,7 +60,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$[1].name", Matchers.is(WFDefBar.getName())));
 
 		// then
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).getWorkFlowDefinitions();
+		verify(this.workFlowDefinitionService, times(1)).getWorkFlowDefinitions();
 	}
 
 	@Test
@@ -63,14 +69,14 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 		this.mockMvc.perform(this.getRequestWithInValidCredentials("/api/v1/workflowdefinitions"))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
 		// then
-		Mockito.verify(this.workFlowDefinitionService, Mockito.never()).getWorkFlowDefinitions();
+		verify(this.workFlowDefinitionService, never()).getWorkFlowDefinitions();
 	}
 
 	@Test
 	public void getWorkFlowDefinitionByIdWithValidData() throws Exception {
 		// given
 		WorkFlowDefinitionResponseDTO WFDef = createSampleWorkFlowDefinition("workflow-foo");
-		Mockito.when(workFlowDefinitionService.getWorkFlowDefinitionById(WFDef.getId())).thenReturn(WFDef);
+		when(workFlowDefinitionService.getWorkFlowDefinitionById(WFDef.getId())).thenReturn(WFDef);
 
 		// when
 		this.mockMvc
@@ -86,13 +92,13 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 						Matchers.is("param1")));
 
 		// then
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).getWorkFlowDefinitionById(WFDef.getId());
+		verify(this.workFlowDefinitionService, times(1)).getWorkFlowDefinitionById(WFDef.getId());
 	}
 
 	@Test
 	public void getWorkFlowDefinitionByIdWithInValidData() throws Exception {
 		// given
-		Mockito.when(workFlowDefinitionService.getWorkFlowDefinitionById(Mockito.any())).thenReturn(null);
+		when(workFlowDefinitionService.getWorkFlowDefinitionById(any())).thenReturn(null);
 
 		// when
 		this.mockMvc
@@ -101,7 +107,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.status().isNotFound());
 
 		// then
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).getWorkFlowDefinitionById(Mockito.any());
+		verify(this.workFlowDefinitionService, times(1)).getWorkFlowDefinitionById(any());
 	}
 
 	@Test
@@ -113,7 +119,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
 		// then
-		Mockito.verify(this.workFlowDefinitionService, Mockito.never()).getWorkFlowDefinitionById(Mockito.any());
+		verify(this.workFlowDefinitionService, never()).getWorkFlowDefinitionById(any());
 	}
 
 	private WorkFlowDefinitionResponseDTO createSampleWorkFlowDefinition(String name) {

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTOTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTOTest.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.workflow.definition.dto;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
@@ -8,9 +11,6 @@ import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.redhat.parodos.workflow.definition.parameter;
 
+import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueResponseDTO;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
@@ -12,14 +15,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.List;
-import java.util.Map;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.definition.service;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
@@ -28,14 +31,12 @@ import com.redhat.parodos.workflow.enums.WorkFlowType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -15,30 +15,38 @@
  */
 package com.redhat.parodos.workflow.definition.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.redhat.parodos.common.AbstractEntity;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
+import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowPropertiesDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowCheckerMappingDefinitionRepository;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowWorkRepository;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
-import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
-import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
-import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
-import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
-import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
-import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.WorkFlowTask;
 import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
-
-import com.redhat.parodos.workflow.task.WorkFlowTask;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.modelmapper.ModelMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,18 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.modelmapper.ModelMapper;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * unit test for WorkFlowDefinitionService

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptorTest.java
@@ -1,8 +1,9 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.util.List;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
-import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
@@ -10,24 +11,18 @@ import com.redhat.parodos.workflow.execution.continuation.WorkFlowContinuationSe
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
-import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.List;
-import java.util.UUID;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionAspectTest.getSampleWorkFlowDefinition;
 import static com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionAspectTest.getSampleWorkFlowExecution;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
@@ -1,9 +1,11 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.WorkFlowDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
-import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowWorkRepository;
@@ -26,11 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionFactoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionFactoryTest.java
@@ -2,12 +2,6 @@ package com.redhat.parodos.workflow.execution.aspect;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.execution.continuation.WorkFlowContinuationServiceImpl;
@@ -19,7 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class WorkFlowExecutionFactoryTest {

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
@@ -2,14 +2,6 @@ package com.redhat.parodos.workflow.execution.aspect;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
@@ -29,7 +21,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 public class WorkFlowExecutionInterceptorTest {

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspectTest.java
@@ -8,9 +8,13 @@ import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
 import org.springframework.core.env.Environment;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class WorkFlowPropertiesAspectTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspectTest.java
@@ -1,34 +1,33 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import java.util.Optional;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
 import com.redhat.parodos.workflow.enums.WorkFlowStatus;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
+import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
+import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
+import com.redhat.parodos.workflow.task.WorkFlowTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
-import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
-import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
-import com.redhat.parodos.workflow.execution.scheduler.WorkFlowSchedulerServiceImpl;
-import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
-import com.redhat.parodos.workflow.task.WorkFlowTask;
-import com.redhat.parodos.workflows.work.DefaultWorkReport;
-import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class WorkFlowTaskExecutionAspectTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
@@ -4,10 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
@@ -23,6 +19,10 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WorkFlowContinuationServiceImplTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
@@ -3,9 +3,6 @@ package com.redhat.parodos.workflow.execution.controller;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.ControllerMockClient;
@@ -25,6 +22,7 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +37,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest
 @DirtiesContext

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/dto/WorkFlowRequestDTOTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/dto/WorkFlowRequestDTOTest.java
@@ -15,11 +15,11 @@
  */
 package com.redhat.parodos.workflow.execution.dto;
 
-import com.redhat.parodos.workflow.enums.WorkType;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
+
+import com.redhat.parodos.workflow.enums.WorkType;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
@@ -3,10 +3,6 @@ package com.redhat.parodos.workflow.execution.repository;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.redhat.parodos.project.entity.Project;
 import com.redhat.parodos.repository.RepositoryTestBase;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
@@ -15,6 +11,10 @@ import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecutionContext;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WorkFlowRepositoryTest extends RepositoryTestBase {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImplTest.java
@@ -3,16 +3,17 @@ package com.redhat.parodos.workflow.execution.scheduler;
 import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class WorkFlowSchedulerServiceImplTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
@@ -1,5 +1,10 @@
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
@@ -21,11 +26,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
@@ -1,5 +1,12 @@
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.service.ProjectService;
 import com.redhat.parodos.workflow.WorkFlowDelegate;
@@ -41,17 +48,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
+
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.server.ResponseStatusException;
-
-import javax.swing.*;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/validation/PubliclyVisibleValidatorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/validation/PubliclyVisibleValidatorTest.java
@@ -2,13 +2,13 @@ package com.redhat.parodos.workflow.execution.validation;
 
 import javax.validation.ConstraintValidatorContext;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class PubliclyVisibleValidatorTest {
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
@@ -1,18 +1,19 @@
 package com.redhat.parodos.workflow.registry;
 
+import java.util.HashMap;
+
+import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
-import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-
-import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/util/WorkFlowDTOUtilTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/util/WorkFlowDTOUtilTest.java
@@ -1,11 +1,11 @@
 package com.redhat.parodos.workflow.util;
 
-import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
**What this PR does / why we need it**:
To reduce merge conflict, enforcing and organzing imports according to project's coding conventions is needed.

Project's coding conventions is spring's one:
https://github.com/spring-projects/spring-framework/wiki/Code-Style

```
The import statements are structured as follow:

import java.*
blank line
import javax.*
import jakarta.*
blank line
import all other imports
blank line
import org.springframework.*
blank line
import static all other imports
```

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [x] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [x] Notification Service

**Checklist**
- [x] Subject and description added to commit and PR.
- [ ] Relevant issues have been referenced.
