### PR TITLE
Create integrationtest base

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/ComplexWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/ComplexWorkFlow.java
@@ -3,11 +3,10 @@ package com.redhat.parodos.flows;
 import java.util.Arrays;
 import java.util.List;
 
+import com.redhat.parodos.flows.base.BaseIntegrationTest;
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
-import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
-import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
 import com.redhat.parodos.sdk.model.ProjectResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
@@ -15,12 +14,8 @@ import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
 import com.redhat.parodos.sdk.model.WorkRequestDTO;
-import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
 import org.junit.Test;
-
-import org.springframework.http.HttpHeaders;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static com.redhat.parodos.sdkutils.SdkUtils.waitWorkflowStatusAsync;
@@ -33,19 +28,11 @@ import static org.junit.Assert.fail;
  * @author Gloria Ciavarrini (Github: gciavarrini)
  */
 @Slf4j
-public class ComplexWorkFlow {
+public class ComplexWorkFlow extends BaseIntegrationTest {
 
 	private static final String projectName = "project-1";
 
 	private static final String projectDescription = "an example project";
-
-	private ApiClient apiClient;
-
-	@Before
-	public void setUp() {
-		apiClient = Configuration.getDefaultApiClient();
-		apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + CredUtils.getBase64Creds("test", "test"));
-	}
 
 	@Test
 	public void runComplexWorkFlow() throws ApiException, InterruptedException {

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlow.java
@@ -1,19 +1,14 @@
 package com.redhat.parodos.flows;
 
+import com.redhat.parodos.flows.base.BaseIntegrationTest;
 import com.redhat.parodos.sdk.api.WorkflowApi;
-import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
-import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.model.ProjectResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
-import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
 import org.junit.Test;
-
-import org.springframework.http.HttpHeaders;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
 import static com.redhat.parodos.sdkutils.SdkUtils.waitWorkflowStatusAsync;
@@ -24,19 +19,11 @@ import static org.junit.Assert.assertNotNull;
  * @author Gloria Ciavarrini (Github: gciavarrini)
  */
 @Slf4j
-public class EscalationFlow {
+public class EscalationFlow extends BaseIntegrationTest {
 
 	private static final String projectName = "project-1";
 
 	private static final String projectDescription = "an example project";
-
-	private ApiClient apiClient;
-
-	@Before
-	public void setUp() {
-		apiClient = Configuration.getDefaultApiClient();
-		apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + CredUtils.getBase64Creds("test", "test"));
-	}
 
 	@Test
 	public void runEscalationFlow() throws ApiException, InterruptedException {

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlow.java
@@ -3,11 +3,10 @@ package com.redhat.parodos.flows;
 import java.util.Arrays;
 import java.util.List;
 
+import com.redhat.parodos.flows.base.BaseIntegrationTest;
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
-import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
-import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
 import com.redhat.parodos.sdk.model.ProjectResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
@@ -17,12 +16,9 @@ import com.redhat.parodos.sdk.model.WorkRequestDTO;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.enums.WorkType;
-import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
@@ -32,20 +28,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
-public class PrebuiltWorkFlow {
+public class PrebuiltWorkFlow extends BaseIntegrationTest {
 
 	private static final String projectName = "project-1";
 
 	private static final String projectDescription = "an example project";
-
-	private ApiClient apiClient;
-
-	@Before
-	public void setUp() {
-		apiClient = Configuration.getDefaultApiClient();
-		apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + CredUtils.getBase64Creds("test", "test"));
-
-	}
 
 	@Test
 	public void runPreBuiltWorkFlow() throws ApiException, InterruptedException {

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlow.java
@@ -4,11 +4,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.redhat.parodos.flows.base.BaseIntegrationTest;
 import com.redhat.parodos.sdk.api.WorkflowApi;
 import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
-import com.redhat.parodos.sdk.invoker.ApiClient;
 import com.redhat.parodos.sdk.invoker.ApiException;
-import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.model.ArgumentRequestDTO;
 import com.redhat.parodos.sdk.model.ProjectResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
@@ -18,12 +17,9 @@ import com.redhat.parodos.sdk.model.WorkRequestDTO;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 import com.redhat.parodos.workflow.enums.WorkType;
-import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 
 import static com.redhat.parodos.sdkutils.SdkUtils.getProjectAsync;
@@ -36,20 +32,11 @@ import static org.junit.Assert.assertTrue;
  * @author Gloria Ciavarrini (Github: gciavarrini)
  */
 @Slf4j
-public class SimpleWorkFlow {
+public class SimpleWorkFlow extends BaseIntegrationTest {
 
 	private static final String projectName = "project-1";
 
 	private static final String projectDescription = "an example project";
-
-	private ApiClient apiClient;
-
-	@Before
-	public void setUp() {
-		apiClient = Configuration.getDefaultApiClient();
-		apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + CredUtils.getBase64Creds("test", "test"));
-
-	}
 
 	@Test
 	public void runSimpleWorkFlow() throws ApiException, InterruptedException {

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/base/BaseIntegrationTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/base/BaseIntegrationTest.java
@@ -1,0 +1,21 @@
+package com.redhat.parodos.flows.base;
+
+import com.redhat.parodos.sdk.invoker.ApiClient;
+import com.redhat.parodos.sdk.invoker.ApiException;
+import org.junit.Before;
+
+import static com.redhat.parodos.sdkutils.SdkUtils.getParodosAPiClient;
+
+/**
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class BaseIntegrationTest {
+
+	protected ApiClient apiClient;
+
+	@Before
+	public void setUp() throws ApiException {
+		apiClient = getParodosAPiClient();
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To ease the integration tests, a new method ` getParodosAPiClient` has been added to `SdkUtils`. 
This method properly set up the `ApiClient`  object to connect with Parodos services, setting the `CSRF` Token and the `JSessionID`. 

A new class that can be extended by integration test has been created. This class help to set up the `ApiClient` consistently in all the integration tests and eliminate the code duplication. 

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [x] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notifivcation Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
