### PR TITLE
Fail correctly when execution fails

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
@@ -35,6 +35,7 @@ import com.redhat.parodos.workflow.execution.service.WorkFlowService;
 import com.redhat.parodos.workflow.execution.validation.PubliclyVisible;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -84,7 +85,7 @@ public class WorkFlowController {
 	@PostMapping
 	public ResponseEntity<WorkFlowResponseDTO> execute(@RequestBody @Valid WorkFlowRequestDTO workFlowRequestDTO) {
 		WorkReport workReport = workFlowService.execute(workFlowRequestDTO);
-		if (workReport == null) {
+		if (workReport.getStatus() == WorkStatus.FAILED) {
 			return ResponseEntity.status(500).build();
 		}
 		return ResponseEntity.ok(WorkFlowResponseDTO.builder()

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
@@ -13,6 +13,7 @@ import com.redhat.parodos.workflow.execution.dto.WorkFlowResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowStatusResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkStatusResponseDTO;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -78,6 +79,7 @@ class WorkFlowControllerTest extends ControllerMockClient {
 		WorkContext workContext = new WorkContext();
 		workContext.put("WORKFLOW_EXECUTION_ID", UUID.randomUUID().toString());
 		when(report.getWorkContext()).thenReturn(workContext);
+		when(report.getStatus()).thenReturn(WorkStatus.IN_PROGRESS);
 		when(this.workFlowService.execute(any())).thenReturn(report);
 
 		// when
@@ -100,7 +102,8 @@ class WorkFlowControllerTest extends ControllerMockClient {
 		ObjectMapper objectMapper = new ObjectMapper();
 		String json = objectMapper.writeValueAsString(workFlowRequestDTO);
 
-		when(this.workFlowService.execute(any())).thenReturn(null);
+		WorkReport workReport = new DefaultWorkReport(WorkStatus.FAILED, new WorkContext(), new Throwable());
+		when(this.workFlowService.execute(any())).thenReturn(workReport);
 
 		// when
 		this.mockMvc.perform(this.postRequestWithValidCredentials("/api/v1/workflows").content(json))


### PR DESCRIPTION
**What this PR does / why we need it**:
When an execution of a workflow fails due to incorrect input or due to internal error, a report with the error should be returned to the user. The status of the report in that case will be FAILED and the HTTP request code will be 500, for now.


**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
