### PR TITLE
Change JsonInclude.NON_EMPTY to NON_NULL

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -48,6 +48,7 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkDefinitionResponseDTO {
 
 	private UUID id;
@@ -56,19 +57,14 @@ public class WorkDefinitionResponseDTO {
 
 	private String workType;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private WorkFlowProcessingType processingType;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String author;
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private List<WorkDefinitionResponseDTO> works;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private Map<String, Map<String, Object>> parameters;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkFlowTaskOutput> outputs;
 
 	@JsonIgnore

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -59,13 +59,13 @@ public class WorkFlowDefinitionResponseDTO {
 
 	private Date modifyDate;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private Map<String, Map<String, Object>> parameters;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private WorkFlowPropertiesDefinitionDTO properties;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private List<WorkDefinitionResponseDTO> works;
 
 	public static class WorkFlowDefinitionResponseDTOBuilder {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowContextResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowContextResponseDTO.java
@@ -35,7 +35,7 @@ public class WorkFlowContextResponseDTO {
 
 	private UUID workFlowExecutionId;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private WorkFlowOptionsResponseDTO workFlowOptions;
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowOptionsResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowOptionsResponseDTO.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkFlowOptionsResponseDTO {
 
 	private WorkFlowOption currentVersion;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowResponseDTO.java
@@ -36,7 +36,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkFlowResponseDTO {
 
 	private UUID workFlowExecutionId;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowStatusResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkFlowStatusResponseDTO.java
@@ -43,7 +43,7 @@ public class WorkFlowStatusResponseDTO {
 
 	private String status;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private List<WorkStatusResponseDTO> works;
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
@@ -46,7 +46,7 @@ public class WorkStatusResponseDTO {
 
 	private ParodosWorkStatus status;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private List<WorkStatusResponseDTO> works;
 
 	@JsonIgnore


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to some specifications related to JsonInclude.NON_EMPTY, the generated openapi.json ignores a collection annoted with NON_EMPTY.

For consistent behavior, we'll use NON_NULL for collections.

**Which issue(s) this PR fixes**:
Fixes #[FLPATH-346](https://issues.redhat.com/browse/FLPATH-346)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notifivcation Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
