### PR TITLE
Use static imports in tests

### DIFF
--- a/notification-service/src/test/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTOTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/dto/NotificationRecordResponseDTOTest.java
@@ -8,16 +8,17 @@ import java.util.UUID;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class NotificationRecordResponseDTOTest {
 
 	@Test
 	void toModel() {
-		NotificationRecord entity = Mockito.mock(NotificationRecord.class);
-		NotificationMessage notificationMessage = Mockito.mock(NotificationMessage.class);
+		NotificationRecord entity = mock(NotificationRecord.class);
+		NotificationMessage notificationMessage = mock(NotificationMessage.class);
 
 		String messageBody = "message-body-test";
 		Instant messageCreation = Instant.now();
@@ -29,17 +30,17 @@ class NotificationRecordResponseDTOTest {
 		List<String> tags = Collections.singletonList("tag-test");
 		UUID uuid = UUID.randomUUID();
 
-		Mockito.when(entity.getNotificationMessage()).thenReturn(notificationMessage);
-		Mockito.when(entity.getFolder()).thenReturn(folderName);
-		Mockito.when(entity.isRead()).thenReturn(isRead);
-		Mockito.when(entity.getTags()).thenReturn(tags);
-		Mockito.when(entity.getId()).thenReturn(uuid);
+		when(entity.getNotificationMessage()).thenReturn(notificationMessage);
+		when(entity.getFolder()).thenReturn(folderName);
+		when(entity.isRead()).thenReturn(isRead);
+		when(entity.getTags()).thenReturn(tags);
+		when(entity.getId()).thenReturn(uuid);
 
-		Mockito.when(notificationMessage.getBody()).thenReturn(messageBody);
-		Mockito.when(notificationMessage.getCreatedOn()).thenReturn(messageCreation);
-		Mockito.when(notificationMessage.getFromuser()).thenReturn(messageSender);
-		Mockito.when(notificationMessage.getSubject()).thenReturn(messageSubject);
-		Mockito.when(notificationMessage.getMessageType()).thenReturn(messageType);
+		when(notificationMessage.getBody()).thenReturn(messageBody);
+		when(notificationMessage.getCreatedOn()).thenReturn(messageCreation);
+		when(notificationMessage.getFromuser()).thenReturn(messageSender);
+		when(notificationMessage.getSubject()).thenReturn(messageSubject);
+		when(notificationMessage.getMessageType()).thenReturn(messageType);
 
 		NotificationRecordResponseDTO result = NotificationRecordResponseDTO.toModel(entity);
 

--- a/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationMessageServiceTest.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationMessageServiceTest.java
@@ -10,48 +10,52 @@ import com.redhat.parodos.notification.jpa.repository.NotificationMessageReposit
 import com.redhat.parodos.notification.service.impl.NotificationMessageServiceImpl;
 import com.redhat.parodos.notification.util.SecurityUtil;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class NotificationMessageServiceTest {
 
 	@Test
 	void createNotificationMessage() {
-		NotificationMessageRepository notificationMessageRepository = Mockito.mock(NotificationMessageRepository.class);
-		NotificationUserService notificationUserService = Mockito.mock(NotificationUserService.class);
-		NotificationRecordService notificationRecordService = Mockito.mock(NotificationRecordService.class);
-		SecurityUtil securityUtil = Mockito.mock(SecurityUtil.class);
+		NotificationMessageRepository notificationMessageRepository = mock(NotificationMessageRepository.class);
+		NotificationUserService notificationUserService = mock(NotificationUserService.class);
+		NotificationRecordService notificationRecordService = mock(NotificationRecordService.class);
+		SecurityUtil securityUtil = mock(SecurityUtil.class);
 
-		NotificationMessageCreateRequestDTO notificationMessageCreateRequestDTO = Mockito
-				.mock(NotificationMessageCreateRequestDTO.class);
-		NotificationMessage savedNotificationMessage = Mockito.mock(NotificationMessage.class);
-		NotificationUser notificationUser = Mockito.mock(NotificationUser.class);
+		NotificationMessageCreateRequestDTO notificationMessageCreateRequestDTO = mock(
+				NotificationMessageCreateRequestDTO.class);
+		NotificationMessage savedNotificationMessage = mock(NotificationMessage.class);
+		NotificationUser notificationUser = mock(NotificationUser.class);
 		List<NotificationUser> usersToNotify = Collections.singletonList(notificationUser);
 		List<String> usernames = Collections.singletonList("test-username");
 
-		Mockito.when(notificationMessageCreateRequestDTO.getMessageType()).thenReturn("test-message-type");
-		Mockito.when(notificationMessageCreateRequestDTO.getBody()).thenReturn("test-body");
-		Mockito.when(notificationMessageCreateRequestDTO.getSubject()).thenReturn("test-subject");
-		Mockito.when(notificationMessageCreateRequestDTO.getUsernames()).thenReturn(usernames);
-		Mockito.when(notificationMessageCreateRequestDTO.getGroupnames())
+		when(notificationMessageCreateRequestDTO.getMessageType()).thenReturn("test-message-type");
+		when(notificationMessageCreateRequestDTO.getBody()).thenReturn("test-body");
+		when(notificationMessageCreateRequestDTO.getSubject()).thenReturn("test-subject");
+		when(notificationMessageCreateRequestDTO.getUsernames()).thenReturn(usernames);
+		when(notificationMessageCreateRequestDTO.getGroupnames())
 				.thenReturn(Collections.singletonList("test-group-name"));
-		Mockito.when(securityUtil.getUsername()).thenReturn("test-from-username");
-		Mockito.when(notificationMessageRepository.save(Mockito.any())).thenReturn(savedNotificationMessage);
-		Mockito.when(notificationUserService.findUsers(usernames)).thenReturn(usersToNotify);
+		when(securityUtil.getUsername()).thenReturn("test-from-username");
+		when(notificationMessageRepository.save(any())).thenReturn(savedNotificationMessage);
+		when(notificationUserService.findUsers(usernames)).thenReturn(usersToNotify);
 
 		NotificationMessageService notificationMessageServiceImpl = new NotificationMessageServiceImpl(
 				notificationMessageRepository, notificationUserService, notificationRecordService, securityUtil);
 		notificationMessageServiceImpl.createNotificationMessage(notificationMessageCreateRequestDTO);
 
-		Mockito.verify(notificationMessageCreateRequestDTO, Mockito.times(1)).getMessageType();
-		Mockito.verify(notificationMessageCreateRequestDTO, Mockito.times(1)).getBody();
-		Mockito.verify(notificationMessageCreateRequestDTO, Mockito.times(1)).getSubject();
-		Mockito.verify(notificationMessageCreateRequestDTO, Mockito.times(2)).getUsernames();
-		Mockito.verify(notificationMessageCreateRequestDTO, Mockito.times(1)).getGroupnames();
-		Mockito.verify(securityUtil, Mockito.times(1)).getUsername();
-		Mockito.verify(notificationMessageRepository, Mockito.times(1)).save(Mockito.any());
-		Mockito.verify(notificationUserService, Mockito.times(1)).findUsers(usernames);
-		Mockito.verify(notificationRecordService, Mockito.times(1)).createNotificationRecords(usersToNotify,
-				savedNotificationMessage);
+		verify(notificationMessageCreateRequestDTO, times(1)).getMessageType();
+		verify(notificationMessageCreateRequestDTO, times(1)).getBody();
+		verify(notificationMessageCreateRequestDTO, times(1)).getSubject();
+		verify(notificationMessageCreateRequestDTO, times(2)).getUsernames();
+		verify(notificationMessageCreateRequestDTO, times(1)).getGroupnames();
+		verify(securityUtil, times(1)).getUsername();
+		verify(notificationMessageRepository, times(1)).save(any());
+		verify(notificationUserService, times(1)).findUsers(usernames);
+		verify(notificationRecordService, times(1)).createNotificationRecords(usersToNotify, savedNotificationMessage);
 	}
 
 }

--- a/pattern-detection-library/src/test/java/com/redhat/parodos/patterndetection/PatternDetectorTest.java
+++ b/pattern-detection-library/src/test/java/com/redhat/parodos/patterndetection/PatternDetectorTest.java
@@ -25,11 +25,11 @@ import com.redhat.parodos.patterndetection.pattern.BasicPatternImpl;
 import com.redhat.parodos.patterndetection.pattern.Pattern;
 import com.redhat.parodos.patterndetection.results.DetectionResults;
 import com.redhat.parodos.workflows.work.WorkContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
@@ -68,7 +68,7 @@ class PatternDetectorTest {
 	@Test
 	void testDetect_failNoConfig_missingConfigurationError() {
 		WorkContext context = new WorkContext();
-		Assertions.assertThrows(PatternDetectionConfigurationException.class, () -> {
+		assertThrows(PatternDetectionConfigurationException.class, () -> {
 			PatternDetector.detect(context, null);
 		});
 	}
@@ -79,7 +79,7 @@ class PatternDetectorTest {
 	 */
 	@Test
 	void testDetect_failNull_missingConfigurationError() {
-		Assertions.assertThrows(PatternDetectionConfigurationException.class, () -> {
+		assertThrows(PatternDetectionConfigurationException.class, () -> {
 			PatternDetector.detect(null, null);
 		});
 	}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/jira/JiraTaskTest.java
@@ -4,20 +4,19 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.SneakyThrows;
-import org.assertj.core.api.Assertions;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,11 +46,11 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getError()).isInstanceOf(Exception.class);
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
-		verify(mockClient, Mockito.times(1)).get(anyString());
-		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).get(anyString());
+		verify(mockClient, times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -62,11 +61,11 @@ public class JiraTaskTest {
 				.thenThrow(new Exception("Missing mandatory params to create a ticket"));
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getError()).isInstanceOf(Exception.class);
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
-		verify(mockClient, Mockito.times(0)).get(anyString());
-		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(1)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).get(anyString());
+		verify(mockClient, times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -81,12 +80,12 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
-		Assertions.assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
+		assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
-		verify(mockClient, Mockito.times(1)).get(anyString());
-		verify(mockClient, Mockito.times(1)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).get(anyString());
+		verify(mockClient, times(1)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -100,11 +99,11 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getError()).isNull();
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
-		verify(mockClient, Mockito.times(1)).get(anyString());
-		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).get(anyString());
+		verify(mockClient, times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -118,11 +117,11 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getError()).isNull();
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
-		verify(mockClient, Mockito.times(0)).get(anyString());
-		verify(mockClient, Mockito.times(0)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(1)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).get(anyString());
+		verify(mockClient, times(0)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -137,12 +136,12 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isInstanceOf(Exception.class);
-		Assertions.assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
+		assertThat(execute.getError()).isInstanceOf(Exception.class);
+		assertThat(execute.getError()).isNotInstanceOf(JSONException.class);
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.FAILED);
-		verify(mockClient, Mockito.times(1)).get(anyString());
-		verify(mockClient, Mockito.times(1)).update(anyString(), anyString(), anyString(), anyString());
-		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).get(anyString());
+		verify(mockClient, times(1)).update(anyString(), anyString(), anyString(), anyString());
+		verify(mockClient, times(0)).create(anyString(), anyString(), anyString());
 	}
 
 	@Test
@@ -158,11 +157,11 @@ public class JiraTaskTest {
 
 		WorkReport execute = underTest.execute(ctx);
 
-		Assertions.assertThat(execute.getError()).isNull();
+		assertThat(execute.getError()).isNull();
 		assertThat(execute.getStatus()).isEqualTo(WorkStatus.COMPLETED);
-		verify(mockClient, Mockito.times(1)).get("123");
-		verify(mockClient, Mockito.times(1)).addComment("123", "new comment");
-		verify(mockClient, Mockito.times(0)).create(anyString(), anyString(), anyString());
+		verify(mockClient, times(1)).get("123");
+		verify(mockClient, times(1)).addComment("123", "new comment");
+		verify(mockClient, times(0)).create(anyString(), anyString(), anyString());
 	}
 
 }

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/kubeapi/KubeapiWorkFlowTaskTest.java
@@ -12,18 +12,18 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.dynamic.Dynamics;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class KubeapiWorkFlowTaskTest {
 
-	private final static KubernetesApi api = Mockito.mock(KubernetesApi.class);
+	private final static KubernetesApi api = mock(KubernetesApi.class);
 
 	private final static KubeapiWorkFlowTask task = new KubeapiWorkFlowTask(api, "Test");
 

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
@@ -15,10 +15,11 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class NotificationWorkFlowTaskTest {
@@ -31,7 +32,7 @@ public class NotificationWorkFlowTaskTest {
 
 	@Before
 	public void setUp() {
-		apiInstanceMock = Mockito.mock(NotificationMessageApi.class);
+		apiInstanceMock = mock(NotificationMessageApi.class);
 		underTest = new NotificationWorkFlowTask("http://localhost:8080", apiInstanceMock);
 		underTest.setBeanName("notificationWorkFlowTask");
 		ctx = new WorkContext();
@@ -48,7 +49,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, Mockito.times(1)).create(dto);
+		verify(apiInstanceMock, times(1)).create(dto);
 	}
 
 	@Test
@@ -65,7 +66,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(ApiException.class, result.getError().getClass());
-		verify(apiInstanceMock, Mockito.times(1)).create(dto);
+		verify(apiInstanceMock, times(1)).create(dto);
 	}
 
 	@Test
@@ -80,7 +81,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, Mockito.times(0)).create(dto);
+		verify(apiInstanceMock, times(0)).create(dto);
 	}
 
 	@Test
@@ -95,7 +96,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, Mockito.times(0)).create(dto);
+		verify(apiInstanceMock, times(0)).create(dto);
 	}
 
 	@Test
@@ -109,7 +110,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, Mockito.times(0)).create(dto);
+		verify(apiInstanceMock, times(0)).create(dto);
 	}
 
 	@Test
@@ -122,7 +123,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, Mockito.times(1)).create(dto);
+		verify(apiInstanceMock, times(1)).create(dto);
 	}
 
 	@Test
@@ -135,7 +136,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, Mockito.times(1)).create(dto);
+		verify(apiInstanceMock, times(1)).create(dto);
 	}
 
 	@Test
