### PR TITLE
Revert "Fix: change check function for waitProjectAsync"

### DIFF
--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
@@ -190,17 +190,7 @@ public abstract class SdkUtils {
 	 * @throws ApiException If the API method invocation fails
 	 */
 	public static void waitProjectStart(ProjectApi projectApi) throws InterruptedException, ApiException {
-		List<ProjectResponseDTO> projectResponseDTOS = waitAsyncResponse(new FuncExecutor<>() {
-			@Override
-			public boolean check(List<ProjectResponseDTO> result) {
-				return result == null;
-			}
-
-			@Override
-			public void execute(@NonNull ApiCallback<List<ProjectResponseDTO>> callback) throws ApiException {
-				projectApi.getProjectsAsync(callback);
-			}
-		});
+		waitAsyncResponse((FuncExecutor<List<ProjectResponseDTO>>) callback -> projectApi.getProjectsAsync(callback));
 	}
 
 	/**


### PR DESCRIPTION
Reverts parodos-dev/parodos#322

The fix is wrong: the waitAsyncProjects ends too early.