### PR TITLE
Exclude notification-service-sdk from coverage

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -60,6 +60,7 @@
                 </executions>
                 <configuration>
                     <excludes>${project.parent.basedir}/workflow-service-sdk/*</excludes>
+                    <excludes>${project.parent.basedir}/notification-service-sdk/*</excludes>
                     <excludes>${project.parent.basedir}/integration-tests/*</excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
**What this PR does / why we need it**:
Since ` notification-service-sdk` module contains auto-generated code, it shouldn't be part of the coverage (like`workflow-service-sdk`)


**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto generated SDK code

**Impacted services**
- [ ] Workflow Service
- [x] Notifivcation Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