@@ -149,7 +150,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, Mockito.times(0)).create(dto);
+		verify(apiInstanceMock, times(0)).create(dto);
 	}
 
 	private NotificationMessageCreateRequestDTO buildNotificationMessageCreateRequestDTO(String type, String body,

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/tibco/TibcoWorkFlowTaskTest.java
@@ -11,11 +11,11 @@ import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -33,7 +33,7 @@ public class TibcoWorkFlowTaskTest {
 
 	private final static String message = "test message";
 
-	private final static Tibjms tibjms = Mockito.mock(Tibjms.class);
+	private final static Tibjms tibjms = mock(Tibjms.class);
 
 	private final static TibcoWorkFlowTask task = new TibcoWorkFlowTask(tibjms, url, caFile, username, passowrd);
 

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImplTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/engine/WorkFlowEngineImplTest.java
@@ -39,7 +39,6 @@ import com.redhat.parodos.workflows.workflow.RepeatFlow;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static com.redhat.parodos.workflows.engine.WorkFlowEngineBuilder.aNewWorkFlowEngine;
 import static com.redhat.parodos.workflows.work.WorkReportPredicate.COMPLETED;
@@ -48,6 +47,8 @@ import static com.redhat.parodos.workflows.workflow.ParallelFlow.Builder.aNewPar
 import static com.redhat.parodos.workflows.workflow.RepeatFlow.Builder.aNewRepeatFlow;
 import static com.redhat.parodos.workflows.workflow.SequentialFlow.Builder.aNewSequentialFlow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class WorkFlowEngineImplTest {
 
@@ -56,14 +57,14 @@ public class WorkFlowEngineImplTest {
 	@Test
 	public void run() {
 		// given
-		WorkFlow workFlow = Mockito.mock(WorkFlow.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkFlow workFlow = mock(WorkFlow.class);
+		WorkContext workContext = mock(WorkContext.class);
 
 		// when
 		workFlowEngine.run(workFlow, workContext);
 
 		// then
-		Mockito.verify(workFlow).execute(workContext);
+		verify(workFlow).execute(workContext);
 	}
 
 	/**

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ConditionalFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ConditionalFlowTest.java
@@ -27,17 +27,21 @@ import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReportPredicate;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class ConditionalFlowTest {
 
 	@Test
 	public void callOnPredicateSuccess() {
 		// given
-		Work toExecute = Mockito.mock(Work.class);
-		Work nextOnPredicateSuccess = Mockito.mock(Work.class);
-		Work nextOnPredicateFailure = Mockito.mock(Work.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		Work toExecute = mock(Work.class);
+		Work nextOnPredicateSuccess = mock(Work.class);
+		Work nextOnPredicateFailure = mock(Work.class);
+		WorkContext workContext = mock(WorkContext.class);
 		WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_TRUE;
 		ConditionalFlow conditionalFlow = ConditionalFlow.Builder.aNewConditionalFlow().named("testFlow")
 				.execute(toExecute).when(predicate).then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure)
@@ -47,18 +51,18 @@ public class ConditionalFlowTest {
 		conditionalFlow.execute(workContext);
 
 		// then
-		Mockito.verify(toExecute, Mockito.times(1)).execute(workContext);
-		Mockito.verify(nextOnPredicateSuccess, Mockito.times(1)).execute(workContext);
-		Mockito.verify(nextOnPredicateFailure, Mockito.never()).execute(workContext);
+		verify(toExecute, times(1)).execute(workContext);
+		verify(nextOnPredicateSuccess, times(1)).execute(workContext);
+		verify(nextOnPredicateFailure, never()).execute(workContext);
 	}
 
 	@Test
 	public void callOnPredicateFailure() {
 		// given
-		Work toExecute = Mockito.mock(Work.class);
-		Work nextOnPredicateSuccess = Mockito.mock(Work.class);
-		Work nextOnPredicateFailure = Mockito.mock(Work.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		Work toExecute = mock(Work.class);
+		Work nextOnPredicateSuccess = mock(Work.class);
+		Work nextOnPredicateFailure = mock(Work.class);
+		WorkContext workContext = mock(WorkContext.class);
 		WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
 		ConditionalFlow conditionalFlow = ConditionalFlow.Builder.aNewConditionalFlow().named("anotherTestFlow")
 				.execute(toExecute).when(predicate).then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure)
@@ -68,9 +72,9 @@ public class ConditionalFlowTest {
 		conditionalFlow.execute(workContext);
 
 		// then
-		Mockito.verify(toExecute, Mockito.times(1)).execute(workContext);
-		Mockito.verify(nextOnPredicateFailure, Mockito.times(1)).execute(workContext);
-		Mockito.verify(nextOnPredicateSuccess, Mockito.never()).execute(workContext);
+		verify(toExecute, times(1)).execute(workContext);
+		verify(nextOnPredicateFailure, times(1)).execute(workContext);
+		verify(nextOnPredicateSuccess, never()).execute(workContext);
 	}
 
 }

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowExecutorTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowExecutorTest.java
@@ -33,9 +33,10 @@ import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class ParallelFlowExecutorTest {
 
@@ -46,7 +47,7 @@ public class ParallelFlowExecutorTest {
 		ExecutorService executorService = Executors.newFixedThreadPool(2);
 		HelloWorldWork work1 = new HelloWorldWork("work1", WorkStatus.COMPLETED);
 		HelloWorldWork work2 = new HelloWorldWork("work2", WorkStatus.FAILED);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 		ParallelFlowExecutor parallelFlowExecutor = new ParallelFlowExecutor(executorService);
 
 		// when
@@ -54,9 +55,9 @@ public class ParallelFlowExecutorTest {
 		executorService.shutdown();
 
 		// then
-		Assertions.assertThat(workReports).hasSize(2);
-		Assertions.assertThat(work1.isExecuted()).isTrue();
-		Assertions.assertThat(work2.isExecuted()).isTrue();
+		assertThat(workReports).hasSize(2);
+		assertThat(work1.isExecuted()).isTrue();
+		assertThat(work2.isExecuted()).isTrue();
 	}
 
 	static class HelloWorldWork implements Work {

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
@@ -26,9 +26,10 @@ package com.redhat.parodos.workflows.workflow;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkStatus;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParallelFlowReportTest {
 
@@ -63,21 +64,21 @@ public class ParallelFlowReportTest {
 
 	@Test
 	public void testGetStatus() {
-		Assertions.assertThat(completedParallelFlowReport.getStatus()).isEqualTo(WorkStatus.COMPLETED);
-		Assertions.assertThat(failedParallelFlowReport.getStatus()).isEqualTo(WorkStatus.FAILED);
-		Assertions.assertThat(progressParallelFlowReport.getStatus()).isEqualTo(WorkStatus.IN_PROGRESS);
+		assertThat(completedParallelFlowReport.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+		assertThat(failedParallelFlowReport.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(progressParallelFlowReport.getStatus()).isEqualTo(WorkStatus.IN_PROGRESS);
 	}
 
 	@Test
 	public void testGetError() {
-		Assertions.assertThat(failedParallelFlowReport.getError()).isEqualTo(exception);
+		assertThat(failedParallelFlowReport.getError()).isEqualTo(exception);
 	}
 
 	@Test
 	public void testGetReports() {
-		Assertions.assertThat(completedParallelFlowReport.getReports()).hasSize(2);
-		Assertions.assertThat(failedParallelFlowReport.getReports()).hasSize(3);
-		Assertions.assertThat(progressParallelFlowReport.getReports()).hasSize(4);
+		assertThat(completedParallelFlowReport.getReports()).hasSize(2);
+		assertThat(failedParallelFlowReport.getReports()).hasSize(3);
+		assertThat(progressParallelFlowReport.getReports()).hasSize(4);
 	}
 
 }

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowTest.java
@@ -28,19 +28,21 @@ import java.util.List;
 
 import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ParallelFlowTest {
 
 	@Test
 	public void testExecute() {
 		// given
-		Work work1 = Mockito.mock(Work.class);
-		Work work2 = Mockito.mock(Work.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		ParallelFlowExecutor parallelFlowExecutor = Mockito.mock(ParallelFlowExecutor.class);
+		Work work1 = mock(Work.class);
+		Work work2 = mock(Work.class);
+		WorkContext workContext = mock(WorkContext.class);
+		ParallelFlowExecutor parallelFlowExecutor = mock(ParallelFlowExecutor.class);
 		List<Work> works = Arrays.asList(work1, work2);
 		ParallelFlow parallelFlow = new ParallelFlow("pf", works, parallelFlowExecutor);
 
@@ -48,8 +50,8 @@ public class ParallelFlowTest {
 		ParallelFlowReport parallelFlowReport = parallelFlow.execute(workContext);
 
 		// then
-		Assertions.assertThat(parallelFlowReport).isNotNull();
-		Mockito.verify(parallelFlowExecutor).executeInParallel(works, workContext);
+		assertThat(parallelFlowReport).isNotNull();
+		verify(parallelFlowExecutor).executeInParallel(works, workContext);
 	}
 
 }

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/RepeatFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/RepeatFlowTest.java
@@ -27,15 +27,18 @@ import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReportPredicate;
 import org.junit.Test;
-import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class RepeatFlowTest {
 
 	@Test
 	public void testRepeatUntil() {
 		// given
-		Work work = Mockito.mock(Work.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		Work work = mock(Work.class);
+		WorkContext workContext = mock(WorkContext.class);
 		WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
 		RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow().repeat(work).until(predicate).build();
 
@@ -43,21 +46,21 @@ public class RepeatFlowTest {
 		repeatFlow.execute(workContext);
 
 		// then
-		Mockito.verify(work, Mockito.times(1)).execute(workContext);
+		verify(work, times(1)).execute(workContext);
 	}
 
 	@Test
 	public void testRepeatTimes() {
 		// given
-		Work work = Mockito.mock(Work.class);
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		Work work = mock(Work.class);
+		WorkContext workContext = mock(WorkContext.class);
 		RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow().repeat(work).times(3).build();
 
 		// when
 		repeatFlow.execute(workContext);
 
 		// then
-		Mockito.verify(work, Mockito.times(3)).execute(workContext);
+		verify(work, times(3)).execute(workContext);
 	}
 
 }

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/SequentialFlowTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/SequentialFlowTest.java
@@ -34,11 +34,15 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 public class SequentialFlowTest {
 
-	private final WorkContext workContext = Mockito.mock(WorkContext.class);
+	private final WorkContext workContext = mock(WorkContext.class);
 
 	private final WorkReport completedWorkReport = new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 
@@ -50,8 +54,7 @@ public class SequentialFlowTest {
 
 	@Before
 	public void initWorks() {
-		works = new Work[] { Mockito.mock(Work.class), Mockito.mock(Work.class), Mockito.mock(Work.class),
-				Mockito.mock(Work.class) };
+		works = new Work[] { mock(Work.class), mock(Work.class), mock(Work.class), mock(Work.class) };
 	}
 
 	@Test
@@ -136,20 +139,20 @@ public class SequentialFlowTest {
 			if (failureWork == i) {
 				report = errReport;
 			}
-			Mockito.when(works[i].execute(workContext)).thenReturn(report);
+			when(works[i].execute(workContext)).thenReturn(report);
 			int count = i + 1;
-			Mockito.when(works[i].getName()).thenReturn("work#" + count);
+			when(works[i].getName()).thenReturn("work#" + count);
 		}
 	}
 
 	private void validateWorks(Work[] works, int failureWork) {
-		InOrder inOrder = Mockito.inOrder(works);
+		InOrder inOrder = inOrder(works);
 		for (int i = 0; i < works.length; i++) {
 			int runCount = 1;
 			if (failureWork >= 0 && failureWork < i) {
 				runCount = 0;
 			}
-			inOrder.verify(works[i], Mockito.times(runCount)).execute(workContext);
+			inOrder.verify(works[i], times(runCount)).execute(workContext);
 		}
 	}
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
@@ -6,7 +6,8 @@ import java.util.List;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import org.junit.Before;
-import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
 
 public abstract class BaseInfrastructureWorkFlowTaskTest {
 
@@ -27,8 +28,8 @@ public abstract class BaseInfrastructureWorkFlowTaskTest {
 	protected abstract BaseInfrastructureWorkFlowTask getConcretePersonImplementation();
 
 	public List<WorkFlow> getWorkFlowCheckers() {
-		WorkFlow testWorkflow1 = Mockito.mock(WorkFlow.class);
-		WorkFlow testWorkflow2 = Mockito.mock(WorkFlow.class);
+		WorkFlow testWorkflow1 = mock(WorkFlow.class);
+		WorkFlow testWorkflow2 = mock(WorkFlow.class);
 		return Arrays.asList(testWorkflow1, testWorkflow2);
 	}
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/checker/NamespaceApprovalWorkFlowCheckerTaskTest.java
@@ -11,11 +11,12 @@ import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Namespace Approval WorkFlow Checker Task execution test
@@ -29,8 +30,8 @@ public class NamespaceApprovalWorkFlowCheckerTaskTest extends BaseWorkFlowChecke
 
 	@Before
 	public void setUp() {
-		namespaceApprovalWorkFlowCheckerTask = Mockito
-				.spy((NamespaceApprovalWorkFlowCheckerTask) getConcretePersonImplementation());
+		namespaceApprovalWorkFlowCheckerTask = spy(
+				(NamespaceApprovalWorkFlowCheckerTask) getConcretePersonImplementation());
 	}
 
 	@Override
@@ -41,7 +42,7 @@ public class NamespaceApprovalWorkFlowCheckerTaskTest extends BaseWorkFlowChecke
 	@Test
 	public void checkWorkFlowStatus() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 
 		// when
 		WorkReport workReport = namespaceApprovalWorkFlowCheckerTask.checkWorkFlowStatus(workContext);

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/complex/task/OnboardingAssessmentTaskTest.java
@@ -13,11 +13,12 @@ import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Onboarding Assessment Task execution test
@@ -38,7 +39,7 @@ public class OnboardingAssessmentTaskTest extends BaseAssessmentTaskTest {
 		workflowOption = new WorkFlowOption.Builder("identifier", "workflowName")
 				.setDescription("a test workflow option").displayName("WorkflowOption_A").addToDetails("Other details")
 				.build();
-		onboardingAssessmentTask = Mockito.spy((OnboardingAssessmentTask) getConcretePersonImplementation());
+		onboardingAssessmentTask = spy((OnboardingAssessmentTask) getConcretePersonImplementation());
 	}
 
 	@Override
@@ -49,7 +50,7 @@ public class OnboardingAssessmentTaskTest extends BaseAssessmentTaskTest {
 	@Test
 	public void execute() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 		WorkReport workReport = onboardingAssessmentTask.execute(workContext);
 
 		// then

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/escalation/JiraTicketApprovalEscalationWorkFlowTaskTest.java
@@ -14,7 +14,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,10 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -49,7 +51,7 @@ public class JiraTicketApprovalEscalationWorkFlowTaskTest extends BaseInfrastruc
 
 		try {
 			doReturn(JIRA_TICKET_URL_TEST).when(this.jiraTicketApprovalEscalationWorkFlowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(ISSUE_LINK_PARAMETER_NAME));
+					.getRequiredParameterValue(any(WorkContext.class), eq(ISSUE_LINK_PARAMETER_NAME));
 		}
 		catch (MissingParameterException e) {
 			throw new RuntimeException(e);
@@ -64,10 +66,9 @@ public class JiraTicketApprovalEscalationWorkFlowTaskTest extends BaseInfrastruc
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.ok("Mail Sent"));
 
 			// when
@@ -81,10 +82,9 @@ public class JiraTicketApprovalEscalationWorkFlowTaskTest extends BaseInfrastruc
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.internalServerError().build());
 
 			// when

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/AppLinkEmailNotificationWorkFlowTaskTest.java
@@ -14,7 +14,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,10 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -48,7 +50,7 @@ public class AppLinkEmailNotificationWorkFlowTaskTest extends BaseInfrastructure
 				(AppLinkEmailNotificationWorkFlowTask) getConcretePersonImplementation());
 		try {
 			doReturn(APP_LINK_TEST).when(this.appLinkEmailNotificationWorkFlowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(APP_LINK_PARAMETER_NAME));
+					.getRequiredParameterValue(any(WorkContext.class), eq(APP_LINK_PARAMETER_NAME));
 		}
 		catch (MissingParameterException e) {
 			throw new RuntimeException(e);
@@ -63,10 +65,9 @@ public class AppLinkEmailNotificationWorkFlowTaskTest extends BaseInfrastructure
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.ok("Mail Sent"));
 
 			// when
@@ -80,10 +81,9 @@ public class AppLinkEmailNotificationWorkFlowTaskTest extends BaseInfrastructure
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.internalServerError().build());
 
 			// when

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketCreationWorkFlowTaskTest.java
@@ -17,7 +17,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +24,8 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -72,17 +73,16 @@ public class JiraTicketCreationWorkFlowTaskTest extends BaseInfrastructureWorkFl
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(
 					() -> RestUtils.executePost(any(String.class), any(), any(String.class), any(String.class), any()))
 					.thenReturn(new ResponseEntity<>(CreateJiraTicketResponseDto.builder().issueId(ISSUE_ID_TEST)
 							.issueKey(ISSUE_KEY_TEST).links(Map.of(WEB_LINK_KEY, WEB_LINK_VALUE)).build(),
 							HttpStatus.OK));
 
-			try (MockedStatic<WorkContextUtils> workContextUtilsMockedStatic = Mockito
-					.mockStatic(WorkContextUtils.class)) {
+			try (MockedStatic<WorkContextUtils> workContextUtilsMockedStatic = mockStatic(WorkContextUtils.class)) {
 				workContextUtilsMockedStatic
 						.when(() -> WorkContextUtils.getAllParameters(any(WorkContext.class), any(String.class)))
 						.thenReturn(Map.of(NAMESPACE_PARAMETER_KEY, NAMESPACE_PARAMETER_VALUE));
@@ -100,9 +100,9 @@ public class JiraTicketCreationWorkFlowTaskTest extends BaseInfrastructureWorkFl
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(
 					() -> RestUtils.executePost(any(String.class), any(), any(String.class), any(String.class), any()))
 					.thenReturn(new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR));

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/JiraTicketEmailNotificationWorkFlowTaskTest.java
@@ -14,7 +14,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,10 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -49,7 +51,7 @@ public class JiraTicketEmailNotificationWorkFlowTaskTest extends BaseInfrastruct
 
 		try {
 			doReturn(JIRA_TICKET_URL_TEST).when(this.jiraTicketEmailNotificationWorkFlowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(ISSUE_LINK_PARAMETER_NAME));
+					.getRequiredParameterValue(any(WorkContext.class), eq(ISSUE_LINK_PARAMETER_NAME));
 		}
 		catch (MissingParameterException e) {
 			throw new RuntimeException(e);
@@ -64,10 +66,9 @@ public class JiraTicketEmailNotificationWorkFlowTaskTest extends BaseInfrastruct
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.ok("Mail Sent"));
 
 			// when
@@ -81,10 +82,9 @@ public class JiraTicketEmailNotificationWorkFlowTaskTest extends BaseInfrastruct
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
-			restUtilsMockedStatic
-					.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), Mockito.any(HttpEntity.class)))
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
+			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(MAIL_SERVICE_URL_TEST), any(HttpEntity.class)))
 					.thenReturn(ResponseEntity.internalServerError().build());
 
 			// when

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/ocponboarding/task/NotificationWorkFlowTaskTest.java
@@ -14,7 +14,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -25,6 +24,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -51,11 +52,11 @@ public class NotificationWorkFlowTaskTest extends BaseInfrastructureWorkFlowTask
 		this.notificationWorkFlowTask = spy((NotificationWorkFlowTask) getConcretePersonImplementation());
 		try {
 			doReturn(JIRA_TICKET_URL_WORKFLOW_TASK_PARAMETER_VALUE_TEST).when(this.notificationWorkFlowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class),
+					.getRequiredParameterValue(any(WorkContext.class),
 							eq(JIRA_TICKET_URL_WORKFLOW_TASK_PARAMETER_NAME_TEST));
 
 			doReturn(OCP_APP_LINK_WORKFLOW_TASK_PARAMETER_VALUE_TEST).when(this.notificationWorkFlowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class),
+					.getRequiredParameterValue(any(WorkContext.class),
 							eq(OCP_APP_LINK_WORKFLOW_TASK_PARAMETER_NAME_TEST));
 		}
 		catch (MissingParameterException e) {
@@ -70,8 +71,8 @@ public class NotificationWorkFlowTaskTest extends BaseInfrastructureWorkFlowTask
 
 	@Test
 	public void executeSuccess() {
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(() -> RestUtils.getRequestWithHeaders(any(NotificationRequest.class),
 					any(String.class), any(String.class)))
 					.thenReturn(new HttpEntity<>(NotificationRequest.builder().build()));
@@ -89,8 +90,8 @@ public class NotificationWorkFlowTaskTest extends BaseInfrastructureWorkFlowTask
 
 	@Test
 	public void executeFail() {
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(() -> RestUtils.getRequestWithHeaders(any(NotificationRequest.class),
 					any(String.class), any(String.class)))
 					.thenReturn(new HttpEntity<>(NotificationRequest.builder().build()));

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
@@ -15,14 +15,16 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -47,10 +49,10 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 		this.restAPIWorkflowTask = spy((RestAPIWorkFlowTask) getConcretePersonImplementation());
 
 		try {
-			doReturn(valueUrl).when(this.restAPIWorkflowTask).getRequiredParameterValue(Mockito.any(WorkContext.class),
+			doReturn(valueUrl).when(this.restAPIWorkflowTask).getRequiredParameterValue(any(WorkContext.class),
 					eq(URL_KEY));
-			doReturn(valuePayload).when(this.restAPIWorkflowTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(PAYLOAD_KEY));
+			doReturn(valuePayload).when(this.restAPIWorkflowTask).getRequiredParameterValue(any(WorkContext.class),
+					eq(PAYLOAD_KEY));
 
 		}
 		catch (MissingParameterException e) {
@@ -66,8 +68,8 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(() -> RestUtils.executeGet(eq(valueUrl)))
 					.thenReturn(ResponseEntity.ok().build());
 			// when
@@ -81,9 +83,9 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(() -> RestUtils.executePost(eq(valueUrl), eq(valuePayload)))
 					.thenReturn(ResponseEntity.badRequest().build());
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/SecureAPIGetTestTaskTest.java
@@ -16,7 +16,6 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -29,8 +28,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Secure API Get Test Task execution test
@@ -54,12 +57,12 @@ public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest
 	public void setUp() {
 		this.secureAPIGetTestTask = spy((SecureAPIGetTestTask) getConcretePersonImplementation());
 		try {
-			doReturn(testUrl).when(this.secureAPIGetTestTask).getRequiredParameterValue(Mockito.any(WorkContext.class),
+			doReturn(testUrl).when(this.secureAPIGetTestTask).getRequiredParameterValue(any(WorkContext.class),
 					eq(SECURED_URL));
-			doReturn(testUsername).when(this.secureAPIGetTestTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(USERNAME));
-			doReturn(testPassword).when(this.secureAPIGetTestTask)
-					.getRequiredParameterValue(Mockito.any(WorkContext.class), eq(PASSWORD));
+			doReturn(testUsername).when(this.secureAPIGetTestTask).getRequiredParameterValue(any(WorkContext.class),
+					eq(USERNAME));
+			doReturn(testPassword).when(this.secureAPIGetTestTask).getRequiredParameterValue(any(WorkContext.class),
+					eq(PASSWORD));
 		}
 		catch (MissingParameterException e) {
 			throw new RuntimeException(e);
@@ -74,8 +77,8 @@ public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest
 	@Test
 	public void executeSuccess() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		WorkContext workContext = mock(WorkContext.class);
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 			restUtilsMockedStatic.when(() -> RestUtils.restExchange(eq(testUrl), eq(testUsername), eq(testPassword)))
 					.thenReturn(new ResponseEntity<>("body", HttpStatus.OK));
 
@@ -85,16 +88,16 @@ public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest
 			// then
 			assertNull(secureAPIGetTestTask.getWorkFlowCheckers());
 			assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
-			Mockito.verifyNoInteractions(workContext);
+			verifyNoInteractions(workContext);
 		}
 	}
 
 	@Test
 	public void executeFail() {
 		// given
-		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkContext workContext = mock(WorkContext.class);
 
-		try (MockedStatic<RestUtils> restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class)) {
+		try (MockedStatic<RestUtils> restUtilsMockedStatic = mockStatic(RestUtils.class)) {
 
 			restUtilsMockedStatic.when(() -> RestUtils.restExchange(eq(testUrl), eq(testUsername), eq(testPassword)))
 					.thenReturn(new ResponseEntity<>("body", HttpStatus.BAD_REQUEST));
@@ -104,7 +107,7 @@ public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest
 			// then
 			assertNull(secureAPIGetTestTask.getWorkFlowCheckers());
 			assertEquals(WorkStatus.FAILED, workReport.getStatus());
-			Mockito.verifyNoInteractions(workContext);
+			verifyNoInteractions(workContext);
 		}
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/project/controller/ProjectControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/controller/ProjectControllerTest.java
@@ -10,7 +10,6 @@ import com.redhat.parodos.project.dto.ProjectResponseDTO;
 import com.redhat.parodos.project.service.ProjectServiceImpl;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -21,6 +20,13 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -49,7 +55,7 @@ public class ProjectControllerTest extends ControllerMockClient {
 
 		ProjectResponseDTO response = createSampleProject(PROJECT_NAME_1);
 
-		Mockito.when(projectService.save(Mockito.eq(project1DTO))).thenReturn(response);
+		when(projectService.save(eq(project1DTO))).thenReturn(response);
 
 		// When
 		mockMvc.perform(this.postRequestWithValidCredentials("/api/v1/projects/").content(json)
@@ -59,7 +65,7 @@ public class ProjectControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$.name", Matchers.is(response.getName())));
 
 		// Then
-		Mockito.verify(projectService, Mockito.times(1)).save(Mockito.any());
+		verify(projectService, times(1)).save(any());
 	}
 
 	@Test
@@ -74,14 +80,14 @@ public class ProjectControllerTest extends ControllerMockClient {
 				.contentType(MediaType.APPLICATION_JSON)).andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
 		// Then
-		Mockito.verify(projectService, Mockito.never()).save(Mockito.any());
+		verify(projectService, never()).save(any());
 	}
 
 	@Test
 	public void testListProjects() throws Exception {
 		ProjectResponseDTO project1DTO = createSampleProject(PROJECT_NAME_1);
 		ProjectResponseDTO project2DTO = createSampleProject(PROJECT_NAME_2);
-		Mockito.when(projectService.getProjects()).thenReturn(List.of(project1DTO, project2DTO));
+		when(projectService.getProjects()).thenReturn(List.of(project1DTO, project2DTO));
 
 		// When
 		mockMvc.perform(this.getRequestWithValidCredentials("/api/v1/projects/"))
@@ -94,7 +100,7 @@ public class ProjectControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$[1].name", Matchers.is(project2DTO.getName())));
 
 		// Then
-		Mockito.verify(projectService, Mockito.times(1)).getProjects();
+		verify(projectService, times(1)).getProjects();
 	}
 
 	@Test
@@ -103,13 +109,13 @@ public class ProjectControllerTest extends ControllerMockClient {
 		mockMvc.perform(this.getRequestWithInValidCredentials("/api/v1/projects/"))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
 		// Then
-		Mockito.verify(projectService, Mockito.never()).getProjects();
+		verify(projectService, never()).getProjects();
 	}
 
 	@Test
 	public void testGetProjectByIdWithValidID() throws Exception {
 		ProjectResponseDTO project1DTO = createSampleProject(PROJECT_NAME_1);
-		Mockito.when(projectService.getProjectById(project1DTO.getId())).thenReturn(project1DTO);
+		when(projectService.getProjectById(project1DTO.getId())).thenReturn(project1DTO);
 
 		// When
 		mockMvc.perform(this.getRequestWithValidCredentials(String.format("/api/v1/projects/%s", project1DTO.getId())))
@@ -119,18 +125,18 @@ public class ProjectControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$.name", Matchers.is(project1DTO.getName())));
 
 		// Then
-		Mockito.verify(projectService, Mockito.times(1)).getProjectById(Mockito.any());
+		verify(projectService, times(1)).getProjectById(any());
 	}
 
 	@Test
 	public void testGetProjectByIdWithInvalidID() throws Exception {
-		Mockito.when(projectService.getProjectById(Mockito.any())).thenReturn(null);
+		when(projectService.getProjectById(any())).thenReturn(null);
 
 		// When
 		mockMvc.perform(this.getRequestWithValidCredentials(String.format("/api/v1/projects/%s", UUID.randomUUID())))
 				.andExpect(MockMvcResultMatchers.status().isNotFound());
 		// Then
-		Mockito.verify(projectService, Mockito.times(1)).getProjectById(Mockito.any());
+		verify(projectService, times(1)).getProjectById(any());
 	}
 
 	@Test
@@ -139,7 +145,7 @@ public class ProjectControllerTest extends ControllerMockClient {
 		mockMvc.perform(this.getRequestWithInValidCredentials(String.format("/api/v1/projects/%s", UUID.randomUUID())))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
 		// Then
-		Mockito.verify(projectService, Mockito.never()).getProjectById(Mockito.any());
+		verify(projectService, never()).getProjectById(any());
 
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/project/service/ProjectServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/project/service/ProjectServiceImplTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 
 import org.springframework.security.test.context.support.WithMockUser;
@@ -34,6 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class ProjectServiceImplTest {
@@ -48,9 +51,9 @@ class ProjectServiceImplTest {
 
 	@BeforeEach
 	public void initEach() {
-		this.projectRepository = Mockito.mock(ProjectRepository.class);
-		this.workFlowRepository = Mockito.mock(WorkFlowRepository.class);
-		this.userService = Mockito.mock(UserService.class);
+		this.projectRepository = mock(ProjectRepository.class);
+		this.workFlowRepository = mock(WorkFlowRepository.class);
+		this.userService = mock(UserService.class);
 		this.projectService = new ProjectServiceImpl(this.projectRepository, this.workFlowRepository, userService,
 				new ModelMapper());
 	}
@@ -66,7 +69,7 @@ class ProjectServiceImplTest {
 	public void testFindProjectByIdWithValidData() {
 		// given
 		Project project = getSampleProject("test");
-		Mockito.when(this.projectRepository.findById(project.getId())).thenReturn(Optional.of(project));
+		when(this.projectRepository.findById(project.getId())).thenReturn(Optional.of(project));
 
 		// when
 		ProjectResponseDTO res = this.projectService.getProjectById(project.getId());
@@ -81,7 +84,7 @@ class ProjectServiceImplTest {
 		String username = "test-user";
 		// given
 		Project project = getSampleProject("test");
-		Mockito.when(this.projectRepository.findByIdAndUserUsername(project.getId(), username))
+		when(this.projectRepository.findByIdAndUserUsername(project.getId(), username))
 				.thenReturn(Optional.of(project));
 
 		// when
@@ -96,7 +99,7 @@ class ProjectServiceImplTest {
 	public void testFindProjectByIdWithInvalidData() {
 		// given
 		Project project = getSampleProject("test");
-		Mockito.when(this.projectRepository.findById(project.getId())).thenReturn(Optional.empty());
+		when(this.projectRepository.findById(project.getId())).thenReturn(Optional.empty());
 
 		// when
 		assertThrows(ResponseStatusException.class, () -> this.projectService.getProjectById(project.getId()),
@@ -123,15 +126,15 @@ class ProjectServiceImplTest {
 				.status(WorkFlowStatus.COMPLETED).mainWorkFlowExecution(null).build();
 
 		// given
-		Mockito.when(this.workFlowRepository
+		when(this.workFlowRepository
 				.findFirstByProjectIdAndMainWorkFlowExecutionIsNullOrderByStartDateDesc(eq(projectIdOne)))
-				.thenReturn(null);
+						.thenReturn(null);
 
-		Mockito.when(this.workFlowRepository
+		when(this.workFlowRepository
 				.findFirstByProjectIdAndMainWorkFlowExecutionIsNullOrderByStartDateDesc(eq(projectIdTwo)))
-				.thenReturn(workFlowExecution);
+						.thenReturn(workFlowExecution);
 
-		Mockito.when(this.projectRepository.findAll()).thenReturn(Arrays.asList(projectOne, projectTwo));
+		when(this.projectRepository.findAll()).thenReturn(Arrays.asList(projectOne, projectTwo));
 
 		// when
 		List<ProjectResponseDTO> res = this.projectService.getProjects();
@@ -148,7 +151,7 @@ class ProjectServiceImplTest {
 	@Test
 	public void testGetProjectsWithInvalidData() {
 		// given
-		Mockito.when(this.projectRepository.findAll()).thenReturn(new ArrayList<Project>());
+		when(this.projectRepository.findAll()).thenReturn(new ArrayList<Project>());
 
 		// when
 		List<ProjectResponseDTO> res = this.projectService.getProjects();
@@ -163,8 +166,8 @@ class ProjectServiceImplTest {
 	public void testSaveWithValidData() {
 		// given
 		Project project = getSampleProject("test");
-		Mockito.when(this.projectRepository.save(any(Project.class))).thenReturn(project);
-		Mockito.when(userService.getUserEntityByUsername(nullable(String.class)))
+		when(this.projectRepository.save(any(Project.class))).thenReturn(project);
+		when(userService.getUserEntityByUsername(nullable(String.class)))
 				.thenReturn(User.builder().username("test-user").build());
 		ProjectRequestDTO projectDTO = ProjectRequestDTO.builder().name("dto").description("dto description").build();
 
@@ -173,7 +176,7 @@ class ProjectServiceImplTest {
 
 		// then
 		ArgumentCaptor<Project> argument = ArgumentCaptor.forClass(Project.class);
-		Mockito.verify(this.projectRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.projectRepository, times(1)).save(argument.capture());
 
 		assertEquals(argument.getValue().getDescription(), "dto description");
 		assertEquals(argument.getValue().getName(), "dto");

--- a/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
@@ -8,13 +8,17 @@ import com.redhat.parodos.user.entity.User;
 import com.redhat.parodos.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UserServiceImplTest {
 
@@ -24,7 +28,7 @@ class UserServiceImplTest {
 
 	@BeforeEach
 	public void initEach() {
-		this.userRepository = Mockito.mock(UserRepository.class);
+		this.userRepository = mock(UserRepository.class);
 		this.service = new UserServiceImpl(this.userRepository, new ModelMapper());
 	}
 
@@ -32,7 +36,7 @@ class UserServiceImplTest {
 	void saveTestWithValidData() {
 		// given
 		User user = getSampleUser();
-		Mockito.when(this.userRepository.save(Mockito.any(User.class))).thenReturn(user);
+		when(this.userRepository.save(any(User.class))).thenReturn(user);
 
 		// when
 		UserResponseDTO res = this.service.save(user);
@@ -43,14 +47,14 @@ class UserServiceImplTest {
 		assertEquals(res.getUsername(), user.getUsername());
 		assertEquals(res.getEmail(), user.getEmail());
 
-		Mockito.verify(this.userRepository, Mockito.times(1)).save(Mockito.any());
+		verify(this.userRepository, times(1)).save(any());
 	}
 
 	@Test
 	void GetUserByIdWithValidData() {
 		// given
 		User user = getSampleUser();
-		Mockito.when(this.userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+		when(this.userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
 		// when
 		UserResponseDTO res = this.service.getUserById(user.getId());
@@ -60,14 +64,14 @@ class UserServiceImplTest {
 		assertEquals(res.getId(), user.getId());
 		assertEquals(res.getUsername(), user.getUsername());
 		assertEquals(res.getEmail(), user.getEmail());
-		Mockito.verify(this.userRepository, Mockito.times(1)).findById(Mockito.any());
+		verify(this.userRepository, times(1)).findById(any());
 	}
 
 	@Test
 	void GetUserByIdWithInvalidData() {
 		// given
 		User user = getSampleUser();
-		Mockito.when(this.userRepository.findById(user.getId())).thenReturn(Optional.empty());
+		when(this.userRepository.findById(user.getId())).thenReturn(Optional.empty());
 
 		// when
 		Exception exception = assertThrows(RuntimeException.class, () -> this.service.getUserById(user.getId()));
@@ -75,14 +79,14 @@ class UserServiceImplTest {
 		// then
 		assertNotNull(exception);
 		assertEquals(exception.getMessage(), format("User with id: %s not found", user.getId()));
-		Mockito.verify(this.userRepository, Mockito.times(1)).findById(Mockito.any());
+		verify(this.userRepository, times(1)).findById(any());
 	}
 
 	@Test
 	void GetUserByNameWithValidData() {
 		// given
 		User user = getSampleUser();
-		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.of(user));
+		when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.of(user));
 
 		// when
 		UserResponseDTO res = this.service.getUserByUsername(user.getUsername());
@@ -92,18 +96,18 @@ class UserServiceImplTest {
 		assertEquals(user.getId(), res.getId());
 		assertEquals(user.getUsername(), res.getUsername());
 		assertEquals(user.getEmail(), res.getEmail());
-		Mockito.verify(this.userRepository, Mockito.times(1)).findByUsername(Mockito.any());
+		verify(this.userRepository, times(1)).findByUsername(any());
 	}
 
 	@Test
 	void GetUserByNameWithInvalidData() {
 		// given
 		User user = getSampleUser();
-		Mockito.when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.empty());
+		when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.empty());
 
 		// then
 		assertThrows(RuntimeException.class, () -> this.service.getUserByUsername(user.getUsername()));
-		Mockito.verify(this.userRepository, Mockito.times(1)).findByUsername(Mockito.any());
+		verify(this.userRepository, times(1)).findByUsername(any());
 	}
 
 	private User getSampleUser() {

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/parameter/WorkParameterServiceImplTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -22,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class WorkParameterServiceImplTest {
@@ -68,19 +68,19 @@ class WorkParameterServiceImplTest {
 		List<WorkParameterValueResponse> workParameterValueResponses = getSampleParameterValueResponses();
 		workParameterValueRequestDTOs = getSampleParameterValueRequestDTOs();
 		workParameterValueResponseDTOs = getSampleParameterValueResponseDTOs();
-		Mockito.when(workParameterValueProvider.getValuesForWorkflow(anyString(), eq(workParameterValueRequests)))
+		when(workParameterValueProvider.getValuesForWorkflow(anyString(), eq(workParameterValueRequests)))
 				.thenReturn(workParameterValueResponses);
 	}
 
 	@Test
 	void updateValue_when_dataProviderIsFound_then_returnModifiedOptions() {
-		Mockito.when(workFlowDefinitionService.getWorkParametersByWorkName(TEST_WORK))
+		when(workFlowDefinitionService.getWorkParametersByWorkName(TEST_WORK))
 				.thenReturn(Map.of(TEST_RESPONSE_KEY, "test-value"));
-		Mockito.when(workFlowDefinitionService.getParentWorkFlowByWorkName(TEST_WORK))
+		when(workFlowDefinitionService.getParentWorkFlowByWorkName(TEST_WORK))
 				.thenReturn(WorkFlowDefinition.builder().name(SUB_WORKFLOW_NAME).build());
-		Mockito.when(workFlowDefinitionService.getParentWorkFlowByWorkName(SUB_WORKFLOW_NAME))
+		when(workFlowDefinitionService.getParentWorkFlowByWorkName(SUB_WORKFLOW_NAME))
 				.thenReturn(WorkFlowDefinition.builder().name(WORKFLOW_NAME).build());
-		Mockito.when(workFlowDefinitionService.getParentWorkFlowByWorkName(WORKFLOW_NAME)).thenReturn(null);
+		when(workFlowDefinitionService.getParentWorkFlowByWorkName(WORKFLOW_NAME)).thenReturn(null);
 		assertEquals(workParameterValueResponseDTOs,
 				workFlowParameterService.getValues(WORKFLOW_NAME, DATA_PROVIDER_NAME, workParameterValueRequestDTOs));
 	}
@@ -94,7 +94,7 @@ class WorkParameterServiceImplTest {
 
 	@Test
 	void updateValue_when_workIsNotFound_then_returnEmptyList() {
-		Mockito.when(workFlowDefinitionService.getWorkParametersByWorkName(anyString())).thenReturn(null);
+		when(workFlowDefinitionService.getWorkParametersByWorkName(anyString())).thenReturn(null);
 		assertThat(
 				workFlowParameterService.getValues(WORKFLOW_NAME, INVALID_DATA_PROVIDER, workParameterValueRequestDTOs))
 						.isEmpty();
@@ -102,7 +102,7 @@ class WorkParameterServiceImplTest {
 
 	@Test
 	void updateValue_when_parameterIsNotFound_then_returnEmptyList() {
-		Mockito.when(workFlowDefinitionService.getWorkParametersByWorkName(anyString()))
+		when(workFlowDefinitionService.getWorkParametersByWorkName(anyString()))
 				.thenReturn(Map.of(TEST_INVALID_RESPONSE_KEY, "test-value"));
 		assertThat(
 				workFlowParameterService.getValues(WORKFLOW_NAME, INVALID_DATA_PROVIDER, workParameterValueRequestDTOs))

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -45,7 +45,6 @@ import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 /**
  * unit test for WorkFlowDefinitionService
@@ -88,11 +88,10 @@ class WorkFlowDefinitionServiceImplTest {
 
 	@BeforeEach
 	public void initEach() {
-		this.workFlowDefinitionRepository = Mockito.mock(WorkFlowDefinitionRepository.class);
-		this.workFlowTaskDefinitionRepository = Mockito.mock(WorkFlowTaskDefinitionRepository.class);
-		this.workFlowWorkRepository = Mockito.mock(WorkFlowWorkRepository.class);
-		this.workFlowCheckerMappingDefinitionRepository = Mockito
-				.mock(WorkFlowCheckerMappingDefinitionRepository.class);
+		this.workFlowDefinitionRepository = mock(WorkFlowDefinitionRepository.class);
+		this.workFlowTaskDefinitionRepository = mock(WorkFlowTaskDefinitionRepository.class);
+		this.workFlowWorkRepository = mock(WorkFlowWorkRepository.class);
+		this.workFlowCheckerMappingDefinitionRepository = mock(WorkFlowCheckerMappingDefinitionRepository.class);
 		this.workFlowDefinitionService = getWorkflowDefinitionService();
 	}
 
@@ -102,16 +101,16 @@ class WorkFlowDefinitionServiceImplTest {
 		String workFlowTaskName = "testTask";
 		// given
 		WorkFlowDefinition workFlowDefinition = this.sampleWorkFlowDefinition(workFlowName);
-		WorkFlowTask workFlowTask = Mockito.mock(WorkFlowTask.class);
+		WorkFlowTask workFlowTask = mock(WorkFlowTask.class);
 		WorkParameter workParameter = WorkParameter.builder().key("key").description("the key").optional(false)
 				.type(WorkParameterType.URL).build();
-		Mockito.when(workFlowTask.getName()).thenReturn(workFlowTaskName);
-		Mockito.when(workFlowTask.getWorkFlowTaskParameters()).thenReturn(List.of(workParameter));
+		when(workFlowTask.getName()).thenReturn(workFlowTaskName);
+		when(workFlowTask.getWorkFlowTaskParameters()).thenReturn(List.of(workParameter));
 		WorkFlowTaskDefinition workFlowTaskDefinition = this.sampleWorkFlowTaskDefinition(workFlowDefinition,
 				workFlowTaskName, workParameter);
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTaskDefinition));
-		Mockito.when(this.workFlowTaskDefinitionRepository.save(any())).thenReturn(workFlowTaskDefinition);
-		Mockito.when(this.workFlowDefinitionRepository.save(any())).thenReturn(workFlowDefinition);
+		when(this.workFlowTaskDefinitionRepository.save(any())).thenReturn(workFlowTaskDefinition);
+		when(this.workFlowDefinitionRepository.save(any())).thenReturn(workFlowDefinition);
 		WorkFlowPropertiesMetadata properties = WorkFlowPropertiesMetadata.builder().version("1.0.0").build();
 
 		// when
@@ -126,7 +125,7 @@ class WorkFlowDefinitionServiceImplTest {
 		assertEquals(workFlowDefinitionResponseDTO.getProperties().getVersion(), "1.0.0");
 
 		ArgumentCaptor<WorkFlowDefinition> argument = ArgumentCaptor.forClass(WorkFlowDefinition.class);
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(2)).save(argument.capture());
+		verify(this.workFlowDefinitionRepository, times(2)).save(argument.capture());
 		assertEquals(argument.getValue().getName(), workFlowName);
 		assertEquals(argument.getValue().getType(), WorkFlowType.ASSESSMENT);
 		assertEquals(argument.getValue().getProcessingType(), WorkFlowProcessingType.SEQUENTIAL);
@@ -142,21 +141,20 @@ class WorkFlowDefinitionServiceImplTest {
 		// given
 		WorkFlowDefinition workFlowDefinition = this.sampleWorkFlowDefinition(workFlowName);
 		workFlowDefinition.setParameters("{}");
-		WorkFlowTask workFlowTask = Mockito.mock(WorkFlowTask.class);
+		WorkFlowTask workFlowTask = mock(WorkFlowTask.class);
 		WorkParameter workParameter = WorkParameter.builder().key("key").description("the key").optional(false)
 				.type(WorkParameterType.URL).build();
-		Mockito.when(workFlowTask.getName()).thenReturn(workFlowTaskName);
-		Mockito.when(workFlowTask.getWorkFlowTaskParameters()).thenReturn(List.of(workParameter));
+		when(workFlowTask.getName()).thenReturn(workFlowTaskName);
+		when(workFlowTask.getWorkFlowTaskParameters()).thenReturn(List.of(workParameter));
 		WorkFlowTaskDefinition workFlowTaskDefinition = this.sampleWorkFlowTaskDefinition(workFlowDefinition,
 				workFlowTaskName, workParameter);
 		workFlowTaskDefinition.setParameters("{}");
 		workFlowTaskDefinition.setOutputs("[]");
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTaskDefinition));
-		Mockito.when(this.workFlowTaskDefinitionRepository.save(any())).thenReturn(workFlowTaskDefinition);
-		Mockito.when(this.workFlowDefinitionRepository.save(any())).thenReturn(workFlowDefinition);
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(workFlowDefinition);
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString()))
-				.thenReturn(workFlowTaskDefinition);
+		when(this.workFlowTaskDefinitionRepository.save(any())).thenReturn(workFlowTaskDefinition);
+		when(this.workFlowDefinitionRepository.save(any())).thenReturn(workFlowDefinition);
+		when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(workFlowDefinition);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString())).thenReturn(workFlowTaskDefinition);
 		// when
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = this.workFlowDefinitionService.save(workFlowName,
 				WorkFlowType.ASSESSMENT, null, Collections.emptyList(), List.of(workFlowTask),
@@ -167,8 +165,8 @@ class WorkFlowDefinitionServiceImplTest {
 		assertNotNull(workFlowDefinitionResponseDTO.getId());
 		assertEquals(workFlowDefinitionResponseDTO.getName(), workFlowName);
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(2)).save(workFlowDefinition);
-		Mockito.verify(this.workFlowTaskDefinitionRepository, Mockito.never()).save(any());
+		verify(this.workFlowDefinitionRepository, times(2)).save(workFlowDefinition);
+		verify(this.workFlowTaskDefinitionRepository, never()).save(any());
 	}
 
 	@Test
@@ -177,7 +175,7 @@ class WorkFlowDefinitionServiceImplTest {
 		WorkFlowDefinition workFlowDefinition = this.sampleWorkFlowDefinition(TEST);
 
 		UUID uuid = UUID.randomUUID();
-		Mockito.when(this.workFlowDefinitionRepository.findById(uuid)).thenReturn(Optional.of(workFlowDefinition));
+		when(this.workFlowDefinitionRepository.findById(uuid)).thenReturn(Optional.of(workFlowDefinition));
 
 		// when
 		WorkFlowDefinitionResponseDTO wkDTO = this.workFlowDefinitionService.getWorkFlowDefinitionById(uuid);
@@ -187,7 +185,7 @@ class WorkFlowDefinitionServiceImplTest {
 		assertEquals(wkDTO.getName(), TEST);
 
 		ArgumentCaptor<UUID> argument = ArgumentCaptor.forClass(UUID.class);
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findById(argument.capture());
+		verify(this.workFlowDefinitionRepository, times(1)).findById(argument.capture());
 		assertEquals(argument.getValue(), uuid);
 	}
 
@@ -197,7 +195,7 @@ class WorkFlowDefinitionServiceImplTest {
 		WorkFlowDefinition workFlowDefinition = this.sampleWorkFlowDefinition(TEST);
 
 		UUID uuid = UUID.randomUUID();
-		Mockito.when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.empty());
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.empty());
 
 		// when
 		Exception exception = assertThrows(RuntimeException.class, () -> {
@@ -211,8 +209,7 @@ class WorkFlowDefinitionServiceImplTest {
 	@Test
 	public void getWorkFlowDefinitionByNameWithValidNameTest() {
 		// given
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any()))
-				.thenReturn(sampleWorkFlowDefinition(TEST));
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(sampleWorkFlowDefinition(TEST));
 
 		// when
 		WorkFlowDefinitionResponseDTO result = this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST);
@@ -221,7 +218,7 @@ class WorkFlowDefinitionServiceImplTest {
 		assertNotNull(result);
 		assertEquals(result.getName(), TEST);
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(any());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
 	}
 
 	@Test
@@ -229,12 +226,12 @@ class WorkFlowDefinitionServiceImplTest {
 		// given
 		WorkFlowDefinition masterWorkFlow = sampleWorkFlowDefinition(TEST);
 		WorkFlowWorkDefinition workFlowWorkDefinition = sampleWorkFlowWorkDefinition("workTest");
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(masterWorkFlow);
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(masterWorkFlow);
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any()))
+		when(this.workFlowDefinitionRepository.findById(any()))
 				.thenReturn(Optional.of(sampleWorkFlowDefinition("SubWorkFlow")));
 
-		Mockito.when(this.workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlow.getId()))
+		when(this.workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlow.getId()))
 				.thenReturn(List.of(sampleWorkFlowWorkDefinition("SubWorkFlow")));
 
 		// when
@@ -244,9 +241,8 @@ class WorkFlowDefinitionServiceImplTest {
 		assertNotNull(result);
 		assertEquals(result.getName(), TEST);
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(any());
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any()))
-				.thenReturn(sampleWorkFlowDefinition(TEST));
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(sampleWorkFlowDefinition(TEST));
 
 		assertEquals(result.getWorks().size(), 1);
 		assertEquals(result.getWorks().get(0).getName(), "SubWorkFlow");
@@ -258,11 +254,11 @@ class WorkFlowDefinitionServiceImplTest {
 		// given
 		WorkFlowDefinition masterWorkFlow = sampleWorkFlowDefinition(TEST);
 		WorkFlowWorkDefinition workFlowWorkDefinition = sampleWorkFlowWorkDefinition("workTest");
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(masterWorkFlow);
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(masterWorkFlow);
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any())).thenReturn(Optional.empty());
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.empty());
 
-		Mockito.when(this.workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(Mockito.any()))
+		when(this.workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(any()))
 				.thenReturn(List.of(workFlowWorkDefinition));
 
 		// when
@@ -272,9 +268,8 @@ class WorkFlowDefinitionServiceImplTest {
 		assertNotNull(result);
 		assertEquals(result.getName(), TEST);
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(any());
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any()))
-				.thenReturn(sampleWorkFlowDefinition(TEST));
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(sampleWorkFlowDefinition(TEST));
 
 		assertEquals(result.getWorks().size(), 0);
 	}
@@ -282,20 +277,20 @@ class WorkFlowDefinitionServiceImplTest {
 	@Test
 	public void getWorkFlowDefinitionByNameWithInvalidNameTest() {
 		// given
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(null);
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(null);
 
 		Exception exception = assertThrows(RuntimeException.class, () -> {
 			this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST);
 		});
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(any());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
 	}
 
 	@Test
 	public void getWorkFlowDefinitionWithoutData() {
 
 		// given
-		Mockito.when(this.workFlowDefinitionRepository.findByTypeIsNot(any())).thenReturn(new ArrayList<>());
+		when(this.workFlowDefinitionRepository.findByTypeIsNot(any())).thenReturn(new ArrayList<>());
 
 		// when
 		List<WorkFlowDefinitionResponseDTO> resultList = this.workFlowDefinitionService.getWorkFlowDefinitions();
@@ -304,13 +299,13 @@ class WorkFlowDefinitionServiceImplTest {
 		assertNotNull(resultList);
 		assertEquals(resultList.size(), 0);
 
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findByTypeIsNot(any());
+		verify(this.workFlowDefinitionRepository, times(1)).findByTypeIsNot(any());
 	}
 
 	@Test
 	public void getWorkFlowDefinitionsWithData() {
 		// given
-		Mockito.when(this.workFlowDefinitionRepository.findByTypeIsNot(WorkFlowType.CHECKER)).thenReturn(
+		when(this.workFlowDefinitionRepository.findByTypeIsNot(WorkFlowType.CHECKER)).thenReturn(
 				Arrays.asList(sampleWorkFlowDefinition("workFLowOne"), sampleWorkFlowDefinition("workFLowTwo")));
 
 		// when
@@ -322,19 +317,19 @@ class WorkFlowDefinitionServiceImplTest {
 		assertEquals(workFlowDefinitionResponseDTOs.size(), 2);
 		assertEquals(workFlowDefinitionResponseDTOs.get(0).getName(), "workFLowOne");
 		assertEquals(workFlowDefinitionResponseDTOs.get(0).getProperties().getVersion(), "1.0.0");
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findByTypeIsNot(WorkFlowType.CHECKER);
+		verify(this.workFlowDefinitionRepository, times(1)).findByTypeIsNot(WorkFlowType.CHECKER);
 	}
 
 	@Test
 	public void saveWorkFlowCheckerTestWithValidData() {
 		// given
 		WorkFlowTaskDefinition taskDefinition = this.sampleWorkflowTaskDefinition();
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(any())).thenReturn(taskDefinition);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(any())).thenReturn(taskDefinition);
 
 		WorkFlowDefinition wfDefinition = this.sampleWorkFlowDefinition(TEST_WF);
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(TEST_WF)).thenReturn(wfDefinition);
+		when(this.workFlowDefinitionRepository.findFirstByName(TEST_WF)).thenReturn(wfDefinition);
 
-		Mockito.when(workFlowCheckerMappingDefinitionRepository.findFirstByCheckWorkFlow(any())).thenReturn(null);
+		when(workFlowCheckerMappingDefinitionRepository.findFirstByCheckWorkFlow(any())).thenReturn(null);
 
 		// when
 		this.workFlowDefinitionService.saveWorkFlowChecker(TEST, TEST_WF,
@@ -342,7 +337,7 @@ class WorkFlowDefinitionServiceImplTest {
 		// then
 
 		ArgumentCaptor<WorkFlowTaskDefinition> argument = ArgumentCaptor.forClass(WorkFlowTaskDefinition.class);
-		Mockito.verify(this.workFlowTaskDefinitionRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowTaskDefinitionRepository, times(1)).save(argument.capture());
 
 		assertEquals(argument.getValue().getName(), TEST);
 		WorkFlowCheckerMappingDefinition checkerDefinition = argument.getValue().getWorkFlowCheckerMappingDefinition();
@@ -362,14 +357,14 @@ class WorkFlowDefinitionServiceImplTest {
 		// @TODO not sure if not doing anything is the right thing to do here
 		// given
 		WorkFlowTaskDefinition taskDefinition = this.sampleWorkflowTaskDefinition();
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(any())).thenReturn(null);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(any())).thenReturn(null);
 
 		// when
 		this.workFlowDefinitionService.saveWorkFlowChecker(TEST, TEST_WF,
 				WorkFlowCheckerDTO.builder().cronExpression(_10).build());
 
 		// then
-		Mockito.verify(this.workFlowTaskDefinitionRepository, Mockito.times(0)).save(any());
+		verify(this.workFlowTaskDefinitionRepository, times(0)).save(any());
 	}
 
 	@Test
@@ -384,17 +379,16 @@ class WorkFlowDefinitionServiceImplTest {
 		WorkFlowTaskDefinition workFlowTaskDefinition = this.sampleWorkFlowTaskDefinition(workFlowDefinition,
 				workFlowTaskName, workParameter);
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTaskDefinition));
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString()))
-				.thenReturn(workFlowTaskDefinition);
+		when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString())).thenReturn(workFlowTaskDefinition);
 		assertThat(workFlowDefinitionService.getWorkParametersByWorkName(workFlowTaskName)).isNotNull()
 				.containsKey(KEY);
 	}
 
 	@Test
 	void getWorkParametersByWorkName_when_workIsNotFound_then_returnNull() {
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
+		when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
 		assertNull(workFlowDefinitionService.getWorkParametersByWorkName("test"));
 	}
 
@@ -409,10 +403,9 @@ class WorkFlowDefinitionServiceImplTest {
 		WorkFlowTaskDefinition workFlowTaskDefinition = this.sampleWorkFlowTaskDefinition(workFlowDefinition,
 				workFlowTaskName, workParameter);
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTaskDefinition));
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString()))
-				.thenReturn(workFlowTaskDefinition);
-		Mockito.when(workFlowWorkRepository.findFirstByWorkDefinitionId(workFlowTaskDefinition.getId()))
+		when(this.workFlowDefinitionRepository.findFirstByName(anyString())).thenReturn(null);
+		when(this.workFlowTaskDefinitionRepository.findFirstByName(anyString())).thenReturn(workFlowTaskDefinition);
+		when(workFlowWorkRepository.findFirstByWorkDefinitionId(workFlowTaskDefinition.getId()))
 				.thenReturn(WorkFlowWorkDefinition.builder().workFlowDefinition(workFlowDefinition).build());
 		assertEquals(workFlowDefinition, workFlowDefinitionService.getParentWorkFlowByWorkName(workFlowTaskName));
 	}
@@ -425,8 +418,8 @@ class WorkFlowDefinitionServiceImplTest {
 		WorkFlowDefinition workFlowDefinition = this.sampleWorkFlowDefinition(workFlowName);
 		WorkFlowDefinition workFlowParentDefinition = this.sampleWorkFlowDefinition(workFlowParentName);
 
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(workFlowName)).thenReturn(workFlowDefinition);
-		Mockito.when(workFlowWorkRepository.findFirstByWorkDefinitionId(workFlowDefinition.getId()))
+		when(this.workFlowDefinitionRepository.findFirstByName(workFlowName)).thenReturn(workFlowDefinition);
+		when(workFlowWorkRepository.findFirstByWorkDefinitionId(workFlowDefinition.getId()))
 				.thenReturn(WorkFlowWorkDefinition.builder().workFlowDefinition(workFlowParentDefinition).build());
 		assertEquals(workFlowParentDefinition, workFlowDefinitionService.getParentWorkFlowByWorkName(workFlowName));
 	}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -29,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,15 +88,15 @@ public class WorkFlowExecutionInterceptorTest {
 	@Test
 	public void testHandleIncompletePostWorkFlowExecution() {
 		// given
-		WorkReport report = Mockito.mock(WorkReport.class);
+		WorkReport report = mock(WorkReport.class);
 		when(report.getStatus()).thenReturn(WorkStatus.IN_PROGRESS);
 
-		WorkFlow workFlow = Mockito.mock(WorkFlow.class);
+		WorkFlow workFlow = mock(WorkFlow.class);
 		when(workFlow.getName()).thenReturn("TestWorkFlow");
 
 		when(workFlowDefinition.getType()).thenReturn(WorkFlowType.CHECKER);
 		when(workFlowDefinition.getCheckerWorkFlowDefinition())
-				.thenReturn(Mockito.mock(WorkFlowCheckerMappingDefinition.class));
+				.thenReturn(mock(WorkFlowCheckerMappingDefinition.class));
 
 		// when
 		WorkFlowExecution workFlowExecution = interceptor.handlePreWorkFlowExecution();
@@ -103,10 +104,9 @@ public class WorkFlowExecutionInterceptorTest {
 		WorkReport result = interceptor.handlePostWorkFlowExecution(report, workFlow);
 
 		// then
-		verify(workFlowService, Mockito.times(0)).saveWorkFlow(any(UUID.class), any(UUID.class),
-				eq(WorkFlowStatus.IN_PROGRESS), any(), anyString());
-		verify(workFlowSchedulerService, Mockito.times(1)).schedule(Mockito.any(), Mockito.any(),
-				Mockito.any(WorkContext.class), Mockito.any());
+		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(UUID.class), eq(WorkFlowStatus.IN_PROGRESS),
+				any(), anyString());
+		verify(workFlowSchedulerService, times(1)).schedule(any(), any(), any(WorkContext.class), any());
 
 		assertEquals(result.getStatus(), report.getStatus());
 	}
@@ -114,16 +114,16 @@ public class WorkFlowExecutionInterceptorTest {
 	@Test
 	public void testHandleCompletePostWorkFlowExecution() {
 		// given
-		WorkReport report = Mockito.mock(WorkReport.class);
+		WorkReport report = mock(WorkReport.class);
 		when(report.getStatus()).thenReturn(WorkStatus.COMPLETED);
 		when(workContext.get(WorkContextDelegate.buildKey(WorkContextDelegate.ProcessType.WORKFLOW_DEFINITION,
 				WorkContextDelegate.Resource.NAME))).thenReturn("TestWorkFlow");
-		WorkFlow workFlow = Mockito.mock(WorkFlow.class);
+		WorkFlow workFlow = mock(WorkFlow.class);
 		when(workFlow.getName()).thenReturn("TestWorkFlow");
 
 		when(workFlowDefinition.getType()).thenReturn(WorkFlowType.CHECKER);
 		when(workFlowDefinition.getCheckerWorkFlowDefinition())
-				.thenReturn(Mockito.mock(WorkFlowCheckerMappingDefinition.class));
+				.thenReturn(mock(WorkFlowCheckerMappingDefinition.class));
 		when(mainWorkFlowExecution.getId()).thenReturn(UUID.randomUUID());
 
 		// when
@@ -132,11 +132,11 @@ public class WorkFlowExecutionInterceptorTest {
 		WorkReport result = interceptor.handlePostWorkFlowExecution(report, workFlow);
 
 		// then
-		verify(workFlowService, Mockito.times(0)).saveWorkFlow(any(UUID.class), any(UUID.class),
-				eq(WorkFlowStatus.IN_PROGRESS), any(), anyString());
-		verify(workFlowSchedulerService, Mockito.times(1)).stop(Mockito.any(), Mockito.any(WorkFlow.class));
-		verify(workFlowContinuationServiceImpl, Mockito.times(1)).continueWorkFlow(Mockito.any(UUID.class),
-				Mockito.anyString(), Mockito.any(WorkContext.class), Mockito.any(UUID.class));
+		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(UUID.class), eq(WorkFlowStatus.IN_PROGRESS),
+				any(), anyString());
+		verify(workFlowSchedulerService, times(1)).stop(any(), any(WorkFlow.class));
+		verify(workFlowContinuationServiceImpl, times(1)).continueWorkFlow(any(UUID.class), anyString(),
+				any(WorkContext.class), any(UUID.class));
 		assertEquals(result.getStatus(), report.getStatus());
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowPropertiesAspectTest.java
@@ -7,7 +7,6 @@ import com.redhat.parodos.workflows.workflow.WorkFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import org.springframework.core.env.Environment;
 
@@ -15,17 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
 
 class WorkFlowPropertiesAspectTest {
 
 	@Test
 	public void testWorkFlowPropertiesAspectWithValidData() {
 		// given
-		WorkFlow workflow = Mockito.mock(WorkFlow.class);
-		WorkFlowProperties properties = Mockito.mock(WorkFlowProperties.class);
-		Mockito.when(properties.version()).thenReturn("1.0.0");
-		Environment env = Mockito.mock(Environment.class);
-		Mockito.when(env.resolvePlaceholders(Mockito.anyString())).thenReturn("1.0.0");
+		WorkFlow workflow = mock(WorkFlow.class);
+		WorkFlowProperties properties = mock(WorkFlowProperties.class);
+		when(properties.version()).thenReturn("1.0.0");
+		Environment env = mock(Environment.class);
+		when(env.resolvePlaceholders(anyString())).thenReturn("1.0.0");
 
 		// when
 		WorkFlowPropertiesAspect aspect = new WorkFlowPropertiesAspect();
@@ -38,19 +38,19 @@ class WorkFlowPropertiesAspectTest {
 
 		// then
 		ArgumentCaptor<WorkFlowPropertiesMetadata> argument = ArgumentCaptor.forClass(WorkFlowPropertiesMetadata.class);
-		Mockito.verify(workflow, Mockito.times(1)).setProperties(argument.capture());
+		verify(workflow, times(1)).setProperties(argument.capture());
 		assertEquals(argument.getValue().getVersion(), "1.0.0");
-		Mockito.verify(env, Mockito.times(1)).resolvePlaceholders("1.0.0");
+		verify(env, times(1)).resolvePlaceholders("1.0.0");
 	}
 
 	@Test
 	public void testWorkFlowPropertiesAspectWithValidEnvData() {
 		// given
-		WorkFlow workflow = Mockito.mock(WorkFlow.class);
-		WorkFlowProperties properties = Mockito.mock(WorkFlowProperties.class);
-		Mockito.when(properties.version()).thenReturn("${git.commit.id}");
-		Environment env = Mockito.mock(Environment.class);
-		Mockito.when(env.resolvePlaceholders(Mockito.anyString())).thenReturn("1.0.0");
+		WorkFlow workflow = mock(WorkFlow.class);
+		WorkFlowProperties properties = mock(WorkFlowProperties.class);
+		when(properties.version()).thenReturn("${git.commit.id}");
+		Environment env = mock(Environment.class);
+		when(env.resolvePlaceholders(anyString())).thenReturn("1.0.0");
 
 		// when
 		WorkFlowPropertiesAspect aspect = new WorkFlowPropertiesAspect();
@@ -63,19 +63,19 @@ class WorkFlowPropertiesAspectTest {
 
 		// then
 		ArgumentCaptor<WorkFlowPropertiesMetadata> argument = ArgumentCaptor.forClass(WorkFlowPropertiesMetadata.class);
-		Mockito.verify(workflow, Mockito.times(1)).setProperties(argument.capture());
+		verify(workflow, times(1)).setProperties(argument.capture());
 		assertEquals(argument.getValue().getVersion(), "1.0.0");
-		Mockito.verify(env, Mockito.times(1)).resolvePlaceholders("${git.commit.id}");
+		verify(env, times(1)).resolvePlaceholders("${git.commit.id}");
 	}
 
 	@Test
 	public void testWorkFlowPropertiesAspectWithNoValidData() {
 		// given
-		WorkFlow workflow = Mockito.mock(WorkFlow.class);
-		WorkFlowProperties properties = Mockito.mock(WorkFlowProperties.class);
-		Mockito.when(properties.version()).thenReturn("1.0.0");
-		Environment env = Mockito.mock(Environment.class);
-		Mockito.when(env.resolvePlaceholders(Mockito.anyString())).thenReturn("1.0.0");
+		WorkFlow workflow = mock(WorkFlow.class);
+		WorkFlowProperties properties = mock(WorkFlowProperties.class);
+		when(properties.version()).thenReturn("1.0.0");
+		Environment env = mock(Environment.class);
+		when(env.resolvePlaceholders(anyString())).thenReturn("1.0.0");
 
 		// when
 		WorkFlowPropertiesAspect aspect = new WorkFlowPropertiesAspect();
@@ -87,21 +87,21 @@ class WorkFlowPropertiesAspectTest {
 		});
 
 		// then
-		Mockito.verify(workflow, Mockito.times(0)).setProperties(Mockito.any());
+		verify(workflow, times(0)).setProperties(any());
 	}
 
 	@Test
 	public void testWorkFlowPropertiesAspectWithNoValidVersion() {
 		// given
 
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
 		workFlow.setProperties(WorkFlowPropertiesMetadata.builder().version("1.0.0").build());
 
-		WorkFlowProperties properties = Mockito.mock(WorkFlowProperties.class);
-		Mockito.when(properties.version()).thenReturn("1.0.0");
-		Environment env = Mockito.mock(Environment.class);
-		Mockito.when(env.resolvePlaceholders(Mockito.anyString())).thenReturn("");
+		WorkFlowProperties properties = mock(WorkFlowProperties.class);
+		when(properties.version()).thenReturn("1.0.0");
+		Environment env = mock(Environment.class);
+		when(env.resolvePlaceholders(anyString())).thenReturn("");
 
 		// when
 		WorkFlowPropertiesAspect aspect = new WorkFlowPropertiesAspect();

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspectTest.java
@@ -23,11 +23,16 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class WorkFlowTaskExecutionAspectTest {
 
@@ -52,20 +57,19 @@ class WorkFlowTaskExecutionAspectTest {
 	@Mock
 	private WorkFlowSchedulerServiceImpl workFlowSchedulerService;
 
-	private WorkFlowRepository workFlowRepository = Mockito.mock(WorkFlowRepository.class);
+	private WorkFlowRepository workFlowRepository = mock(WorkFlowRepository.class);
 
-	private WorkFlowTaskDefinitionRepository workFlowTaskDefinitionRepository = Mockito
-			.mock(WorkFlowTaskDefinitionRepository.class);
+	private WorkFlowTaskDefinitionRepository workFlowTaskDefinitionRepository = mock(
+			WorkFlowTaskDefinitionRepository.class);
 
 	@BeforeEach
 	public void setUp() {
-		this.workFlowService = Mockito.mock(WorkFlowServiceImpl.class);
+		this.workFlowService = mock(WorkFlowServiceImpl.class);
 		this.workFlowTaskExecutionAspect = new WorkFlowTaskExecutionAspect(workFlowRepository,
 				workFlowTaskDefinitionRepository, workFlowService, workFlowSchedulerService);
-		WorkFlowTaskDefinition workFlowTaskDefinition = Mockito.mock(WorkFlowTaskDefinition.class);
-		Mockito.when(workFlowTaskDefinition.getId()).thenReturn(UUID.randomUUID());
-		Mockito.when(workFlowTaskDefinitionRepository.findFirstByName(Mockito.any()))
-				.thenReturn(workFlowTaskDefinition);
+		WorkFlowTaskDefinition workFlowTaskDefinition = mock(WorkFlowTaskDefinition.class);
+		when(workFlowTaskDefinition.getId()).thenReturn(UUID.randomUUID());
+		when(workFlowTaskDefinitionRepository.findFirstByName(any())).thenReturn(workFlowTaskDefinition);
 	}
 
 	@Test
@@ -75,19 +79,17 @@ class WorkFlowTaskExecutionAspectTest {
 		WorkContext workContext = getSampleWorkContext(projectID, TEST_TASK);
 		WorkFlowTask workFlowTask = getSampleWorkFlowTask(TEST_TASK);
 
-		ProceedingJoinPoint proceedingJoinPoint = Mockito.mock(ProceedingJoinPoint.class);
-		Mockito.when(proceedingJoinPoint.getTarget()).thenReturn(workFlowTask);
+		ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+		when(proceedingJoinPoint.getTarget()).thenReturn(workFlowTask);
 		assertDoesNotThrow(() -> {
-			Mockito.when(proceedingJoinPoint.proceed())
-					.thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+			when(proceedingJoinPoint.proceed()).thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
 		});
 
 		WorkFlowExecution workFlowExecution = getSampleWorkFlowExecution();
-		Mockito.when(workFlowRepository.findById(Mockito.any())).thenReturn(Optional.of(workFlowExecution));
-		Mockito.when(workFlowTaskDefinitionRepository.findFirstByName(Mockito.anyString()))
+		when(workFlowRepository.findById(any())).thenReturn(Optional.of(workFlowExecution));
+		when(workFlowTaskDefinitionRepository.findFirstByName(anyString()))
 				.thenReturn(getSampleWorkFlowTaskDefinition(TEST_TASK));
-		Mockito.when(workFlowService.saveWorkFlowTask(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-				.thenReturn(getSampleWorkFlowTaskExecution());
+		when(workFlowService.saveWorkFlowTask(any(), any(), any(), any())).thenReturn(getSampleWorkFlowTaskExecution());
 
 		// when
 		WorkReport report = this.workFlowTaskExecutionAspect.executeAroundAdviceTask(proceedingJoinPoint, workContext);
@@ -102,8 +104,7 @@ class WorkFlowTaskExecutionAspectTest {
 				workContext.get(WORKFLOW_TASK_EXECUTION_TESTTASK_ARGUMENTS));
 		assertEquals(report.getWorkContext().get(PROJECT_ID), projectID);
 
-		Mockito.verify(this.workFlowService, Mockito.times(1)).saveWorkFlowTask(Mockito.any(), Mockito.any(),
-				Mockito.any(), Mockito.any());
+		verify(this.workFlowService, times(1)).saveWorkFlowTask(any(), any(), any(), any());
 	}
 
 	@Test
@@ -113,22 +114,19 @@ class WorkFlowTaskExecutionAspectTest {
 		WorkContext workContext = getSampleWorkContext(projectID, TEST_TASK);
 		WorkFlowTask workFlowTask = getSampleWorkFlowTask(TEST_TASK);
 
-		ProceedingJoinPoint proceedingJoinPoint = Mockito.mock(ProceedingJoinPoint.class);
-		Mockito.when(proceedingJoinPoint.getTarget()).thenReturn(workFlowTask);
+		ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+		when(proceedingJoinPoint.getTarget()).thenReturn(workFlowTask);
 		assertDoesNotThrow(() -> {
-			Mockito.when(proceedingJoinPoint.proceed())
-					.thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+			when(proceedingJoinPoint.proceed()).thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
 		});
 
-		Mockito.when(this.workFlowService.getWorkFlowTask(Mockito.any(), Mockito.any()))
-				.thenReturn(getSampleWorkFlowTaskExecution());
+		when(this.workFlowService.getWorkFlowTask(any(), any())).thenReturn(getSampleWorkFlowTaskExecution());
 
 		WorkFlowExecution workFlowExecution = getSampleWorkFlowExecution();
-		Mockito.when(workFlowRepository.findById(Mockito.any())).thenReturn(Optional.of(workFlowExecution));
-		Mockito.when(workFlowTaskDefinitionRepository.findFirstByName(Mockito.anyString()))
+		when(workFlowRepository.findById(any())).thenReturn(Optional.of(workFlowExecution));
+		when(workFlowTaskDefinitionRepository.findFirstByName(anyString()))
 				.thenReturn(getSampleWorkFlowTaskDefinition(TEST_TASK));
-		Mockito.when(workFlowService.saveWorkFlowTask(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-				.thenReturn(getSampleWorkFlowTaskExecution());
+		when(workFlowService.saveWorkFlowTask(any(), any(), any(), any())).thenReturn(getSampleWorkFlowTaskExecution());
 
 		// when
 		WorkReport report = this.workFlowTaskExecutionAspect.executeAroundAdviceTask(proceedingJoinPoint, workContext);
@@ -143,7 +141,7 @@ class WorkFlowTaskExecutionAspectTest {
 				workContext.get(WORKFLOW_TASK_EXECUTION_TESTTASK_ARGUMENTS));
 		assertEquals(report.getWorkContext().get(PROJECT_ID), projectID);
 
-		Mockito.verify(this.workFlowService, Mockito.times(1)).updateWorkFlowTask(Mockito.any());
+		verify(this.workFlowService, times(1)).updateWorkFlowTask(any());
 	}
 
 	WorkContext getSampleWorkContext(UUID projectID, String taskName) {
@@ -159,8 +157,8 @@ class WorkFlowTaskExecutionAspectTest {
 	}
 
 	WorkFlowTask getSampleWorkFlowTask(String taskName) {
-		WorkFlowTask workFlowTask = Mockito.mock(WorkFlowTask.class);
-		Mockito.when(workFlowTask.getName()).thenReturn(taskName);
+		WorkFlowTask workFlowTask = mock(WorkFlowTask.class);
+		when(workFlowTask.getName()).thenReturn(taskName);
 		return workFlowTask;
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
@@ -18,11 +18,11 @@ import com.redhat.parodos.workflow.task.enums.WorkFlowTaskStatus;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
 
 class WorkFlowContinuationServiceImplTest {
 
@@ -46,11 +46,11 @@ class WorkFlowContinuationServiceImplTest {
 
 	@BeforeEach
 	void initEach() {
-		this.workFlowDefinitionRepository = Mockito.mock(WorkFlowDefinitionRepository.class);
-		this.workFlowTaskDefinitionRepository = Mockito.mock(WorkFlowTaskDefinitionRepository.class);
-		this.workFlowRepository = Mockito.mock(WorkFlowRepository.class);
-		this.workFlowTaskRepository = Mockito.mock(WorkFlowTaskRepository.class);
-		this.asyncWorkFlowContinuer = Mockito.mock(AsyncWorkFlowContinuerImpl.class);
+		this.workFlowDefinitionRepository = mock(WorkFlowDefinitionRepository.class);
+		this.workFlowTaskDefinitionRepository = mock(WorkFlowTaskDefinitionRepository.class);
+		this.workFlowRepository = mock(WorkFlowRepository.class);
+		this.workFlowTaskRepository = mock(WorkFlowTaskRepository.class);
+		this.asyncWorkFlowContinuer = mock(AsyncWorkFlowContinuerImpl.class);
 		this.service = new WorkFlowContinuationServiceImpl(this.workFlowDefinitionRepository, this.workFlowRepository,
 				this.asyncWorkFlowContinuer);
 	}
@@ -58,99 +58,89 @@ class WorkFlowContinuationServiceImplTest {
 	@Test
 	void workFlowSkipCompletedJobs() {
 		// given
-		Mockito.when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of());
+		when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of());
 
 		// when
 		this.service.workFlowRunAfterStartup();
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		Mockito.verify(this.asyncWorkFlowContinuer, Mockito.times(0)).executeAsync(Mockito.any(), Mockito.any(),
-				Mockito.any(), Mockito.any());
+		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
+		verify(this.asyncWorkFlowContinuer, times(0)).executeAsync(any(), any(), any(), any());
 	}
 
 	@Test
 	void workFlowCompleteInProgress() {
 		// given
 		WorkFlowExecution workFlowExecution = this.sampleWorkFlowExecution(WorkFlowStatus.IN_PROGRESS);
-		Mockito.when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses))
-				.thenReturn(List.of(workFlowExecution));
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any()))
-				.thenReturn(Optional.of(sampleWorkFlowDefinition()));
+		when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of(workFlowExecution));
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.of(sampleWorkFlowDefinition()));
 		// when
 		this.service.workFlowRunAfterStartup();
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		Mockito.verify(this.asyncWorkFlowContinuer, Mockito.times(1)).executeAsync(
-				Mockito.eq(workFlowExecution.getProjectId()), Mockito.eq(TEST_WORKFLOW), Mockito.any(), Mockito.any());
+		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
+		verify(this.asyncWorkFlowContinuer, times(1)).executeAsync(eq(workFlowExecution.getProjectId()),
+				eq(TEST_WORKFLOW), any(), any());
 	}
 
 	@Test
 	void workFlowCompletePending() {
 		// given
 		WorkFlowExecution workFlowExecution = this.sampleWorkFlowExecution(WorkFlowStatus.PENDING);
-		Mockito.when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses))
-				.thenReturn(List.of(workFlowExecution));
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any()))
-				.thenReturn(Optional.of(sampleWorkFlowDefinition()));
+		when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of(workFlowExecution));
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.of(sampleWorkFlowDefinition()));
 		// when
 		this.service.workFlowRunAfterStartup();
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		Mockito.verify(this.asyncWorkFlowContinuer, Mockito.times(1)).executeAsync(
-				Mockito.eq(workFlowExecution.getProjectId()), Mockito.eq(TEST_WORKFLOW), Mockito.any(), Mockito.any());
+		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
+		verify(this.asyncWorkFlowContinuer, times(1)).executeAsync(eq(workFlowExecution.getProjectId()),
+				eq(TEST_WORKFLOW), any(), any());
 	}
 
 	@Test
 	void workFlowCompleteWithTaskExecutions() {
 		// given
 		WorkFlowExecution workFlowExecution = this.sampleWorkFlowExecution(WorkFlowStatus.IN_PROGRESS);
-		Mockito.when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses))
-				.thenReturn(List.of(workFlowExecution));
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any()))
-				.thenReturn(Optional.of(sampleWorkFlowDefinition()));
+		when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of(workFlowExecution));
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.of(sampleWorkFlowDefinition()));
 		WorkFlowTaskDefinition workFlowTaskDefinition = sampleWorkFlowTaskDefinition();
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(Mockito.any()))
-				.thenReturn(Optional.of(workFlowTaskDefinition));
+		when(this.workFlowTaskDefinitionRepository.findById(any())).thenReturn(Optional.of(workFlowTaskDefinition));
 		WorkFlowTaskExecution workFlowTaskExecution = WorkFlowTaskExecution.builder().arguments("{\"test\": \"test\"}")
 				.results("res").status(WorkFlowTaskStatus.COMPLETED)
 				.workFlowTaskDefinitionId(workFlowTaskDefinition.getId()).workFlowExecutionId(workFlowExecution.getId())
 				.build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionId(workFlowExecution.getId()))
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionId(workFlowExecution.getId()))
 				.thenReturn(List.of(workFlowTaskExecution));
 
 		// when
 		this.service.workFlowRunAfterStartup();
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		Mockito.verify(this.asyncWorkFlowContinuer, Mockito.times(1)).executeAsync(
-				Mockito.eq(workFlowExecution.getProjectId()), Mockito.eq(TEST_WORKFLOW), Mockito.any(), Mockito.any());
+		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
+		verify(this.asyncWorkFlowContinuer, times(1)).executeAsync(eq(workFlowExecution.getProjectId()),
+				eq(TEST_WORKFLOW), any(), any());
 	}
 
 	@Test
 	void workFlowCompleteWithInvalidJson() {
 		// given
 		WorkFlowExecution wfExecution = this.sampleWorkFlowExecution(WorkFlowStatus.IN_PROGRESS);
-		Mockito.when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses))
-				.thenReturn(List.of(wfExecution));
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.any()))
-				.thenReturn(Optional.of(sampleWorkFlowDefinition()));
+		when(this.workFlowRepository.findByStatusInAndIsMain(workFlowStatuses)).thenReturn(List.of(wfExecution));
+		when(this.workFlowDefinitionRepository.findById(any())).thenReturn(Optional.of(sampleWorkFlowDefinition()));
 		WorkFlowTaskDefinition wfTaskDef = sampleWorkFlowTaskDefinition();
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(Mockito.any())).thenReturn(Optional.of(wfTaskDef));
+		when(this.workFlowTaskDefinitionRepository.findById(any())).thenReturn(Optional.of(wfTaskDef));
 		WorkFlowTaskExecution workFlowTaskExecution = WorkFlowTaskExecution.builder().arguments("invalid")
 				.results("res").status(WorkFlowTaskStatus.FAILED).workFlowTaskDefinitionId(wfTaskDef.getId())
 				.workFlowExecutionId(wfExecution.getId()).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionId(wfExecution.getId()))
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionId(wfExecution.getId()))
 				.thenReturn(List.of(workFlowTaskExecution));
-		Mockito.doThrow(new RuntimeException("JsonParseException")).when(asyncWorkFlowContinuer)
-				.executeAsync(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+		doThrow(new RuntimeException("JsonParseException")).when(asyncWorkFlowContinuer).executeAsync(any(), any(),
+				any(), any());
 
 		// when
 		Exception exception = assertThrows(RuntimeException.class, () -> this.service.workFlowRunAfterStartup());
@@ -159,9 +149,8 @@ class WorkFlowContinuationServiceImplTest {
 		assertNotNull(exception);
 		assertTrue(exception.getMessage().contains("JsonParseException"));
 
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		Mockito.verify(this.asyncWorkFlowContinuer, Mockito.times(1)).executeAsync(Mockito.any(), Mockito.any(),
-				Mockito.any(), Mockito.any());
+		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
+		verify(this.asyncWorkFlowContinuer, times(1)).executeAsync(any(), any(), any(), any());
 	}
 
 	private WorkFlowExecution sampleWorkFlowExecution(WorkFlowStatus workFlowStatus) {

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/scheduler/WorkFlowSchedulerServiceImplTest.java
@@ -8,12 +8,17 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class WorkFlowSchedulerServiceImplTest {
 
@@ -31,39 +36,37 @@ class WorkFlowSchedulerServiceImplTest {
 
 	@BeforeEach
 	public void eachInit() {
-		this.taskScheduler = Mockito.mock(TaskScheduler.class);
+		this.taskScheduler = mock(TaskScheduler.class);
 		this.service = new WorkFlowSchedulerServiceImpl(taskScheduler);
 
-		this.work = Mockito.mock(Work.class);
+		this.work = mock(Work.class);
 		this.workFlow = SequentialFlow.Builder.aNewSequentialFlow().named(TEST).execute(work).build();
 	}
 
 	@Test
 	void scheduleWithValidData() {
 		// given
-		Mockito.when(this.taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(CronTrigger.class)))
-				.thenReturn(null);
+		when(this.taskScheduler.schedule(any(Runnable.class), any(CronTrigger.class))).thenReturn(null);
+
 		// when
 		this.service.schedule(UUID.randomUUID(), this.workFlow, new WorkContext(), CRON_EXPRESSION);
+
 		// then
-		Mockito.verify(this.taskScheduler, Mockito.times(1)).schedule(Mockito.any(Runnable.class),
-				Mockito.any(CronTrigger.class));
+		verify(this.taskScheduler, times(1)).schedule(any(Runnable.class), any(CronTrigger.class));
 	}
 
 	@Test
 	void workFlowIsNotScheduledTwice() {
 		UUID projectId = UUID.randomUUID();
 		// given
-		Mockito.when(this.taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(CronTrigger.class)))
-				.thenReturn(null);
+		when(this.taskScheduler.schedule(any(Runnable.class), any(CronTrigger.class))).thenReturn(null);
 		this.service.schedule(projectId, this.workFlow, new WorkContext(), CRON_EXPRESSION);
 
 		// when
 		this.service.schedule(projectId, this.workFlow, new WorkContext(), CRON_EXPRESSION);
 
 		// then
-		Mockito.verify(this.taskScheduler, Mockito.times(1)).schedule(Mockito.any(Runnable.class),
-				Mockito.any(CronTrigger.class));
+		verify(this.taskScheduler, times(1)).schedule(any(Runnable.class), any(CronTrigger.class));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -71,31 +74,30 @@ class WorkFlowSchedulerServiceImplTest {
 	void workFlowCanBeCancel() {
 		UUID projectId = UUID.randomUUID();
 		// given
-		var mockScheduledFuture = Mockito.mock(ScheduledFuture.class);
-		Mockito.when(mockScheduledFuture.cancel(false)).thenReturn(true);
-		Mockito.when(this.taskScheduler.schedule(Mockito.any(Runnable.class), Mockito.any(CronTrigger.class)))
-				.thenReturn(mockScheduledFuture);
+		var mockScheduledFuture = mock(ScheduledFuture.class);
+		when(mockScheduledFuture.cancel(false)).thenReturn(true);
+		when(this.taskScheduler.schedule(any(Runnable.class), any(CronTrigger.class))).thenReturn(mockScheduledFuture);
 		this.service.schedule(projectId, this.workFlow, new WorkContext(), CRON_EXPRESSION);
 
 		// when
 		this.service.stop(projectId, this.workFlow);
 
 		// then
-		Mockito.verify(mockScheduledFuture, Mockito.times(1)).cancel(Mockito.anyBoolean());
+		verify(mockScheduledFuture, times(1)).cancel(anyBoolean());
 	}
 
 	@Test
 	void workFlowIsNotCalledIfNoPresent() {
 		// given
 		@SuppressWarnings("rawtypes")
-		ScheduledFuture mockScheduledFuture = Mockito.mock(ScheduledFuture.class);
-		Mockito.when(mockScheduledFuture.cancel(Mockito.anyBoolean())).thenReturn(true);
+		ScheduledFuture mockScheduledFuture = mock(ScheduledFuture.class);
+		when(mockScheduledFuture.cancel(anyBoolean())).thenReturn(true);
 		// when
 		boolean res = this.service.stop(UUID.randomUUID(), this.workFlow);
 
 		// then
 		assertFalse(res);
-		Mockito.verify(mockScheduledFuture, Mockito.times(0)).cancel(Mockito.anyBoolean());
+		verify(mockScheduledFuture, times(0)).cancel(anyBoolean());
 	}
 
 }

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
@@ -25,11 +25,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.when;
 
 public class WorkFlowServiceDelegateTest {
 
@@ -47,11 +50,11 @@ public class WorkFlowServiceDelegateTest {
 
 	@BeforeEach
 	void initEach() {
-		this.workFlowRepository = Mockito.mock(WorkFlowRepository.class);
-		this.workFlowDefinitionRepository = Mockito.mock(WorkFlowDefinitionRepository.class);
-		this.workFlowTaskDefinitionRepository = Mockito.mock(WorkFlowTaskDefinitionRepository.class);
-		this.workFlowTaskRepository = Mockito.mock(WorkFlowTaskRepository.class);
-		this.workFlowWorkRepository = Mockito.mock(WorkFlowWorkRepository.class);
+		this.workFlowRepository = mock(WorkFlowRepository.class);
+		this.workFlowDefinitionRepository = mock(WorkFlowDefinitionRepository.class);
+		this.workFlowTaskDefinitionRepository = mock(WorkFlowTaskDefinitionRepository.class);
+		this.workFlowTaskRepository = mock(WorkFlowTaskRepository.class);
+		this.workFlowWorkRepository = mock(WorkFlowWorkRepository.class);
 
 		this.workFlowServiceDelegate = new WorkFlowServiceDelegate(this.workFlowDefinitionRepository,
 				this.workFlowTaskDefinitionRepository, this.workFlowRepository, this.workFlowTaskRepository,
@@ -139,34 +142,31 @@ public class WorkFlowServiceDelegateTest {
 				.workFlowDefinition(testSubWorkFlowDefinition1).build();
 		subWorkFlowWorkDefinition1.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowWorkRepository
-				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(Mockito.eq(workFlowDefinitionId)))
+		when(this.workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(eq(workFlowDefinitionId)))
 				.thenReturn(List.of(mainWorkFlowWorkDefinition1, mainWorkFlowWorkDefinition2));
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(Mockito.eq(testSubWorkFlowDefinitionId1)))
+		when(this.workFlowDefinitionRepository.findById(eq(testSubWorkFlowDefinitionId1)))
 				.thenReturn(Optional.of(testSubWorkFlowDefinition1));
 
-		Mockito.when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(
-				Mockito.eq(workFlowExecution), Mockito.eq(testSubWorkFlowDefinitionId1)))
-				.thenReturn(testSubWorkFlowExecution1);
+		when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(eq(workFlowExecution),
+				eq(testSubWorkFlowDefinitionId1))).thenReturn(testSubWorkFlowExecution1);
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(Mockito.eq(testSubWorkFlowTaskDefinitionId1)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(testSubWorkFlowTaskDefinitionId1)))
 				.thenReturn(Optional.of(testSubWorkFlowTaskDefinition1));
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(Mockito.eq(testWorkFlowTaskDefinitionId1)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(testWorkFlowTaskDefinitionId1)))
 				.thenReturn(Optional.of(testWorkFlowTaskDefinition1));
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-				Mockito.eq(testSubWorkFlowExecutionId1), Mockito.eq(testSubWorkFlowTaskDefinitionId1)))
-				.thenReturn(List.of(testSubWorkFlowTaskExecution1));
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
+				eq(testSubWorkFlowExecutionId1), eq(testSubWorkFlowTaskDefinitionId1)))
+						.thenReturn(List.of(testSubWorkFlowTaskExecution1));
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-				Mockito.eq(workFlowExecutionId), Mockito.eq(testWorkFlowTaskDefinitionId1)))
-				.thenReturn(List.of(testWorkFlowTaskExecution1));
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(eq(workFlowExecutionId),
+				eq(testWorkFlowTaskDefinitionId1))).thenReturn(List.of(testWorkFlowTaskExecution1));
 
-		Mockito.when(this.workFlowWorkRepository
-				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(Mockito.eq(testSubWorkFlowDefinitionId1)))
-				.thenReturn(List.of(subWorkFlowWorkDefinition1));
+		when(this.workFlowWorkRepository
+				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(eq(testSubWorkFlowDefinitionId1)))
+						.thenReturn(List.of(subWorkFlowWorkDefinition1));
 
 		// then
 		List<WorkStatusResponseDTO> workStatusResponseDTOs = this.workFlowServiceDelegate
@@ -256,37 +256,32 @@ public class WorkFlowServiceDelegateTest {
 			setupMasterWorkflow();
 			setupCheckerMapping();
 
-			Mockito.when(
-					workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlowDefinitionId))
+			when(workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlowDefinitionId))
 					.thenReturn(List.of(masterWorkflowWorkDefinition, checkerWorkflowWorkDefinition));
 
 			// master
-			Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-					masterWorkFlowExecutionId, subWorkFlowTaskDefinitionId))
-					.thenReturn(List.of(masterWorkFlowTaskExecution));
+			when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(masterWorkFlowExecutionId,
+					subWorkFlowTaskDefinitionId)).thenReturn(List.of(masterWorkFlowTaskExecution));
 
-			Mockito.when(workFlowTaskDefinitionRepository.findById(subWorkFlowTaskDefinitionId))
+			when(workFlowTaskDefinitionRepository.findById(subWorkFlowTaskDefinitionId))
 					.thenReturn(Optional.of(masterWorkFlowTaskDefinition));
 
-			Mockito.when(
-					workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlowDefinitionId))
+			when(workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(masterWorkFlowDefinitionId))
 					.thenReturn(List.of(masterWorkflowWorkDefinition));
 
 			// checker
-			Mockito.when(workFlowTaskDefinitionRepository.findById(checkerWorkFlowTaskDefinitionId))
+			when(workFlowTaskDefinitionRepository.findById(checkerWorkFlowTaskDefinitionId))
 					.thenReturn(Optional.of(checkerWorkFlowTaskDefinition));
 
-			Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-					masterWorkFlowExecutionId, checkerWorkFlowTaskDefinitionId))
-					.thenReturn(List.of(checkerWorkFlowTaskExecution));
+			when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(masterWorkFlowExecutionId,
+					checkerWorkFlowTaskDefinitionId)).thenReturn(List.of(checkerWorkFlowTaskExecution));
 
-			Mockito.when(
-					workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(checkerWorkFlowDefinitionId))
+			when(workFlowWorkRepository.findByWorkFlowDefinitionIdOrderByCreateDateAsc(checkerWorkFlowDefinitionId))
 					.thenReturn(List.of(checkerWorkflowWorkDefinition));
 
-			Mockito.when(workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(
-					Mockito.nullable(WorkFlowExecution.class), Mockito.eq(checkerWorkFlowDefinitionId)))
-					.thenReturn(checkerWorkflowExecution);
+			when(workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(
+					nullable(WorkFlowExecution.class), eq(checkerWorkFlowDefinitionId)))
+							.thenReturn(checkerWorkflowExecution);
 		}
 
 		@Test

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 
 import org.springframework.security.test.context.support.WithMockUser;
@@ -61,6 +60,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class WorkFlowServiceImplTest {
@@ -91,16 +95,16 @@ class WorkFlowServiceImplTest {
 
 	@BeforeEach
 	void initEach() {
-		this.workFlowDelegate = Mockito.mock(WorkFlowDelegate.class);
-		this.workFlowServiceDelegate = Mockito.mock(WorkFlowServiceDelegate.class);
-		this.workFlowRepository = Mockito.mock(WorkFlowRepository.class);
-		this.workFlowDefinitionRepository = Mockito.mock(WorkFlowDefinitionRepository.class);
-		this.workFlowTaskDefinitionRepository = Mockito.mock(WorkFlowTaskDefinitionRepository.class);
-		this.workFlowTaskRepository = Mockito.mock(WorkFlowTaskRepository.class);
-		this.workFlowWorkRepository = Mockito.mock(WorkFlowWorkRepository.class);
-		this.workFlowDefinitionService = Mockito.mock(WorkFlowDefinitionServiceImpl.class);
+		this.workFlowDelegate = mock(WorkFlowDelegate.class);
+		this.workFlowServiceDelegate = mock(WorkFlowServiceDelegate.class);
+		this.workFlowRepository = mock(WorkFlowRepository.class);
+		this.workFlowDefinitionRepository = mock(WorkFlowDefinitionRepository.class);
+		this.workFlowTaskDefinitionRepository = mock(WorkFlowTaskDefinitionRepository.class);
+		this.workFlowTaskRepository = mock(WorkFlowTaskRepository.class);
+		this.workFlowWorkRepository = mock(WorkFlowWorkRepository.class);
+		this.workFlowDefinitionService = mock(WorkFlowDefinitionServiceImpl.class);
 		this.metricRegistry = new SimpleMeterRegistry();
-		this.projectService = Mockito.mock(ProjectService.class);
+		this.projectService = mock(ProjectService.class);
 		this.modelMapper = new ModelMapper();
 
 		this.workFlowService = new WorkFlowServiceImpl(this.workFlowDelegate, this.workFlowServiceDelegate,
@@ -112,19 +116,17 @@ class WorkFlowServiceImplTest {
 	@Test
 	void executeTestWithValidData() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
 
-		Mockito.when(work.execute(Mockito.any()))
-				.thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext() {
-					{
-						put("foo", "bar");
-					}
-				}));
-		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
-		Mockito.when(this.workFlowDelegate.initWorkFlowContext(Mockito.any(), Mockito.any()))
-				.thenReturn(new WorkContext());
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(Mockito.any()))
+		when(work.execute(any())).thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext() {
+			{
+				put("foo", "bar");
+			}
+		}));
+		when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
+		when(this.workFlowDelegate.initWorkFlowContext(any(), any())).thenReturn(new WorkContext());
+		when(this.workFlowDefinitionRepository.findFirstByName(any()))
 				.thenReturn(this.sampleWorkflowDefinition("test"));
 
 		// when
@@ -138,15 +140,15 @@ class WorkFlowServiceImplTest {
 		assertNotNull(report.getWorkContext());
 		assertEquals(report.getWorkContext().get("foo"), "bar");
 
-		Mockito.verify(this.workFlowDelegate, Mockito.times(1)).getWorkFlowExecutionByName(Mockito.any());
-		Mockito.verify(work, Mockito.times(1)).execute(Mockito.any());
+		verify(this.workFlowDelegate, times(1)).getWorkFlowExecutionByName(any());
+		verify(work, times(1)).execute(any());
 
 	}
 
 	@Test
 	void executeTestWithNoValidWorkflow() {
 		// given
-		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName(Mockito.any())).thenReturn(null);
+		when(this.workFlowDelegate.getWorkFlowExecutionByName(any())).thenReturn(null);
 
 		// when
 		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
@@ -158,28 +160,26 @@ class WorkFlowServiceImplTest {
 
 		assertNotNull(report.getWorkContext());
 
-		Mockito.verify(this.workFlowDelegate, Mockito.times(1)).getWorkFlowExecutionByName(Mockito.any());
-		Mockito.verify(this.workFlowDelegate, Mockito.times(0)).initWorkFlowContext(Mockito.any(), Mockito.any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(0)).findFirstByName(Mockito.any());
+		verify(this.workFlowDelegate, times(1)).getWorkFlowExecutionByName(any());
+		verify(this.workFlowDelegate, times(0)).initWorkFlowContext(any(), any());
+		verify(this.workFlowDefinitionRepository, times(0)).findFirstByName(any());
 	}
 
 	@Test
 	void executeWithDTOWithValidData() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
-		Mockito.when(work.execute(Mockito.any()))
-				.thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext() {
-					{
-						put("foo", "bar");
-					}
-				}));
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(Mockito.any()))
+		when(work.execute(any())).thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext() {
+			{
+				put("foo", "bar");
+			}
+		}));
+		when(this.workFlowDefinitionRepository.findFirstByName(any()))
 				.thenReturn(this.sampleWorkflowDefinition("test"));
-		Mockito.when(this.workFlowWorkRepository.findFirstByWorkDefinitionId(Mockito.any())).thenReturn(null);
-		Mockito.when(this.workFlowDelegate.initWorkFlowContext(Mockito.any(), Mockito.any()))
-				.thenReturn(new WorkContext());
-		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
+		when(this.workFlowWorkRepository.findFirstByWorkDefinitionId(any())).thenReturn(null);
+		when(this.workFlowDelegate.initWorkFlowContext(any(), any())).thenReturn(new WorkContext());
+		when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
 
 		// when
 		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
@@ -191,22 +191,22 @@ class WorkFlowServiceImplTest {
 
 		assertNotNull(report.getWorkContext());
 
-		Mockito.verify(this.workFlowDelegate, Mockito.times(2)).getWorkFlowExecutionByName(Mockito.any());
-		Mockito.verify(this.workFlowDelegate, Mockito.times(1)).initWorkFlowContext(Mockito.any(), Mockito.any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(Mockito.any());
+		verify(this.workFlowDelegate, times(2)).getWorkFlowExecutionByName(any());
+		verify(this.workFlowDelegate, times(1)).initWorkFlowContext(any(), any());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
 	}
 
 	@Test
 	void executeWithDTOWithNoMainWorkFlow() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(Mockito.any()))
+		when(this.workFlowDefinitionRepository.findFirstByName(any()))
 				.thenReturn(this.sampleWorkflowDefinition("test"));
-		Mockito.when(this.workFlowWorkRepository.findFirstByWorkDefinitionId(Mockito.any()))
+		when(this.workFlowWorkRepository.findFirstByWorkDefinitionId(any()))
 				.thenReturn(WorkFlowWorkDefinition.builder().build());
 
-		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
+		when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
 
 		// when
 		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
@@ -218,18 +218,18 @@ class WorkFlowServiceImplTest {
 
 		assertNotNull(report.getWorkContext());
 
-		Mockito.verify(this.workFlowDelegate, Mockito.times(1)).getWorkFlowExecutionByName(Mockito.any());
-		Mockito.verify(this.workFlowDelegate, Mockito.times(0)).initWorkFlowContext(Mockito.any(), Mockito.any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(Mockito.any());
+		verify(this.workFlowDelegate, times(1)).getWorkFlowExecutionByName(any());
+		verify(this.workFlowDelegate, times(0)).initWorkFlowContext(any(), any());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
 	}
 
 	@Test
 	void executeWithDTOWithNoWorkFlowDefinition() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
-		Mockito.when(this.workFlowDefinitionRepository.findFirstByName(Mockito.any())).thenReturn(null);
-		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(null);
+		when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
 
 		// when
 		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
@@ -241,10 +241,10 @@ class WorkFlowServiceImplTest {
 
 		assertNotNull(report.getWorkContext());
 
-		Mockito.verify(this.workFlowDelegate, Mockito.times(1)).getWorkFlowExecutionByName(Mockito.any());
-		Mockito.verify(this.workFlowDelegate, Mockito.never()).initWorkFlowContext(Mockito.any(), Mockito.any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findFirstByName(Mockito.any());
-		Mockito.verify(this.workFlowWorkRepository, Mockito.never()).findFirstByWorkDefinitionId(Mockito.any());
+		verify(this.workFlowDelegate, times(1)).getWorkFlowExecutionByName(any());
+		verify(this.workFlowDelegate, never()).initWorkFlowContext(any(), any());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
+		verify(this.workFlowWorkRepository, never()).findFirstByWorkDefinitionId(any());
 	}
 
 	@Test
@@ -254,7 +254,7 @@ class WorkFlowServiceImplTest {
 
 		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().status(WorkFlowStatus.COMPLETED).build();
 		workFlowExecution.setId(id);
-		Mockito.when(this.workFlowRepository.findById(id)).thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(id)).thenReturn(Optional.of(workFlowExecution));
 
 		// when
 		WorkFlowExecution res = this.workFlowService.getWorkFlowById(id);
@@ -272,7 +272,7 @@ class WorkFlowServiceImplTest {
 
 		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().status(WorkFlowStatus.COMPLETED).build();
 		workFlowExecution.setId(id);
-		Mockito.when(this.workFlowRepository.findById(id)).thenReturn(Optional.empty());
+		when(this.workFlowRepository.findById(id)).thenReturn(Optional.empty());
 
 		// when
 		WorkFlowExecution res = this.workFlowService.getWorkFlowById(id);
@@ -292,7 +292,7 @@ class WorkFlowServiceImplTest {
 		WorkFlowExecution mainWorkFlowExecution = WorkFlowExecution.builder().status(WorkFlowStatus.COMPLETED).build();
 		mainWorkFlowExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowRepository.save(Mockito.any())).thenReturn(workFlowExecution);
+		when(this.workFlowRepository.save(any())).thenReturn(workFlowExecution);
 
 		// when
 		WorkFlowExecution res = this.workFlowService.saveWorkFlow(projectId, workflowDefID, WorkFlowStatus.COMPLETED,
@@ -302,7 +302,7 @@ class WorkFlowServiceImplTest {
 		assertNotNull(res);
 
 		ArgumentCaptor<WorkFlowExecution> argument = ArgumentCaptor.forClass(WorkFlowExecution.class);
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowRepository, times(1)).save(argument.capture());
 		assertEquals(argument.getValue().getStatus().toString(), "COMPLETED");
 		assertEquals(argument.getValue().getProjectId().toString(), projectId.toString());
 		assertEquals(argument.getValue().getWorkFlowDefinitionId().toString(), workflowDefID.toString());
@@ -317,7 +317,7 @@ class WorkFlowServiceImplTest {
 		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().status(WorkFlowStatus.COMPLETED)
 				.projectId(projectId).workFlowDefinitionId(workflowDefID).build();
 		workFlowExecution.setId(UUID.randomUUID());
-		Mockito.when(this.workFlowRepository.save(Mockito.any())).thenReturn(workFlowExecution);
+		when(this.workFlowRepository.save(any())).thenReturn(workFlowExecution);
 
 		// when
 		WorkFlowExecution res = this.workFlowService.updateWorkFlow(workFlowExecution);
@@ -326,7 +326,7 @@ class WorkFlowServiceImplTest {
 		assertNotNull(res);
 
 		ArgumentCaptor<WorkFlowExecution> argument = ArgumentCaptor.forClass(WorkFlowExecution.class);
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowRepository, times(1)).save(argument.capture());
 		assertEquals(argument.getValue().getStatus().toString(), "COMPLETED");
 		assertEquals(argument.getValue().getProjectId().toString(), projectId.toString());
 		assertEquals(argument.getValue().getWorkFlowDefinitionId().toString(), workflowDefID.toString());
@@ -351,7 +351,7 @@ class WorkFlowServiceImplTest {
 				.workFlowExecutionId(wfExecutionID).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
 				wfTaskDefID)).thenReturn(List.of(workFlowTaskExecution));
 		// when
 
@@ -371,14 +371,14 @@ class WorkFlowServiceImplTest {
 		// given
 		UUID wfTaskDefID = UUID.randomUUID();
 		UUID wfExecutionID = UUID.randomUUID();
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
 				wfTaskDefID)).thenReturn(null);
 
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.getWorkFlowTask(wfExecutionID, wfTaskDefID);
 		// then
 		assertNull(res);
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(1))
+		verify(this.workFlowTaskRepository, times(1))
 				.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID, wfTaskDefID);
 	}
 
@@ -387,14 +387,14 @@ class WorkFlowServiceImplTest {
 		// given
 		UUID wfTaskDefID = UUID.randomUUID();
 		UUID wfExecutionID = UUID.randomUUID();
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
 				wfTaskDefID)).thenReturn(new LinkedList<>());
 
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.getWorkFlowTask(wfExecutionID, wfTaskDefID);
 		// then
 		assertNull(res);
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(1))
+		verify(this.workFlowTaskRepository, times(1))
 				.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID, wfTaskDefID);
 	}
 
@@ -409,7 +409,7 @@ class WorkFlowServiceImplTest {
 				.workFlowExecutionId(wfExecutionID).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.save(Mockito.any())).thenReturn(workFlowTaskExecution);
+		when(this.workFlowTaskRepository.save(any())).thenReturn(workFlowTaskExecution);
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.saveWorkFlowTask("arguments", wfTaskDefID, wfExecutionID,
 				WorkFlowTaskStatus.COMPLETED);
@@ -418,7 +418,7 @@ class WorkFlowServiceImplTest {
 		assertNotNull(res);
 
 		ArgumentCaptor<WorkFlowTaskExecution> argument = ArgumentCaptor.forClass(WorkFlowTaskExecution.class);
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowTaskRepository, times(1)).save(argument.capture());
 		assertEquals(argument.getValue().getStatus().toString(), "COMPLETED");
 		assertEquals(argument.getValue().getWorkFlowExecutionId().toString(), wfExecutionID.toString());
 		assertEquals(argument.getValue().getWorkFlowTaskDefinitionId().toString(), wfTaskDefID.toString());
@@ -437,7 +437,7 @@ class WorkFlowServiceImplTest {
 				.workFlowExecutionId(wfExecutionID).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.save(Mockito.any())).thenReturn(workFlowTaskExecution);
+		when(this.workFlowTaskRepository.save(any())).thenReturn(workFlowTaskExecution);
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.updateWorkFlowTask(workFlowTaskExecution);
 
@@ -445,7 +445,7 @@ class WorkFlowServiceImplTest {
 		assertNotNull(res);
 
 		ArgumentCaptor<WorkFlowTaskExecution> argument = ArgumentCaptor.forClass(WorkFlowTaskExecution.class);
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowTaskRepository, times(1)).save(argument.capture());
 		assertEquals(argument.getValue().getStatus().toString(), "COMPLETED");
 		assertEquals(argument.getValue().getWorkFlowExecutionId().toString(), wfExecutionID.toString());
 		assertEquals(argument.getValue().getWorkFlowTaskDefinitionId().toString(), wfTaskDefID.toString());
@@ -517,33 +517,31 @@ class WorkFlowServiceImplTest {
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTask1Definition));
 
 		// when
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
+		when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
 				.thenReturn(Optional.of(workFlowDefinition));
 
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(testSubWorkFlow1DefinitionId)))
+		when(this.workFlowDefinitionRepository.findById(eq(testSubWorkFlow1DefinitionId)))
 				.thenReturn(Optional.of(subWorkFlow1Definition));
 
-		Mockito.when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(
-				eq(workFlowExecution), eq(testSubWorkFlow1DefinitionId))).thenReturn(subWorkFlow1Execution);
+		when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(eq(workFlowExecution),
+				eq(testSubWorkFlow1DefinitionId))).thenReturn(subWorkFlow1Execution);
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(eq(subWorkFlow1Task1DefinitionId)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(subWorkFlow1Task1DefinitionId)))
 				.thenReturn(Optional.of(subWorkFlow1Task1Definition));
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(eq(workFlowTask1DefinitionId)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(workFlowTask1DefinitionId)))
 				.thenReturn(Optional.of(workFlowTask1Definition));
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
 				eq(testSubWorkFlow1ExecutionId), eq(subWorkFlow1Task1DefinitionId)))
-				.thenReturn(List.of(subWorkFlow1Task1Execution));
+						.thenReturn(List.of(subWorkFlow1Task1Execution));
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-				eq(workFlowExecutionId), eq(workFlowTask1DefinitionId))).thenReturn(List.of(workFlowTask1Execution));
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(eq(workFlowExecutionId),
+				eq(workFlowTask1DefinitionId))).thenReturn(List.of(workFlowTask1Execution));
 
-		Mockito.when(
-				this.workFlowServiceDelegate.getWorkFlowAndWorksStatus(eq(workFlowExecution), eq(workFlowDefinition)))
+		when(this.workFlowServiceDelegate.getWorkFlowAndWorksStatus(eq(workFlowExecution), eq(workFlowDefinition)))
 				.thenReturn(List.of(
 						WorkStatusResponseDTO.builder().name(SUB_WORKFLOW_1_NAME).type(WorkType.WORKFLOW)
 								.status(com.redhat.parodos.workflow.enums.ParodosWorkStatus.PENDING)
@@ -592,15 +590,14 @@ class WorkFlowServiceImplTest {
 		UUID workFlowExecutionId = UUID.randomUUID();
 
 		// when
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.empty());
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.empty());
 
 		assertThrows(ResponseStatusException.class, () -> {
 			this.workFlowService.getWorkFlowStatus(workFlowExecutionId);
 		});
 
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findById(any());
-		Mockito.verify(this.workFlowWorkRepository, Mockito.never())
-				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(any());
+		verify(this.workFlowRepository, times(1)).findById(any());
+		verify(this.workFlowWorkRepository, never()).findByWorkFlowDefinitionIdOrderByCreateDateAsc(any());
 	}
 
 	@Test
@@ -608,22 +605,20 @@ class WorkFlowServiceImplTest {
 		// workflow (main)
 		UUID workFlowExecutionId = UUID.randomUUID();
 		UUID workFlowDefinitionId = UUID.randomUUID();
-		WorkFlowExecution workFlowExecution = Mockito.mock(WorkFlowExecution.class);
+		WorkFlowExecution workFlowExecution = mock(WorkFlowExecution.class);
 
 		// when
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId))).thenReturn(Optional.empty());
+		when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId))).thenReturn(Optional.empty());
 
 		assertThrows(ResponseStatusException.class, () -> {
 			this.workFlowService.getWorkFlowStatus(workFlowExecutionId);
 		});
 
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findById(any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findById(any());
-		Mockito.verify(this.workFlowServiceDelegate, Mockito.never()).getWorkFlowAndWorksStatus(eq(workFlowExecution),
-				Mockito.any());
+		verify(this.workFlowRepository, times(1)).findById(any());
+		verify(this.workFlowDefinitionRepository, times(1)).findById(any());
+		verify(this.workFlowServiceDelegate, never()).getWorkFlowAndWorksStatus(eq(workFlowExecution), any());
 	}
 
 	@Test
@@ -631,25 +626,24 @@ class WorkFlowServiceImplTest {
 		// workflow
 		UUID workFlowExecutionId = UUID.randomUUID();
 		UUID workFlowDefinitionId = UUID.randomUUID();
-		WorkFlowExecution workFlowExecution = Mockito.mock(WorkFlowExecution.class);
-		WorkFlowDefinition workFlowDefinition = Mockito.mock(WorkFlowDefinition.class);
+		WorkFlowExecution workFlowExecution = mock(WorkFlowExecution.class);
+		WorkFlowDefinition workFlowDefinition = mock(WorkFlowDefinition.class);
 
 		// when
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
+		when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
 				.thenReturn(Optional.of(workFlowDefinition));
 
-		Mockito.when(workFlowExecution.getMainWorkFlowExecution()).thenReturn(null);
+		when(workFlowExecution.getMainWorkFlowExecution()).thenReturn(null);
 
 		assertThrows(ResponseStatusException.class, () -> {
 			this.workFlowService.getWorkFlowStatus(workFlowExecutionId);
 		});
 
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findById(any());
-		Mockito.verify(this.workFlowDefinitionRepository, Mockito.times(1)).findById(any());
-		Mockito.verify(this.workFlowServiceDelegate, Mockito.never()).getWorkFlowAndWorksStatus(eq(workFlowExecution),
+		verify(this.workFlowRepository, times(1)).findById(any());
+		verify(this.workFlowDefinitionRepository, times(1)).findById(any());
+		verify(this.workFlowServiceDelegate, never()).getWorkFlowAndWorksStatus(eq(workFlowExecution),
 				eq(workFlowDefinition));
 	}
 
@@ -703,32 +697,30 @@ class WorkFlowServiceImplTest {
 		workFlowDefinition.setWorkFlowTaskDefinitions(List.of(workFlowTask1Definition));
 
 		// when
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
+		when(this.workFlowDefinitionRepository.findById(eq(workFlowDefinitionId)))
 				.thenReturn(Optional.of(workFlowDefinition));
 
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
-		Mockito.when(this.workFlowDefinitionRepository.findById(eq(subWorkFlow1DefinitionId)))
+		when(this.workFlowDefinitionRepository.findById(eq(subWorkFlow1DefinitionId)))
 				.thenReturn(Optional.of(subWorkFlow1Definition));
 
-		Mockito.when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(
-				eq(workFlowExecution), eq(subWorkFlow1DefinitionId))).thenReturn(null);
+		when(this.workFlowRepository.findFirstByMainWorkFlowExecutionAndWorkFlowDefinitionId(eq(workFlowExecution),
+				eq(subWorkFlow1DefinitionId))).thenReturn(null);
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(eq(subWorkFlow1Task1DefinitionId)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(subWorkFlow1Task1DefinitionId)))
 				.thenReturn(Optional.of(subWorkFlow1Task1Definition));
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findById(eq(workFlowTask1DefinitionId)))
+		when(this.workFlowTaskDefinitionRepository.findById(eq(workFlowTask1DefinitionId)))
 				.thenReturn(Optional.of(workFlowTask1Definition));
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-				eq(subWorkFlow1ExecutionId), eq(subWorkFlow1Task1DefinitionId))).thenReturn(List.of());
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(eq(subWorkFlow1ExecutionId),
+				eq(subWorkFlow1Task1DefinitionId))).thenReturn(List.of());
 
-		Mockito.when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(
-				eq(workFlowExecutionId), eq(workFlowTask1DefinitionId))).thenReturn(List.of());
+		when(workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(eq(workFlowExecutionId),
+				eq(workFlowTask1DefinitionId))).thenReturn(List.of());
 
-		Mockito.when(
-				this.workFlowServiceDelegate.getWorkFlowAndWorksStatus(eq(workFlowExecution), eq(workFlowDefinition)))
+		when(this.workFlowServiceDelegate.getWorkFlowAndWorksStatus(eq(workFlowExecution), eq(workFlowDefinition)))
 				.thenReturn(List.of(
 						WorkStatusResponseDTO.builder().name(SUB_WORKFLOW_1_NAME).type(WorkType.WORKFLOW)
 								.status(com.redhat.parodos.workflow.enums.ParodosWorkStatus.PENDING)
@@ -777,8 +769,7 @@ class WorkFlowServiceImplTest {
 		WorkFlowExecution mainWorkFlowExecution = WorkFlowExecution.builder().status(WorkFlowStatus.FAILED)
 				.projectId(projectId).workFlowDefinitionId(UUID.randomUUID()).build();
 		mainWorkFlowExecution.setId(workFlowExecutionId);
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(mainWorkFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(mainWorkFlowExecution));
 
 		// workflow checker definition
 		WorkFlowDefinition workFlowDefinition = WorkFlowDefinition.builder().name(workFlowCheckerName).build();
@@ -787,29 +778,28 @@ class WorkFlowServiceImplTest {
 		WorkFlowTaskDefinition workFlowCheckerTaskDefinition = WorkFlowTaskDefinition.builder()
 				.workFlowDefinition(workFlowDefinition).name(workFlowCheckerTaskName).build();
 		workFlowCheckerTaskDefinition.setId(UUID.randomUUID());
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByNameAndWorkFlowDefinitionType(Mockito.any(),
-				Mockito.any())).thenReturn(workFlowCheckerTaskDefinition);
+		when(this.workFlowTaskDefinitionRepository.findFirstByNameAndWorkFlowDefinitionType(any(), any()))
+				.thenReturn(workFlowCheckerTaskDefinition);
 
 		// workflow checker task execution
 		WorkFlowExecution workFlowCheckerExecution = WorkFlowExecution.builder().status(WorkFlowStatus.IN_PROGRESS)
 				.projectId(projectId).workFlowDefinitionId(workFlowCheckerDefinitionId).build();
 		workFlowCheckerExecution.setId(UUID.randomUUID());
-		Mockito.when(this.workFlowRepository.findByMainWorkFlowExecution(Mockito.any()))
-				.thenReturn(List.of(workFlowCheckerExecution));
+		when(this.workFlowRepository.findByMainWorkFlowExecution(any())).thenReturn(List.of(workFlowCheckerExecution));
 
 		WorkFlowTaskExecution workFlowTaskExecution = WorkFlowTaskExecution.builder().arguments("test").results("res")
 				.status(WorkFlowTaskStatus.FAILED).workFlowTaskDefinitionId(workFlowCheckerTaskDefinition.getId())
 				.workFlowExecutionId(workFlowCheckerExecution.getId()).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(Mockito.any(),
-				Mockito.any())).thenReturn(List.of(workFlowTaskExecution));
+		when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(any(), any()))
+				.thenReturn(List.of(workFlowTaskExecution));
 
 		this.workFlowService.updateWorkFlowCheckerTaskStatus(workFlowExecutionId, workFlowCheckerTaskName,
 				WorkFlowTaskStatus.COMPLETED);
 
 		// then
 		ArgumentCaptor<WorkFlowTaskExecution> argument = ArgumentCaptor.forClass(WorkFlowTaskExecution.class);
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(1)).save(argument.capture());
+		verify(this.workFlowTaskRepository, times(1)).save(argument.capture());
 		assertEquals(argument.getValue().getWorkFlowTaskDefinitionId(), workFlowCheckerTaskDefinition.getId());
 		assertEquals(argument.getValue().getWorkFlowExecutionId(), workFlowCheckerExecution.getId());
 		assertEquals(argument.getValue().getStatus(), WorkFlowTaskStatus.COMPLETED);
@@ -824,14 +814,14 @@ class WorkFlowServiceImplTest {
 		String workFlowCheckerTaskName = "testWorkFlowTask";
 
 		// when
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.empty());
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.empty());
 
 		assertThrows(ResponseStatusException.class, () -> {
 			this.workFlowService.updateWorkFlowCheckerTaskStatus(workFlowExecutionId, workFlowCheckerTaskName,
 					WorkFlowTaskStatus.COMPLETED);
 		});
 
-		Mockito.verify(this.workFlowTaskRepository, Mockito.times(0)).save(any());
+		verify(this.workFlowTaskRepository, times(0)).save(any());
 	}
 
 	@Test
@@ -843,11 +833,11 @@ class WorkFlowServiceImplTest {
 		String workFlowCheckerTaskName = "testWorkFlowTask";
 
 		// when
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
 				.thenReturn(Optional.of(WorkFlowExecution.builder().status(WorkFlowStatus.FAILED)
 						.projectId(UUID.randomUUID()).workFlowDefinitionId(UUID.randomUUID()).build()));
 
-		Mockito.when(this.workFlowTaskDefinitionRepository.findFirstByNameAndWorkFlowDefinitionType(any(), any()))
+		when(this.workFlowTaskDefinitionRepository.findFirstByNameAndWorkFlowDefinitionType(any(), any()))
 				.thenReturn(null);
 
 		// then
@@ -856,7 +846,7 @@ class WorkFlowServiceImplTest {
 					WorkFlowTaskStatus.COMPLETED);
 		});
 
-		Mockito.verify(this.workFlowTaskRepository, Mockito.never()).save(any());
+		verify(this.workFlowTaskRepository, never()).save(any());
 
 	}
 
@@ -864,25 +854,24 @@ class WorkFlowServiceImplTest {
 	public void testGetWorkflowParametersWithWorkflowOptions() {
 		// given
 		UUID workFlowExecutionId = UUID.randomUUID();
-		WorkFlowExecution workFlowExecution = Mockito.mock(WorkFlowExecution.class);
-		Mockito.when(workFlowExecution.getId()).thenReturn(workFlowExecutionId);
-		WorkFlowExecutionContext executionContext = Mockito.mock(WorkFlowExecutionContext.class);
-		Mockito.when(workFlowExecution.getWorkFlowExecutionContext()).thenReturn(executionContext);
+		WorkFlowExecution workFlowExecution = mock(WorkFlowExecution.class);
+		when(workFlowExecution.getId()).thenReturn(workFlowExecutionId);
+		WorkFlowExecutionContext executionContext = mock(WorkFlowExecutionContext.class);
+		when(workFlowExecution.getWorkFlowExecutionContext()).thenReturn(executionContext);
 		WorkContext workContext = new WorkContext();
 		WorkContextDelegate.write(workContext, WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION,
 				WorkContextDelegate.Resource.WORKFLOW_OPTIONS,
 				Map.of("newOptions", List.of(new WorkFlowOption.Builder("test-id", "test-workflow").build())));
-		Mockito.when(executionContext.getWorkContext()).thenReturn(workContext);
+		when(executionContext.getWorkContext()).thenReturn(workContext);
 
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
 		// when
 		WorkFlowContextResponseDTO workflowParameters = this.workFlowService.getWorkflowParameters(workFlowExecutionId,
 				List.of(WorkContextDelegate.Resource.WORKFLOW_OPTIONS));
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findById(any());
+		verify(this.workFlowRepository, times(1)).findById(any());
 		assertNotNull(workflowParameters);
 		assertNotNull(workflowParameters.getWorkFlowOptions());
 		assertEquals(workFlowExecutionId, workflowParameters.getWorkFlowExecutionId());
@@ -898,21 +887,20 @@ class WorkFlowServiceImplTest {
 	public void testGetWorkflowParametersWithoutWorkflowOptions() {
 		// given
 		UUID workFlowExecutionId = UUID.randomUUID();
-		WorkFlowExecution workFlowExecution = Mockito.mock(WorkFlowExecution.class);
-		Mockito.when(workFlowExecution.getId()).thenReturn(workFlowExecutionId);
-		WorkFlowExecutionContext executionContext = Mockito.mock(WorkFlowExecutionContext.class);
-		Mockito.when(workFlowExecution.getWorkFlowExecutionContext()).thenReturn(executionContext);
-		Mockito.when(executionContext.getWorkContext()).thenReturn(new WorkContext());
+		WorkFlowExecution workFlowExecution = mock(WorkFlowExecution.class);
+		when(workFlowExecution.getId()).thenReturn(workFlowExecutionId);
+		WorkFlowExecutionContext executionContext = mock(WorkFlowExecutionContext.class);
+		when(workFlowExecution.getWorkFlowExecutionContext()).thenReturn(executionContext);
+		when(executionContext.getWorkContext()).thenReturn(new WorkContext());
 
-		Mockito.when(this.workFlowRepository.findById(eq(workFlowExecutionId)))
-				.thenReturn(Optional.of(workFlowExecution));
+		when(this.workFlowRepository.findById(eq(workFlowExecutionId))).thenReturn(Optional.of(workFlowExecution));
 
 		// when
 		WorkFlowContextResponseDTO workflowParameters = this.workFlowService.getWorkflowParameters(workFlowExecutionId,
 				List.of(WorkContextDelegate.Resource.WORKFLOW_OPTIONS));
 
 		// then
-		Mockito.verify(this.workFlowRepository, Mockito.times(1)).findById(any());
+		verify(this.workFlowRepository, times(1)).findById(any());
 		assertNotNull(workflowParameters);
 		assertNotNull(workflowParameters.getWorkFlowOptions());
 		assertEquals(workFlowExecutionId, workflowParameters.getWorkFlowExecutionId());
@@ -931,10 +919,10 @@ class WorkFlowServiceImplTest {
 		workFlowExecution.setId(workflowExecutionId);
 		List<WorkStatusResponseDTO> workStatusResponseDTOList = List
 				.of(WorkStatusResponseDTO.builder().name(workName).status(ParodosWorkStatus.COMPLETED).build());
-		Mockito.when(workFlowRepository.findAllByProjectId(projectId)).thenReturn(List.of(workFlowExecution));
-		Mockito.when(projectService.getProjectByIdAndUsername(eq(projectId), nullable(String.class)))
+		when(workFlowRepository.findAllByProjectId(projectId)).thenReturn(List.of(workFlowExecution));
+		when(projectService.getProjectByIdAndUsername(eq(projectId), nullable(String.class)))
 				.thenReturn(ProjectResponseDTO.builder().id(projectId).name("test-project").build());
-		Mockito.when(workFlowDefinitionService.getWorkFlowDefinitionById(any()))
+		when(workFlowDefinitionService.getWorkFlowDefinitionById(any()))
 				.thenReturn(WorkFlowDefinitionResponseDTO.builder().name("test").build());
 
 		assertThat(workFlowService.getWorkFlowsByProjectId(projectId)).hasSize(1).extracting("workStatus")
@@ -956,12 +944,12 @@ class WorkFlowServiceImplTest {
 				.status(WorkFlowStatus.FAILED).build();
 		workFlowExecution2.setId(workflowExecution2Id);
 
-		Mockito.when(workFlowRepository.findAllByProjectId(project1Id)).thenReturn(List.of(workFlowExecution1));
-		Mockito.when(workFlowRepository.findAllByProjectId(project2Id)).thenReturn(List.of(workFlowExecution2));
-		Mockito.when(projectService.findProjectsByUserName(nullable(String.class)))
+		when(workFlowRepository.findAllByProjectId(project1Id)).thenReturn(List.of(workFlowExecution1));
+		when(workFlowRepository.findAllByProjectId(project2Id)).thenReturn(List.of(workFlowExecution2));
+		when(projectService.findProjectsByUserName(nullable(String.class)))
 				.thenReturn(List.of(ProjectResponseDTO.builder().id(project1Id).name("test-project1").build(),
 						ProjectResponseDTO.builder().id(project2Id).name("test-project2").build()));
-		Mockito.when(workFlowDefinitionService.getWorkFlowDefinitionById(any()))
+		when(workFlowDefinitionService.getWorkFlowDefinitionById(any()))
 				.thenReturn(WorkFlowDefinitionResponseDTO.builder().name("test").build());
 
 		assertThat(workFlowService.getWorkFlows()).hasSize(2).extracting("workStatus").contains(WorkStatus.COMPLETED,
@@ -972,7 +960,7 @@ class WorkFlowServiceImplTest {
 	void getWorkFlowsByProjectId_when_projectIsNotFound_then_returnException() {
 		UUID projectId = UUID.randomUUID();
 
-		Mockito.when(projectService.getProjectById(projectId)).thenReturn(null);
+		when(projectService.getProjectById(projectId)).thenReturn(null);
 
 		assertThrows(RuntimeException.class, () -> workFlowService.getWorkFlowsByProjectId(projectId));
 	}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
@@ -9,7 +9,6 @@ import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -18,6 +17,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 class BeanWorkFlowRegistryImplTest {
 
@@ -35,8 +35,8 @@ class BeanWorkFlowRegistryImplTest {
 
 	@BeforeEach
 	public void initEach() {
-		this.beanFactory = Mockito.mock(ConfigurableListableBeanFactory.class);
-		this.workFlowDefinitionService = Mockito.mock(WorkFlowDefinitionServiceImpl.class);
+		this.beanFactory = mock(ConfigurableListableBeanFactory.class);
+		this.workFlowDefinitionService = mock(WorkFlowDefinitionServiceImpl.class);
 	}
 
 	@Test
@@ -47,23 +47,21 @@ class BeanWorkFlowRegistryImplTest {
 		registry.postInit();
 
 		// then
-		Mockito.verify(this.beanFactory, Mockito.times(0)).getDependenciesForBean(Mockito.any());
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(0)).save(Mockito.any(), Mockito.any(),
-				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+		verify(this.beanFactory, times(0)).getDependenciesForBean(any());
+		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
 	void TestRegistryWithValidWorkflows() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named(TEST).execute(work).build();
 
-		Mockito.when(this.beanFactory.getDependenciesForBean(Mockito.any()))
-				.thenReturn(new String[] { FOO_DEPENDENCY });
-		AnnotatedTypeMetadata bean = Mockito.mock(AnnotatedTypeMetadata.class);
-		BeanDefinition beanDefinition = Mockito.mock(BeanDefinition.class);
-		Mockito.when(beanDefinition.getSource()).thenReturn(bean);
-		Mockito.when(this.beanFactory.getBeanDefinition(Mockito.any())).thenReturn(beanDefinition);
+		when(this.beanFactory.getDependenciesForBean(any())).thenReturn(new String[] { FOO_DEPENDENCY });
+		AnnotatedTypeMetadata bean = mock(AnnotatedTypeMetadata.class);
+		BeanDefinition beanDefinition = mock(BeanDefinition.class);
+		when(beanDefinition.getSource()).thenReturn(bean);
+		when(this.beanFactory.getBeanDefinition(any())).thenReturn(beanDefinition);
 
 		// when
 		BeanWorkFlowRegistryImpl registry = new BeanWorkFlowRegistryImpl(this.beanFactory, new HashMap<>() {
@@ -75,11 +73,10 @@ class BeanWorkFlowRegistryImplTest {
 		registry.postInit();
 
 		// then
-		Mockito.verify(this.beanFactory, Mockito.times(1)).getDependenciesForBean(Mockito.any());
+		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
 
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).save(Mockito.eq(TEST),
-				Mockito.eq(WorkFlowType.ASSESSMENT), Mockito.any(), Mockito.anyList(), Mockito.anyList(),
-				Mockito.eq(WorkFlowProcessingType.SEQUENTIAL));
+		verify(this.workFlowDefinitionService, times(1)).save(eq(TEST), eq(WorkFlowType.ASSESSMENT), any(), anyList(),
+				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL));
 
 		assertEquals(registry.getWorkFlowByName(TEST), workFlow);
 	}
@@ -87,18 +84,16 @@ class BeanWorkFlowRegistryImplTest {
 	@Test
 	void TestRegistryWithValidWorkflowTasks() {
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named(TEST).execute(work).build();
 
-		Mockito.when(this.beanFactory.getDependenciesForBean(Mockito.eq(TEST)))
-				.thenReturn(new String[] { FOO_DEPENDENCY });
-		AnnotatedTypeMetadata bean = Mockito.mock(AnnotatedTypeMetadata.class);
-		BeanDefinition beanDefinition = Mockito.mock(BeanDefinition.class);
-		Mockito.when(beanDefinition.getSource()).thenReturn(bean);
-		Mockito.when(this.beanFactory.getBeanDefinition(Mockito.any())).thenReturn(beanDefinition);
+		when(this.beanFactory.getDependenciesForBean(eq(TEST))).thenReturn(new String[] { FOO_DEPENDENCY });
+		AnnotatedTypeMetadata bean = mock(AnnotatedTypeMetadata.class);
+		BeanDefinition beanDefinition = mock(BeanDefinition.class);
+		when(beanDefinition.getSource()).thenReturn(bean);
+		when(this.beanFactory.getBeanDefinition(any())).thenReturn(beanDefinition);
 
-		Mockito.when(this.beanFactory.getDependenciesForBean(Mockito.eq(TEST_TASK)))
-				.thenReturn(new String[] { TASK_DEPENDENCY });
+		when(this.beanFactory.getDependenciesForBean(eq(TEST_TASK))).thenReturn(new String[] { TASK_DEPENDENCY });
 
 		// when
 		BeanWorkFlowRegistryImpl registry = new BeanWorkFlowRegistryImpl(this.beanFactory, new HashMap<>() {
@@ -109,13 +104,11 @@ class BeanWorkFlowRegistryImplTest {
 		registry.postInit();
 
 		// then
-		Mockito.verify(this.beanFactory, Mockito.times(1)).getDependenciesForBean(Mockito.any());
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).save(Mockito.eq("test"),
-				Mockito.eq(WorkFlowType.ASSESSMENT), Mockito.any(), Mockito.anyList(), Mockito.anyList(),
-				Mockito.eq(WorkFlowProcessingType.SEQUENTIAL));
+		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
+		verify(this.workFlowDefinitionService, times(1)).save(eq("test"), eq(WorkFlowType.ASSESSMENT), any(), anyList(),
+				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL));
 
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(0)).saveWorkFlowChecker(Mockito.eq(TEST_TASK),
-				Mockito.eq(TASK_DEPENDENCY), Mockito.any());
+		verify(this.workFlowDefinitionService, times(0)).saveWorkFlowChecker(eq(TEST_TASK), eq(TASK_DEPENDENCY), any());
 	}
 
 	@SuppressWarnings("serial")
@@ -123,14 +116,13 @@ class BeanWorkFlowRegistryImplTest {
 	void TestThatBeanIsAnnotatedTypeMetadata() {
 
 		// given
-		Work work = Mockito.mock(Work.class);
+		Work work = mock(Work.class);
 		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named(TEST).execute(work).build();
 
-		Mockito.when(this.beanFactory.getDependenciesForBean(Mockito.eq(TEST)))
-				.thenReturn(new String[] { FOO_DEPENDENCY });
+		when(this.beanFactory.getDependenciesForBean(eq(TEST))).thenReturn(new String[] { FOO_DEPENDENCY });
 
-		BeanDefinition beanDefinition = Mockito.mock(BeanDefinition.class);
-		Mockito.when(this.beanFactory.getBeanDefinition(Mockito.any())).thenReturn(beanDefinition);
+		BeanDefinition beanDefinition = mock(BeanDefinition.class);
+		when(this.beanFactory.getBeanDefinition(any())).thenReturn(beanDefinition);
 
 		// when
 		BeanWorkFlowRegistryImpl registry = new BeanWorkFlowRegistryImpl(this.beanFactory, new HashMap<>() {
@@ -143,9 +135,8 @@ class BeanWorkFlowRegistryImplTest {
 		// then
 		assertNotNull(exception);
 
-		Mockito.verify(this.beanFactory, Mockito.times(1)).getDependenciesForBean(Mockito.any());
-		Mockito.verify(this.workFlowDefinitionService, Mockito.times(0)).save(Mockito.any(), Mockito.any(),
-				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
+		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any());
 		assertEquals(registry.getWorkFlowByName(TEST), workFlow);
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the project coding style, `import static` can be used only in tests.
To improve tests' readability and make them a bit less verbose, the tests are aligned with that convention. 

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notifivcation Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
