### PR TITLE
FLPATH-303: workflow rollback

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleRollbackWorkFlow.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleRollbackWorkFlow.java
@@ -1,0 +1,84 @@
+package com.redhat.parodos.flows;
+
+import java.util.List;
+
+import com.redhat.parodos.flows.base.BaseIntegrationTest;
+import com.redhat.parodos.sdk.api.WorkflowApi;
+import com.redhat.parodos.sdk.api.WorkflowDefinitionApi;
+import com.redhat.parodos.sdk.invoker.ApiException;
+import com.redhat.parodos.sdk.model.ProjectResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
+import com.redhat.parodos.sdk.model.WorkFlowResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowResponseDTO.WorkStatusEnum;
+import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
+import com.redhat.parodos.sdkutils.SdkUtils;
+import com.redhat.parodos.workflow.consts.WorkFlowConstants;
+import com.redhat.parodos.workflow.enums.WorkFlowType;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Richard Wang (Github: richrdW98)
+ */
+@Slf4j
+public class SimpleRollbackWorkFlow extends BaseIntegrationTest {
+
+	private static final String projectName = "project-1";
+
+	private static final String projectDescription = "an example project";
+
+	@Test
+	public void runRollbackWorkFlow() throws ApiException, InterruptedException {
+		log.info("Running simple flow");
+
+		ProjectResponseDTO testProject = SdkUtils.getProjectAsync(apiClient, projectName, projectDescription);
+
+		// GET simpleSequentialWorkFlow DEFINITIONS
+		WorkflowDefinitionApi workflowDefinitionApi = new WorkflowDefinitionApi();
+		List<WorkFlowDefinitionResponseDTO> simpleFailedWorkFlowDefinitions = workflowDefinitionApi
+				.getWorkFlowDefinitions("simpleFailedWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW);
+		assertEquals(1, simpleFailedWorkFlowDefinitions.size());
+
+		// GET WORKFLOW DEFINITION BY Id
+		WorkFlowDefinitionResponseDTO simpleSequentialWorkFlowDefinition = workflowDefinitionApi
+				.getWorkFlowDefinitionById(simpleFailedWorkFlowDefinitions.get(0).getId());
+
+		assertNotNull(simpleSequentialWorkFlowDefinition.getId());
+		assertEquals("simpleFailedWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW,
+				simpleSequentialWorkFlowDefinition.getName());
+		assertEquals(WorkFlowDefinitionResponseDTO.ProcessingTypeEnum.SEQUENTIAL,
+				simpleSequentialWorkFlowDefinition.getProcessingType());
+		assertEquals(WorkFlowType.INFRASTRUCTURE.toString(), simpleSequentialWorkFlowDefinition.getType().name());
+
+		// Define WorkRequests
+
+		// Define WorkFlowRequest
+		WorkFlowRequestDTO workFlowRequestDTO = new WorkFlowRequestDTO();
+		workFlowRequestDTO.setProjectId(testProject.getId());
+		workFlowRequestDTO.setWorkFlowName("simpleFailedWorkFlow_INFRASTRUCTURE_WORKFLOW");
+		workFlowRequestDTO.setWorks(List.of());
+
+		WorkflowApi workflowApi = new WorkflowApi();
+		log.info("******** Running The Simple Failed Flow ********");
+
+		WorkFlowResponseDTO workFlowResponseDTO = workflowApi.execute(workFlowRequestDTO);
+
+		assertNotNull(workFlowResponseDTO.getWorkFlowExecutionId());
+		assertNotNull(workFlowResponseDTO.getWorkStatus());
+		assertEquals(WorkStatusEnum.IN_PROGRESS, workFlowResponseDTO.getWorkStatus());
+
+		WorkFlowStatusResponseDTO workFlowStatusResponseDTO = SdkUtils.waitWorkflowStatusAsync(workflowApi,
+				workFlowResponseDTO.getWorkFlowExecutionId());
+
+		assertNotNull(workFlowStatusResponseDTO.getWorkFlowExecutionId());
+		assertNotNull(workFlowStatusResponseDTO.getStatus());
+		assertEquals(WorkStatusEnum.FAILED.name(), workFlowStatusResponseDTO.getStatus().name());
+		log.info("workflow finished successfully with response: {}", workFlowResponseDTO);
+		log.info("******** Simple Failed Flow Completed ********");
+	}
+
+}

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Infrastructure.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/annotation/Infrastructure.java
@@ -35,4 +35,6 @@ public @interface Infrastructure {
 
 	Parameter[] parameters() default {};
 
+	String rollbackWorkflow() default "";
+
 }

--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
@@ -208,7 +208,7 @@ public abstract class SdkUtils {
 		WorkFlowStatusResponseDTO workFlowStatusResponseDTO = waitAsyncResponse(new FuncExecutor<>() {
 			@Override
 			public boolean check(WorkFlowStatusResponseDTO result) {
-				return !result.getStatus().equals(WorkStatus.COMPLETED.toString());
+				return result.getStatus().equals(WorkStatus.IN_PROGRESS.toString());
 			}
 
 			@Override

--- a/workflow-examples/README.md
+++ b/workflow-examples/README.md
@@ -362,6 +362,24 @@ hours (or even days). As all state is persisted, when the workflow-service is re
 
 WorkflowCheckers can be used to determine if required manual processes, outside the scope of Parodos, have completed.
 
+#### Workflow rollback
+
+Rollback workflow is a type of workflow that will be triggered once the main workflow is failed. To set up a rollback workflow:
+1. define a rollback workflow with tasks to be executed for the rollback purpose
+2. add the reference of rollback workflow's name to the field `rollbackWorkflow` in `@Infrastructure` annotation of the main workflow. In the example below, a rollback workflow `complexRollbackWorkFlow` is assigned to `complexWorkFlow`:
+```java
+	@Bean(name = "complexWorkFlow")
+	@Infrastructure(parameters = { ... }, 
+            rollbackWorkflow = "complexRollbackWorkFlow")
+	WorkFlow complexWorkFlow(@Qualifier("subWorkFlowThree") WorkFlow subWorkFlowThree,
+			@Qualifier("subWorkFlowFour") WorkFlow subWorkFlowFour) {
+		return SequentialFlow.Builder.aNewSequentialFlow().named("complexWorkFlow").execute(subWorkFlowThree)
+				.then(subWorkFlowFour).build();
+	}
+```
+The property `rollbackWorkflow` in `@Infrastructure` can be removed in order to remove the rollback workflow. By default, there will be no rollback for any workflows.
+
+
 ### TIBCO workflow
 
 'TibcoWorkFlowConfiguration.java' is the workflow code. You'll find details inside the file.

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/ComplexWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/ComplexWorkFlowConfiguration.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors;
 import com.redhat.parodos.examples.complex.checker.NamespaceApprovalWorkFlowCheckerTask;
 import com.redhat.parodos.examples.complex.checker.SslCertificationApprovalWorkFlowCheckerTask;
 import com.redhat.parodos.examples.complex.parameter.ComplexWorkParameterValueProvider;
+import com.redhat.parodos.examples.complex.rollback.RollbackWorkFlowTask;
 import com.redhat.parodos.examples.complex.task.AdGroupsWorkFlowTask;
 import com.redhat.parodos.examples.complex.task.LoadBalancerWorkFlowTask;
 import com.redhat.parodos.examples.complex.task.NamespaceWorkFlowTask;
@@ -181,6 +182,14 @@ public class ComplexWorkFlowConfiguration {
 				.build();
 	}
 
+	// rollback workflow
+	@Bean(name = "complexRollbackWorkFlow")
+	@Infrastructure()
+	WorkFlow complexRollbackWorkFlow(RollbackWorkFlowTask rollbackWorkFlowTask) {
+		return SequentialFlow.Builder.aNewSequentialFlow().named("complexRollbackWorkFlow")
+				.execute(rollbackWorkFlowTask).build();
+	}
+
 	// USER WORKFLOW
 	// Sequential Flow:
 	// - subWorkFlowThree
@@ -198,7 +207,8 @@ public class ComplexWorkFlowConfiguration {
 			@Parameter(key = "WORKFLOW_MULTI_SELECT_SAMPLE", description = "Workflow multi-select parameter sample",
 					type = WorkParameterType.MULTI_SELECT, optional = true),
 			@Parameter(key = "DYNAMIC_TEXT_SAMPLE", description = "dynamic text sample", type = WorkParameterType.TEXT,
-					optional = true) })
+					optional = true) },
+			rollbackWorkflow = "complexRollbackWorkFlow")
 	WorkFlow complexWorkFlow(@Qualifier("subWorkFlowThree") WorkFlow subWorkFlowThree,
 			@Qualifier("subWorkFlowFour") WorkFlow subWorkFlowFour) {
 		return SequentialFlow.Builder.aNewSequentialFlow().named("complexWorkFlow").execute(subWorkFlowThree)
@@ -208,6 +218,11 @@ public class ComplexWorkFlowConfiguration {
 	@Bean(name = "complexWorkFlowValueProvider")
 	WorkParameterValueProvider complexWorkFlowValueProvider() {
 		return new ComplexWorkParameterValueProvider("complexWorkFlow");
+	}
+
+	@Bean
+	RollbackWorkFlowTask rollbackWorkFlowTask() {
+		return new RollbackWorkFlowTask();
 	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/rollback/RollbackWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/complex/rollback/RollbackWorkFlowTask.java
@@ -1,0 +1,19 @@
+package com.redhat.parodos.examples.complex.rollback;
+
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RollbackWorkFlowTask extends BaseInfrastructureWorkFlowTask {
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		log.info("RollbackWorkFlowTask");
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/SimpleRollbackWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/SimpleRollbackWorkFlowConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.examples.rollback;
+
+import com.redhat.parodos.examples.complex.rollback.RollbackWorkFlowTask;
+import com.redhat.parodos.examples.rollback.task.SimpleFailedWorkFlowTask;
+import com.redhat.parodos.workflow.annotation.Infrastructure;
+import com.redhat.parodos.workflow.annotation.WorkFlowProperties;
+import com.redhat.parodos.workflow.consts.WorkFlowConstants;
+import com.redhat.parodos.workflows.workflow.SequentialFlow;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Very simple workflow configurations
+ *
+ * @author Luke Shannon (Github: lshannon)
+ */
+
+@Configuration
+@Slf4j
+@PropertySource("classpath:git.properties")
+public class SimpleRollbackWorkFlowConfiguration {
+
+	// START Sequential Example (WorkflowTasks and Workflow Definitions)
+	@Bean
+	SimpleFailedWorkFlowTask simpleFailedWorkFlowTask() {
+		return new SimpleFailedWorkFlowTask();
+	}
+
+	@Bean(name = "simpleFailedWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+	@Infrastructure(rollbackWorkflow = "simpleRollbackWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+	@WorkFlowProperties(version = "${git.commit.id}")
+	WorkFlow simpleFailedWorkFlow(
+			@Qualifier("simpleFailedWorkFlowTask") SimpleFailedWorkFlowTask simpleFailedWorkFlowTask) {
+		// @formatter:off
+		return SequentialFlow
+				.Builder.aNewSequentialFlow()
+				.named("simpleFailedWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+				.execute(simpleFailedWorkFlowTask)
+				.build();
+		// @formatter:on
+	}
+
+	// END Sequential Example (WorkflowTasks and Workflow Definitions)
+
+	@Bean
+	RollbackWorkFlowTask rollbackWorkFlowTask() {
+		return new RollbackWorkFlowTask();
+	}
+
+	@Bean("simpleRollbackWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+	@Infrastructure
+	WorkFlow simpleRollbackWorkFlow(@Qualifier("rollbackWorkFlowTask") RollbackWorkFlowTask rollbackWorkFlowTask) {
+		// @formatter:off
+		return SequentialFlow
+				.Builder.aNewSequentialFlow()
+				.named("simpleRollbackWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+				.execute(rollbackWorkFlowTask)
+				.build();
+		// @formatter:on
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/rollback/RollbackWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/rollback/RollbackWorkFlowTask.java
@@ -1,0 +1,19 @@
+package com.redhat.parodos.examples.rollback.rollback;
+
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RollbackWorkFlowTask extends BaseInfrastructureWorkFlowTask {
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		log.info("RollbackWorkFlowTask");
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/task/SimpleFailedWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/rollback/task/SimpleFailedWorkFlowTask.java
@@ -13,24 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.redhat.parodos.workflow.execution.continuation;
+package com.redhat.parodos.examples.rollback.task;
 
-import java.util.UUID;
-
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
 
 /**
- * When the application starts up it will run any workflows in Progress @see
- * Status.IN_PROGRESS
+ * sample failed task execution
  *
+ * @author Luke Shannon (Github: lshannon)
  * @author Richard Wang (Github: richardw98)
  * @author Annel Ketcha (Github: anludke)
  */
-public interface WorkFlowContinuationService {
 
-	void workFlowRunAfterStartup();
+@Slf4j
+@Component
+public class SimpleFailedWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 
-	void continueWorkFlow(UUID projectId, String workflowName, WorkContext workContext, UUID executionId,
-			String rollbackWorkflowName);
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+	}
 
 }

--- a/workflow-service-sdk/README.md
+++ b/workflow-service-sdk/README.md
@@ -130,11 +130,9 @@ Class | Method | HTTP request | Description
 ## Documentation for Models
 
  - [ArgumentRequestDTO](docs/ArgumentRequestDTO.md)
- - [GetStatusByProjectId200Response](docs/GetStatusByProjectId200Response.md)
  - [ProjectRequestDTO](docs/ProjectRequestDTO.md)
  - [ProjectResponseDTO](docs/ProjectResponseDTO.md)
  - [ProjectUserRoleResponseDTO](docs/ProjectUserRoleResponseDTO.md)
- - [UpdateParameter200Response](docs/UpdateParameter200Response.md)
  - [UserRoleRequestDTO](docs/UserRoleRequestDTO.md)
  - [UserRoleResponseDTO](docs/UserRoleResponseDTO.md)
  - [WorkDefinitionResponseDTO](docs/WorkDefinitionResponseDTO.md)

--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -262,7 +262,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/updateParameter_200_response'
+                items:
+                  $ref: '#/components/schemas/WorkParameterValueResponseDTO'
+                type: array
           description: Succeeded
         "401":
           description: Unauthorized
@@ -290,7 +292,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/getStatusByProjectId_200_response'
+                items:
+                  $ref: '#/components/schemas/WorkFlowResponseDTO'
+                type: array
           description: Succeeded
         "401":
           description: Unauthorized
@@ -708,6 +712,7 @@ components:
     WorkFlowDefinitionResponseDTO:
       example:
         processingType: SEQUENTIAL
+        rollbackWorkflow: rollbackWorkflow
         works:
         - outputs:
           - EXCEPTION
@@ -776,6 +781,8 @@ components:
           type: string
         properties:
           $ref: '#/components/schemas/WorkFlowPropertiesDefinitionDTO'
+        rollbackWorkflow:
+          type: string
         type:
           enum:
           - ASSESSMENT
@@ -1050,6 +1057,13 @@ components:
           type: string
       type: object
     WorkParameterValueResponseDTO:
+      example:
+        options:
+        - options
+        - options
+        propertyPath: propertyPath
+        value: value
+        key: key
       properties:
         key:
           type: string
@@ -1113,10 +1127,4 @@ components:
             $ref: '#/components/schemas/WorkStatusResponseDTO'
           type: array
       type: object
-    updateParameter_200_response:
-      allOf:
-      - $ref: '#/components/schemas/WorkParameterValueResponseDTO'
-    getStatusByProjectId_200_response:
-      allOf:
-      - $ref: '#/components/schemas/WorkFlowStatusResponseDTO'
 

--- a/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
@@ -15,6 +15,7 @@
 |**parameters** | **Map&lt;String, Map&lt;String, Object&gt;&gt;** |  |  [optional] |
 |**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional] |
 |**properties** | [**WorkFlowPropertiesDefinitionDTO**](WorkFlowPropertiesDefinitionDTO.md) |  |  [optional] |
+|**rollbackWorkflow** | **String** |  |  [optional] |
 |**type** | [**TypeEnum**](#TypeEnum) |  |  [optional] |
 |**works** | [**List&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
 

--- a/workflow-service-sdk/docs/WorkflowApi.md
+++ b/workflow-service-sdk/docs/WorkflowApi.md
@@ -137,7 +137,7 @@ No authorization required
 
 <a name="getStatusByProjectId"></a>
 # **getStatusByProjectId**
-> GetStatusByProjectId200Response getStatusByProjectId(projectId)
+> List&lt;WorkFlowResponseDTO&gt; getStatusByProjectId(projectId)
 
 Returns workflows by project id
 
@@ -158,7 +158,7 @@ public class Example {
     WorkflowApi apiInstance = new WorkflowApi(defaultClient);
     UUID projectId = UUID.randomUUID(); // UUID | 
     try {
-      GetStatusByProjectId200Response result = apiInstance.getStatusByProjectId(projectId);
+      List<WorkFlowResponseDTO> result = apiInstance.getStatusByProjectId(projectId);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling WorkflowApi#getStatusByProjectId");
@@ -179,7 +179,7 @@ public class Example {
 
 ### Return type
 
-[**GetStatusByProjectId200Response**](GetStatusByProjectId200Response.md)
+[**List&lt;WorkFlowResponseDTO&gt;**](WorkFlowResponseDTO.md)
 
 ### Authorization
 

--- a/workflow-service-sdk/docs/WorkflowDefinitionApi.md
+++ b/workflow-service-sdk/docs/WorkflowDefinitionApi.md
@@ -135,7 +135,7 @@ No authorization required
 
 <a name="updateParameter"></a>
 # **updateParameter**
-> UpdateParameter200Response updateParameter(workflowDefinitionName, valueProviderName, workParameterValueRequestDTO)
+> List&lt;WorkParameterValueResponseDTO&gt; updateParameter(workflowDefinitionName, valueProviderName, workParameterValueRequestDTO)
 
 Returns updated parameter value
 
@@ -158,7 +158,7 @@ public class Example {
     String valueProviderName = "complexWorkFlowValueProvider"; // String | valueProvider Name. It can be referenced to 'valueProviderName' in [GET /getWorkFlowDefinitions](#/Workflow%20Definition/getWorkFlowDefinitions)
     List<WorkParameterValueRequestDTO> workParameterValueRequestDTO = Arrays.asList(); // List<WorkParameterValueRequestDTO> | 
     try {
-      UpdateParameter200Response result = apiInstance.updateParameter(workflowDefinitionName, valueProviderName, workParameterValueRequestDTO);
+      List<WorkParameterValueResponseDTO> result = apiInstance.updateParameter(workflowDefinitionName, valueProviderName, workParameterValueRequestDTO);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling WorkflowDefinitionApi#updateParameter");
@@ -181,7 +181,7 @@ public class Example {
 
 ### Return type
 
-[**UpdateParameter200Response**](UpdateParameter200Response.md)
+[**List&lt;WorkParameterValueResponseDTO&gt;**](WorkParameterValueResponseDTO.md)
 
 ### Authorization
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowApi.java
@@ -26,7 +26,6 @@ import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.model.GetStatusByProjectId200Response;
 import com.redhat.parodos.sdk.model.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.sdk.model.WorkFlowContextResponseDTO;
 import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
@@ -566,7 +565,7 @@ public class WorkflowApi {
 	/**
 	 * Returns workflows by project id
 	 * @param projectId (optional)
-	 * @return GetStatusByProjectId200Response
+	 * @return List&lt;WorkFlowResponseDTO&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot
 	 * deserialize the response body
 	 * @http.response.details
@@ -593,15 +592,15 @@ public class WorkflowApi {
 	 * </tr>
 	 * </table>
 	 */
-	public GetStatusByProjectId200Response getStatusByProjectId(UUID projectId) throws ApiException {
-		ApiResponse<GetStatusByProjectId200Response> localVarResp = getStatusByProjectIdWithHttpInfo(projectId);
+	public List<WorkFlowResponseDTO> getStatusByProjectId(UUID projectId) throws ApiException {
+		ApiResponse<List<WorkFlowResponseDTO>> localVarResp = getStatusByProjectIdWithHttpInfo(projectId);
 		return localVarResp.getData();
 	}
 
 	/**
 	 * Returns workflows by project id
 	 * @param projectId (optional)
-	 * @return ApiResponse&lt;GetStatusByProjectId200Response&gt;
+	 * @return ApiResponse&lt;List&lt;WorkFlowResponseDTO&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot
 	 * deserialize the response body
 	 * @http.response.details
@@ -628,10 +627,9 @@ public class WorkflowApi {
 	 * </tr>
 	 * </table>
 	 */
-	public ApiResponse<GetStatusByProjectId200Response> getStatusByProjectIdWithHttpInfo(UUID projectId)
-			throws ApiException {
+	public ApiResponse<List<WorkFlowResponseDTO>> getStatusByProjectIdWithHttpInfo(UUID projectId) throws ApiException {
 		okhttp3.Call localVarCall = getStatusByProjectIdValidateBeforeCall(projectId, null);
-		Type localVarReturnType = new TypeToken<GetStatusByProjectId200Response>() {
+		Type localVarReturnType = new TypeToken<List<WorkFlowResponseDTO>>() {
 		}.getType();
 		return localVarApiClient.execute(localVarCall, localVarReturnType);
 	}
@@ -668,10 +666,10 @@ public class WorkflowApi {
 	 * </table>
 	 */
 	public okhttp3.Call getStatusByProjectIdAsync(UUID projectId,
-			final ApiCallback<GetStatusByProjectId200Response> _callback) throws ApiException {
+			final ApiCallback<List<WorkFlowResponseDTO>> _callback) throws ApiException {
 
 		okhttp3.Call localVarCall = getStatusByProjectIdValidateBeforeCall(projectId, _callback);
-		Type localVarReturnType = new TypeToken<GetStatusByProjectId200Response>() {
+		Type localVarReturnType = new TypeToken<List<WorkFlowResponseDTO>>() {
 		}.getType();
 		localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
 		return localVarCall;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowDefinitionApi.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/api/WorkflowDefinitionApi.java
@@ -26,9 +26,9 @@ import com.redhat.parodos.sdk.invoker.ApiException;
 import com.redhat.parodos.sdk.invoker.ApiResponse;
 import com.redhat.parodos.sdk.invoker.Configuration;
 import com.redhat.parodos.sdk.invoker.Pair;
-import com.redhat.parodos.sdk.model.UpdateParameter200Response;
 import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.sdk.model.WorkParameterValueRequestDTO;
+import com.redhat.parodos.sdk.model.WorkParameterValueResponseDTO;
 
 public class WorkflowDefinitionApi {
 
@@ -589,7 +589,7 @@ public class WorkflowDefinitionApi {
 	 * &#39;valueProviderName&#39; in [GET
 	 * /getWorkFlowDefinitions](#/Workflow%20Definition/getWorkFlowDefinitions) (required)
 	 * @param workParameterValueRequestDTO (required)
-	 * @return UpdateParameter200Response
+	 * @return List&lt;WorkParameterValueResponseDTO&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot
 	 * deserialize the response body
 	 * @http.response.details
@@ -616,10 +616,10 @@ public class WorkflowDefinitionApi {
 	 * </tr>
 	 * </table>
 	 */
-	public UpdateParameter200Response updateParameter(String workflowDefinitionName, String valueProviderName,
+	public List<WorkParameterValueResponseDTO> updateParameter(String workflowDefinitionName, String valueProviderName,
 			List<WorkParameterValueRequestDTO> workParameterValueRequestDTO) throws ApiException {
-		ApiResponse<UpdateParameter200Response> localVarResp = updateParameterWithHttpInfo(workflowDefinitionName,
-				valueProviderName, workParameterValueRequestDTO);
+		ApiResponse<List<WorkParameterValueResponseDTO>> localVarResp = updateParameterWithHttpInfo(
+				workflowDefinitionName, valueProviderName, workParameterValueRequestDTO);
 		return localVarResp.getData();
 	}
 
@@ -630,7 +630,7 @@ public class WorkflowDefinitionApi {
 	 * &#39;valueProviderName&#39; in [GET
 	 * /getWorkFlowDefinitions](#/Workflow%20Definition/getWorkFlowDefinitions) (required)
 	 * @param workParameterValueRequestDTO (required)
-	 * @return ApiResponse&lt;UpdateParameter200Response&gt;
+	 * @return ApiResponse&lt;List&lt;WorkParameterValueResponseDTO&gt;&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot
 	 * deserialize the response body
 	 * @http.response.details
@@ -657,12 +657,12 @@ public class WorkflowDefinitionApi {
 	 * </tr>
 	 * </table>
 	 */
-	public ApiResponse<UpdateParameter200Response> updateParameterWithHttpInfo(String workflowDefinitionName,
+	public ApiResponse<List<WorkParameterValueResponseDTO>> updateParameterWithHttpInfo(String workflowDefinitionName,
 			String valueProviderName, List<WorkParameterValueRequestDTO> workParameterValueRequestDTO)
 			throws ApiException {
 		okhttp3.Call localVarCall = updateParameterValidateBeforeCall(workflowDefinitionName, valueProviderName,
 				workParameterValueRequestDTO, null);
-		Type localVarReturnType = new TypeToken<UpdateParameter200Response>() {
+		Type localVarReturnType = new TypeToken<List<WorkParameterValueResponseDTO>>() {
 		}.getType();
 		return localVarApiClient.execute(localVarCall, localVarReturnType);
 	}
@@ -704,11 +704,11 @@ public class WorkflowDefinitionApi {
 	 */
 	public okhttp3.Call updateParameterAsync(String workflowDefinitionName, String valueProviderName,
 			List<WorkParameterValueRequestDTO> workParameterValueRequestDTO,
-			final ApiCallback<UpdateParameter200Response> _callback) throws ApiException {
+			final ApiCallback<List<WorkParameterValueResponseDTO>> _callback) throws ApiException {
 
 		okhttp3.Call localVarCall = updateParameterValidateBeforeCall(workflowDefinitionName, valueProviderName,
 				workParameterValueRequestDTO, _callback);
-		Type localVarReturnType = new TypeToken<UpdateParameter200Response>() {
+		Type localVarReturnType = new TypeToken<List<WorkParameterValueResponseDTO>>() {
 		}.getType();
 		localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
 		return localVarCall;

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/JSON.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/invoker/JSON.java
@@ -88,15 +88,11 @@ public class JSON {
 		gsonBuilder.registerTypeAdapterFactory(
 				new com.redhat.parodos.sdk.model.ArgumentRequestDTO.CustomTypeAdapterFactory());
 		gsonBuilder.registerTypeAdapterFactory(
-				new com.redhat.parodos.sdk.model.GetStatusByProjectId200Response.CustomTypeAdapterFactory());
-		gsonBuilder.registerTypeAdapterFactory(
 				new com.redhat.parodos.sdk.model.ProjectRequestDTO.CustomTypeAdapterFactory());
 		gsonBuilder.registerTypeAdapterFactory(
 				new com.redhat.parodos.sdk.model.ProjectResponseDTO.CustomTypeAdapterFactory());
 		gsonBuilder.registerTypeAdapterFactory(
 				new com.redhat.parodos.sdk.model.ProjectUserRoleResponseDTO.CustomTypeAdapterFactory());
-		gsonBuilder.registerTypeAdapterFactory(
-				new com.redhat.parodos.sdk.model.UpdateParameter200Response.CustomTypeAdapterFactory());
 		gsonBuilder.registerTypeAdapterFactory(
 				new com.redhat.parodos.sdk.model.UserRoleRequestDTO.CustomTypeAdapterFactory());
 		gsonBuilder.registerTypeAdapterFactory(

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
@@ -136,6 +136,11 @@ public class WorkFlowDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_PROPERTIES)
 	private WorkFlowPropertiesDefinitionDTO properties;
 
+	public static final String SERIALIZED_NAME_ROLLBACK_WORKFLOW = "rollbackWorkflow";
+
+	@SerializedName(SERIALIZED_NAME_ROLLBACK_WORKFLOW)
+	private String rollbackWorkflow;
+
 	/**
 	 * Gets or Sets type
 	 */
@@ -372,6 +377,26 @@ public class WorkFlowDefinitionResponseDTO {
 		this.properties = properties;
 	}
 
+	public WorkFlowDefinitionResponseDTO rollbackWorkflow(String rollbackWorkflow) {
+
+		this.rollbackWorkflow = rollbackWorkflow;
+		return this;
+	}
+
+	/**
+	 * Get rollbackWorkflow
+	 * @return rollbackWorkflow
+	 **/
+	@javax.annotation.Nullable
+
+	public String getRollbackWorkflow() {
+		return rollbackWorkflow;
+	}
+
+	public void setRollbackWorkflow(String rollbackWorkflow) {
+		this.rollbackWorkflow = rollbackWorkflow;
+	}
+
 	public WorkFlowDefinitionResponseDTO type(TypeEnum type) {
 
 		this.type = type;
@@ -437,14 +462,15 @@ public class WorkFlowDefinitionResponseDTO {
 				&& Objects.equals(this.parameters, workFlowDefinitionResponseDTO.parameters)
 				&& Objects.equals(this.processingType, workFlowDefinitionResponseDTO.processingType)
 				&& Objects.equals(this.properties, workFlowDefinitionResponseDTO.properties)
+				&& Objects.equals(this.rollbackWorkflow, workFlowDefinitionResponseDTO.rollbackWorkflow)
 				&& Objects.equals(this.type, workFlowDefinitionResponseDTO.type)
 				&& Objects.equals(this.works, workFlowDefinitionResponseDTO.works);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(author, createDate, id, modifyDate, name, parameters, processingType, properties, type,
-				works);
+		return Objects.hash(author, createDate, id, modifyDate, name, parameters, processingType, properties,
+				rollbackWorkflow, type, works);
 	}
 
 	@Override
@@ -459,6 +485,7 @@ public class WorkFlowDefinitionResponseDTO {
 		sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
 		sb.append("    processingType: ").append(toIndentedString(processingType)).append("\n");
 		sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+		sb.append("    rollbackWorkflow: ").append(toIndentedString(rollbackWorkflow)).append("\n");
 		sb.append("    type: ").append(toIndentedString(type)).append("\n");
 		sb.append("    works: ").append(toIndentedString(works)).append("\n");
 		sb.append("}");
@@ -491,6 +518,7 @@ public class WorkFlowDefinitionResponseDTO {
 		openapiFields.add("parameters");
 		openapiFields.add("processingType");
 		openapiFields.add("properties");
+		openapiFields.add("rollbackWorkflow");
 		openapiFields.add("type");
 		openapiFields.add("works");
 
@@ -555,6 +583,12 @@ public class WorkFlowDefinitionResponseDTO {
 		// validate the optional field `properties`
 		if (jsonObj.get("properties") != null && !jsonObj.get("properties").isJsonNull()) {
 			WorkFlowPropertiesDefinitionDTO.validateJsonObject(jsonObj.getAsJsonObject("properties"));
+		}
+		if ((jsonObj.get("rollbackWorkflow") != null && !jsonObj.get("rollbackWorkflow").isJsonNull())
+				&& !jsonObj.get("rollbackWorkflow").isJsonPrimitive()) {
+			throw new IllegalArgumentException(String.format(
+					"Expected the field `rollbackWorkflow` to be a primitive type in the JSON string but got `%s`",
+					jsonObj.get("rollbackWorkflow").toString()));
 		}
 		if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull())
 				&& !jsonObj.get("type").isJsonPrimitive()) {

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -332,9 +332,10 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "allOf" : [ {
+                  "type" : "array",
+                  "items" : {
                     "$ref" : "#/components/schemas/WorkParameterValueResponseDTO"
-                  } ]
+                  }
                 }
               }
             },
@@ -368,9 +369,10 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "allOf" : [ {
-                    "$ref" : "#/components/schemas/WorkFlowStatusResponseDTO"
-                  } ]
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/WorkFlowResponseDTO"
+                  }
                 }
               }
             },
@@ -752,6 +754,9 @@
           },
           "properties" : {
             "$ref" : "#/components/schemas/WorkFlowPropertiesDefinitionDTO"
+          },
+          "rollbackWorkflow" : {
+            "type" : "string"
           },
           "type" : {
             "type" : "string",

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/WorkFlowDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/WorkFlowDelegate.java
@@ -82,7 +82,7 @@ public class WorkFlowDelegate {
 							work, workDefinitionResponseDTO.getName()));
 	}
 
-	public WorkFlow getWorkFlowExecutionByName(String workFlowName) {
+	public WorkFlow getWorkFlowByName(String workFlowName) {
 		return beanWorkFlowRegistry.getWorkFlowByName(workFlowName);
 	}
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
@@ -110,7 +110,8 @@ public class WorkFlowDefinitionController {
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Succeeded",
 					content = { @Content(mediaType = "application/json",
-							schema = @Schema(allOf = WorkParameterValueResponseDTO.class)) }),
+							array = @ArraySchema(
+									schema = @Schema(implementation = WorkParameterValueResponseDTO.class))) }),
 			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
 			@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content) })
 	@PostMapping("/{workflowDefinitionName}/parameters/update/{valueProviderName}")

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -18,6 +18,7 @@ package com.redhat.parodos.workflow.definition.dto;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -69,6 +70,9 @@ public class WorkFlowDefinitionResponseDTO {
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkDefinitionResponseDTO> works;
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String rollbackWorkflow;
+
 	public static class WorkFlowDefinitionResponseDTOBuilder {
 
 		public WorkFlowDefinitionResponseDTOBuilder parameterFromString(String parameters) {
@@ -90,6 +94,8 @@ public class WorkFlowDefinitionResponseDTO {
 				.parameterFromString(workFlowDefinition.getParameters()).author(workFlowDefinition.getAuthor())
 				.createDate(workFlowDefinition.getCreateDate()).modifyDate(workFlowDefinition.getModifyDate())
 				.type(workFlowDefinition.getType()).processingType(workFlowDefinition.getProcessingType()).works(works)
+				.rollbackWorkflow(Optional.ofNullable(workFlowDefinition.getRollbackWorkFlowDefinition())
+						.map(WorkFlowDefinition::getName).orElse(null))
 				.build();
 	}
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowDefinition.java
@@ -25,12 +25,15 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import com.redhat.parodos.common.AbstractEntity;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -95,6 +98,15 @@ public class WorkFlowDefinition extends AbstractEntity {
 	@OneToOne(mappedBy = "checkWorkFlow", cascade = CascadeType.ALL)
 	private WorkFlowCheckerMappingDefinition checkerWorkFlowDefinition;
 
+	@OneToOne(cascade = { CascadeType.MERGE }, fetch = FetchType.EAGER)
+	@JoinTable(name = "prds_workflow_rollback_mapping", joinColumns = @JoinColumn(name = "workflow_definition_id"),
+			inverseJoinColumns = @JoinColumn(name = "workflow_rollback_definition_id"))
+	private WorkFlowDefinition rollbackWorkFlowDefinition;
+
 	private String commitId;
+
+	@OneToMany(mappedBy = "workFlowDefinition", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@Builder.Default
+	private List<WorkFlowExecution> workFlowExecutions = new ArrayList<>();
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowDefinitionRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/repository/WorkFlowDefinitionRepository.java
@@ -22,6 +22,9 @@ import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * workflow definition repository
@@ -34,5 +37,10 @@ public interface WorkFlowDefinitionRepository extends JpaRepository<WorkFlowDefi
 	WorkFlowDefinition findFirstByName(String name);
 
 	List<WorkFlowDefinition> findByTypeIsNot(WorkFlowType type);
+
+	@Query(value = "delete from prds_workflow_rollback_mapping", nativeQuery = true)
+	@Modifying
+	@Transactional
+	void deleteAllFromRollbackMapping();
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
@@ -37,9 +37,8 @@ import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 public interface WorkFlowDefinitionService {
 
 	WorkFlowDefinitionResponseDTO save(String workFlowName, WorkFlowType workFlowType,
-			WorkFlowPropertiesMetadata workFlowPropertiesMetadata, List<WorkParameter> workParameters,
-
-			List<Work> works, WorkFlowProcessingType workFlowProcessingType);
+			WorkFlowPropertiesMetadata workFlowPropertiesMetadata, List<WorkParameter> workParameters, List<Work> works,
+			WorkFlowProcessingType workFlowProcessingType, String rollbackWorkflowName);
 
 	WorkFlowDefinitionResponseDTO getWorkFlowDefinitionByName(String name);
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -49,6 +49,7 @@ import com.redhat.parodos.workflows.work.Work;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlowPropertiesMetadata;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.modelmapper.ModelMapper;
 
 import org.springframework.stereotype.Service;
@@ -99,7 +100,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 	@Override
 	public WorkFlowDefinitionResponseDTO save(String workFlowName, WorkFlowType workFlowType,
 			WorkFlowPropertiesMetadata properties, List<WorkParameter> workParameters, List<Work> works,
-			WorkFlowProcessingType workFlowProcessingType) {
+			WorkFlowProcessingType workFlowProcessingType, String rollbackWorkflowName) {
 
 		String stringifyParameters = WorkFlowDTOUtil.writeObjectValueAsString(convertWorkParameters(workParameters));
 
@@ -121,6 +122,10 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 		workFlowDefinition.setProperties(propertiesDefinition);
 		workFlowDefinition.setProcessingType(workFlowProcessingType);
 		workFlowDefinition.setNumberOfWorks(works.size());
+		if (!StringUtils.isEmpty(rollbackWorkflowName)) {
+			workFlowDefinition
+					.setRollbackWorkFlowDefinition(workFlowDefinitionRepository.findFirstByName(rollbackWorkflowName));
+		}
 
 		workFlowDefinition = workFlowDefinitionRepository.save(workFlowDefinition);
 
@@ -343,6 +348,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 	public void cleanAllDefinitionMappings() {
 		workFlowCheckerMappingDefinitionRepository.deleteAll();
 		workFlowWorkRepository.deleteAll();
+		workFlowDefinitionRepository.deleteAllFromRollbackMapping();
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/AssessmentInfrastructureWorkFlowPostInterceptor.java
@@ -71,7 +71,7 @@ public class AssessmentInfrastructureWorkFlowPostInterceptor implements WorkFlow
 		List<WorkFlowExecution> checkerExecutions = workFlowCheckerMappingDefinitions.stream().map(
 				workFlowCheckerDefinition -> workFlowRepository.findFirstByWorkFlowDefinitionIdAndMainWorkFlowExecution(
 						workFlowCheckerDefinition.getCheckWorkFlow().getId(), mainWorkFlowExecution))
-				.collect(Collectors.toList());
+				.toList();
 
 		for (WorkFlowExecution checkerExecution : checkerExecutions)
 			if (checkerExecution != null && checkerExecution.getStatus() == WorkStatus.REJECTED) {
@@ -81,9 +81,10 @@ public class AssessmentInfrastructureWorkFlowPostInterceptor implements WorkFlow
 				break;
 			}
 			else if (checkerExecution == null || checkerExecution.getStatus() == WorkStatus.FAILED) {
-				log.info("workflow: {} has a pending/running checker: {}", workFlowDefinition.getName(),
-						checkerExecution == null ? "checker is pending"
-								: checkerExecution.getWorkFlowDefinitionId().toString());
+				log.info("workflow: {} has a pending/running checker: {} in execution: {}",
+						workFlowDefinition.getName(), checkerExecution == null ? "checker is pending"
+								: checkerExecution.getWorkFlowDefinition().getName(),
+						mainWorkFlowExecution.getId());
 				workFlowExecution.setStatus(WorkStatus.IN_PROGRESS);
 				report = new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext);
 			}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/CheckerWorkFlowPostInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/CheckerWorkFlowPostInterceptor.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.workflow.execution.aspect;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
@@ -104,7 +105,9 @@ public class CheckerWorkFlowPostInterceptor implements WorkFlowPostInterceptor {
 		 */
 		if (workFlowService.findRunningChecker(mainWorkFlowExecution).isEmpty())
 			workFlowContinuationServiceImpl.continueWorkFlow(projectId, mainWorkFlowName, workContext,
-					mainWorkFlowExecution.getId());
+					mainWorkFlowExecution.getId(),
+					Optional.ofNullable(mainWorkFlowExecution.getWorkFlowDefinition().getRollbackWorkFlowDefinition())
+							.map(WorkFlowDefinition::getName).orElse(null));
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptor.java
@@ -50,7 +50,7 @@ public abstract class WorkFlowExecutionInterceptor implements WorkFlowIntercepto
 				WorkContextDelegate.read(workContext, WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION,
 						workFlowDefinition.getName(), WorkContextDelegate.Resource.ARGUMENTS));
 		UUID projectId = WorkContextUtils.getProjectId(workContext);
-		return workFlowService.saveWorkFlow(projectId, workFlowDefinition.getId(), WorkStatus.IN_PROGRESS,
+		return workFlowService.saveWorkFlow(projectId, workFlowDefinition, WorkStatus.IN_PROGRESS,
 				mainWorkFlowExecution, arguments);
 	}
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
@@ -37,6 +37,7 @@ import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -123,12 +124,14 @@ public class WorkFlowController {
 	}
 
 	@Operation(summary = "Returns workflows by project id")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Succeeded",
-					content = { @Content(mediaType = "application/json",
-							schema = @Schema(allOf = WorkFlowStatusResponseDTO.class)) }),
-			@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
-			@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content) })
+	@ApiResponses(
+			value = {
+					@ApiResponse(responseCode = "200", description = "Succeeded",
+							content = { @Content(mediaType = "application/json",
+									array = @ArraySchema(
+											schema = @Schema(implementation = WorkFlowResponseDTO.class))) }),
+					@ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+					@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content) })
 	@GetMapping()
 	public ResponseEntity<List<WorkFlowResponseDTO>> getStatusByProjectId(
 			@RequestParam(value = "projectId", required = false) UUID projectId) {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
@@ -30,6 +30,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import com.redhat.parodos.common.AbstractEntity;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,8 +60,9 @@ public class WorkFlowExecution extends AbstractEntity {
 
 	private Date endDate;
 
-	@Column(name = "workflow_definition_id")
-	private UUID workFlowDefinitionId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "workflow_definition_id")
+	private WorkFlowDefinition workFlowDefinition;
 
 	@Column(name = "project_id")
 	private UUID projectId;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepository.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepository.java
@@ -47,10 +47,10 @@ public interface WorkFlowRepository extends JpaRepository<WorkFlowExecution, UUI
 	@Query("SELECT w FROM prds_workflow_execution w WHERE w.status IN :statuses AND w.mainWorkFlowExecution IS NULL")
 	List<WorkFlowExecution> findByStatusInAndIsMain(@Param("statuses") List<WorkStatus> statuses);
 
-	@Query("SELECT w FROM prds_workflow_execution w WHERE w.status = com.redhat.parodos.workflows.work.WorkStatus.FAILED and w.mainWorkFlowExecution.id = :mainWorkflowId and EXISTS (SELECT f.type FROM prds_workflow_definition f WHERE f.id = w.workFlowDefinitionId AND f.type = com.redhat.parodos.workflow.enums.WorkFlowType.CHECKER)")
+	@Query("SELECT w FROM prds_workflow_execution w WHERE w.status = com.redhat.parodos.workflows.work.WorkStatus.FAILED and w.mainWorkFlowExecution.id = :mainWorkflowId and EXISTS (SELECT f.type FROM prds_workflow_definition f WHERE f.id = w.workFlowDefinition.id AND f.type = com.redhat.parodos.workflow.enums.WorkFlowType.CHECKER)")
 	List<WorkFlowExecution> findRunningCheckersById(@Param("mainWorkflowId") UUID mainWorkflowId);
 
-	@Query("SELECT w FROM prds_workflow_execution w WHERE w.mainWorkFlowExecution.id = :mainWorkflowId and EXISTS (SELECT f.type FROM prds_workflow_definition f WHERE f.id = w.workFlowDefinitionId AND f.type = com.redhat.parodos.workflow.enums.WorkFlowType.CHECKER)")
+	@Query("SELECT w FROM prds_workflow_execution w WHERE w.mainWorkFlowExecution.id = :mainWorkflowId and EXISTS (SELECT f.type FROM prds_workflow_definition f WHERE f.id = w.workFlowDefinition.id AND f.type = com.redhat.parodos.workflow.enums.WorkFlowType.CHECKER)")
 	List<WorkFlowExecution> findCheckers(@Param("mainWorkflowId") UUID mainWorkflowId);
 
 	WorkFlowExecution findFirstByProjectIdAndMainWorkFlowExecutionIsNullOrderByStartDateDesc(UUID projectId);

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutor.java
@@ -10,8 +10,10 @@ import org.springframework.scheduling.annotation.Async;
 public interface WorkFlowExecutor {
 
 	@Async
-	void executeAsync(UUID projectId, String workflowName, WorkContext workContext, UUID executionId);
+	void executeAsync(UUID projectId, String workflowName, WorkContext workContext, UUID executionId,
+			String rollbackWorkflowName);
 
-	WorkReport execute(UUID projectId, String workflowName, WorkContext workContext, UUID executionId);
+	WorkReport execute(UUID projectId, String workflowName, WorkContext workContext, UUID executionId,
+			String rollbackWorkflowName);
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImpl.java
@@ -1,12 +1,15 @@
 package com.redhat.parodos.workflow.execution.service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.WorkFlowDelegate;
+import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.engine.WorkFlowEngineBuilder;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,21 +21,39 @@ public class WorkFlowExecutorImpl implements WorkFlowExecutor {
 
 	private final WorkFlowDelegate workFlowDelegate;
 
-	public WorkFlowExecutorImpl(WorkFlowDelegate workFlowDelegate) {
+	private final WorkFlowRepository workFlowRepository;
+
+	public WorkFlowExecutorImpl(WorkFlowDelegate workFlowDelegate, WorkFlowRepository workFlowRepository) {
 		this.workFlowDelegate = workFlowDelegate;
+		this.workFlowRepository = workFlowRepository;
 	}
 
 	@Override
-	public void executeAsync(UUID projectId, String workflowName, WorkContext workContext, UUID executionId) {
-		execute(projectId, workflowName, workContext, executionId);
+	public void executeAsync(UUID projectId, String workflowName, WorkContext workContext, UUID executionId,
+			String rollbackWorkflowName) {
+		execute(projectId, workflowName, workContext, executionId, rollbackWorkflowName);
 	}
 
 	@Override
-	public WorkReport execute(UUID projectId, String workflowName, WorkContext workContext, UUID executionId) {
-		WorkFlow workFlow = workFlowDelegate.getWorkFlowExecutionByName(workflowName);
-		log.info("execute workFlow '{}': {}", workflowName, workFlow);
+	public WorkReport execute(UUID projectId, String workflowName, WorkContext workContext, UUID executionId,
+			String rollbackWorkflowName) {
+		WorkFlow workFlow = workFlowDelegate.getWorkFlowByName(workflowName);
+		log.info("execute workFlow {}", workflowName);
 		WorkContextUtils.updateWorkContextPartially(workContext, projectId, workflowName, executionId);
-		return WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(workFlow, workContext);
+		WorkReport report = WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(workFlow, workContext);
+		// need to use the status from db to avoid of repetitive execution on rollback
+		if (workFlowRepository.findById(executionId).map(execution -> execution.getStatus() == WorkStatus.FAILED)
+				.orElse(false)) {
+			Optional.ofNullable(workFlowDelegate.getWorkFlowByName(rollbackWorkflowName))
+					.ifPresentOrElse(rollbackWorkFlow -> {
+						log.error(
+								"The Infrastructure  workflow failed. Check the logs for errors coming for the Tasks in this workflow. Checking if there is a Rollback");
+						WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(rollbackWorkFlow, workContext);
+					}, () -> log.error(
+							"A rollback workflow could not be found for failed workflow: {} in execution: {}",
+							workflowName, executionId));
+		}
+		return report;
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowResponseDTO;
@@ -40,7 +41,7 @@ public interface WorkFlowService {
 
 	WorkFlowExecution getWorkFlowById(UUID workFlowExecutionId);
 
-	WorkFlowExecution saveWorkFlow(UUID projectId, UUID workFlowDefinitionId, WorkStatus workStatus,
+	WorkFlowExecution saveWorkFlow(UUID projectId, WorkFlowDefinition workFlowDefinition, WorkStatus workStatus,
 			WorkFlowExecution mainWorkFlowExecution, String arguments);
 
 	WorkFlowExecution updateWorkFlow(WorkFlowExecution workFlowExecution);

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
@@ -128,7 +128,7 @@ public class WorkFlowServiceDelegate {
 
 		// get workflow's works definition to find each status
 		List<WorkFlowWorkDefinition> workFlowWorksDefinitions = workFlowWorkRepository
-				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(workFlowExecution.getWorkFlowDefinitionId());
+				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(workFlowExecution.getWorkFlowDefinition().getId());
 
 		workFlowWorksDefinitions.forEach(workFlowWorkDefinition -> {
 			if (workFlowWorkDefinition.getWorkDefinitionType().equals(WorkType.WORKFLOW))

--- a/workflow-service/src/main/resources/db/changelog/tables.xml
+++ b/workflow-service/src/main/resources/db/changelog/tables.xml
@@ -206,5 +206,17 @@
                              referencedTableName="prds_workflow_checker_definition" referencedColumnNames="id"/>
             </column>
         </createTable>
+
+        <!-- Workflow Rollback join Table -->
+        <createTable tableName="prds_workflow_rollback_mapping">
+            <column name="workflow_rollback_definition_id" type="${uuidType}">
+                <constraints nullable="false" foreignKeyName="fk_workflow_rollback_definition_mapping_workflow_rollback_definition_id"
+                             referencedTableName="prds_workflow_definition" referencedColumnNames="id"/>
+            </column>
+            <column name="workflow_definition_id" type="${uuidType}">
+                <constraints nullable="false" foreignKeyName="fk_workflow_rollback_definition_mapping_workflow_definition_id"
+                             referencedTableName="prds_workflow_definition" referencedColumnNames="id"/>
+            </column>
+        </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -120,7 +120,7 @@ class WorkFlowDefinitionServiceImplTest {
 		// when
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = this.workFlowDefinitionService.save(workFlowName,
 				WorkFlowType.ASSESSMENT, properties, Collections.emptyList(), List.of(workFlowTask),
-				WorkFlowProcessingType.SEQUENTIAL);
+				WorkFlowProcessingType.SEQUENTIAL, null);
 
 		// then
 		assertNotNull(workFlowDefinitionResponseDTO);
@@ -162,7 +162,7 @@ class WorkFlowDefinitionServiceImplTest {
 		// when
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = this.workFlowDefinitionService.save(workFlowName,
 				WorkFlowType.ASSESSMENT, null, Collections.emptyList(), List.of(workFlowTask),
-				WorkFlowProcessingType.SEQUENTIAL);
+				WorkFlowProcessingType.SEQUENTIAL, null);
 
 		// then
 		assertNotNull(workFlowDefinitionResponseDTO);

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
@@ -90,7 +90,7 @@ class WorkFlowExecutionAspectTest {
 		WorkFlowDelegate workFlowDelegate = mock(WorkFlowDelegate.class);
 		this.workFlowExecutionAspect = new WorkFlowExecutionAspect(this.workFlowSchedulerService,
 				this.workFlowDefinitionRepository, workFlowExecutionFactory);
-		when(workFlowDelegate.getWorkFlowExecutionByName(any())).thenReturn(mock(WorkFlow.class));
+		when(workFlowDelegate.getWorkFlowByName(any())).thenReturn(mock(WorkFlow.class));
 		when(workflow.getName()).thenReturn(TEST);
 	}
 
@@ -122,7 +122,7 @@ class WorkFlowExecutionAspectTest {
 		when(workFlowRepository.findFirstByWorkFlowDefinitionIdAndMainWorkFlowExecution(any(), any()))
 				.thenReturn(workFlowExecution);
 		when(workFlowRepository.findById(any())).thenReturn(Optional.of(workFlowExecution));
-		doNothing().when(workFlowContinuationService).continueWorkFlow(any(), any(), any(), any());
+		doNothing().when(workFlowContinuationService).continueWorkFlow(any(), any(), any(), any(), any());
 		// when
 		WorkReport workReport = this.workFlowExecutionAspect.executeAroundAdvice(proceedingJoinPoint, workContext);
 
@@ -183,7 +183,7 @@ class WorkFlowExecutionAspectTest {
 		return new WorkFlowExecution() {
 			{
 				setId(UUID.randomUUID());
-				setWorkFlowDefinitionId(UUID.randomUUID());
+				setWorkFlowDefinition(WorkFlowDefinition.builder().build());
 				setStatus(WorkStatus.IN_PROGRESS);
 				setProjectId(UUID.randomUUID());
 			}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionInterceptorTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -103,8 +104,8 @@ public class WorkFlowExecutionInterceptorTest {
 		WorkReport result = interceptor.handlePostWorkFlowExecution(report, workFlow);
 
 		// then
-		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(UUID.class), eq(WorkStatus.IN_PROGRESS),
-				any(), anyString());
+		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(), eq(WorkStatus.IN_PROGRESS), any(),
+				anyString());
 		verify(workFlowSchedulerService, times(1)).schedule(any(), any(), any(WorkContext.class), any());
 
 		assertEquals(result.getStatus(), report.getStatus());
@@ -124,6 +125,7 @@ public class WorkFlowExecutionInterceptorTest {
 		when(workFlowDefinition.getCheckerWorkFlowDefinition())
 				.thenReturn(mock(WorkFlowCheckerMappingDefinition.class));
 		when(mainWorkFlowExecution.getId()).thenReturn(UUID.randomUUID());
+		when(mainWorkFlowExecution.getWorkFlowDefinition()).thenReturn(workFlowDefinition);
 
 		// when
 		WorkFlowExecution workFlowExecution = interceptor.handlePreWorkFlowExecution();
@@ -131,11 +133,11 @@ public class WorkFlowExecutionInterceptorTest {
 		WorkReport result = interceptor.handlePostWorkFlowExecution(report, workFlow);
 
 		// then
-		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(UUID.class), eq(WorkStatus.IN_PROGRESS),
-				any(), anyString());
+		verify(workFlowService, times(0)).saveWorkFlow(any(UUID.class), any(), eq(WorkStatus.IN_PROGRESS), any(),
+				anyString());
 		verify(workFlowSchedulerService, times(1)).stop(any(), any(WorkFlow.class));
 		verify(workFlowContinuationServiceImpl, times(1)).continueWorkFlow(any(UUID.class), anyString(),
-				any(WorkContext.class), any(UUID.class));
+				any(WorkContext.class), any(UUID.class), nullable(String.class));
 		assertEquals(result.getStatus(), report.getStatus());
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -57,8 +58,7 @@ class WorkFlowContinuationServiceImplTest {
 		this.workFlowRepository = mock(WorkFlowRepository.class);
 		this.workFlowTaskRepository = mock(WorkFlowTaskRepository.class);
 		this.workFlowExecutor = mock(WorkFlowExecutor.class);
-		this.service = new WorkFlowContinuationServiceImpl(this.workFlowDefinitionRepository, this.workFlowRepository,
-				this.workFlowExecutor);
+		this.service = new WorkFlowContinuationServiceImpl(this.workFlowRepository, this.workFlowExecutor);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class WorkFlowContinuationServiceImplTest {
 
 		// then
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		verify(this.workFlowExecutor, times(0)).executeAsync(any(), any(), any(), any());
+		verify(this.workFlowExecutor, times(0)).executeAsync(any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -86,7 +86,7 @@ class WorkFlowContinuationServiceImplTest {
 		// then
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
 		verify(this.workFlowExecutor, times(1)).executeAsync(eq(workFlowExecution.getProjectId()), eq(TEST_WORKFLOW),
-				any(), any());
+				any(), any(), nullable(String.class));
 	}
 
 	@Test
@@ -101,7 +101,7 @@ class WorkFlowContinuationServiceImplTest {
 		// then
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
 		verify(this.workFlowExecutor, times(1)).executeAsync(eq(workFlowExecution.getProjectId()), eq(TEST_WORKFLOW),
-				any(), any());
+				any(), any(), nullable(String.class));
 	}
 
 	@Test
@@ -126,7 +126,7 @@ class WorkFlowContinuationServiceImplTest {
 		// then
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
 		verify(this.workFlowExecutor, times(1)).executeAsync(eq(workFlowExecution.getProjectId()), eq(TEST_WORKFLOW),
-				any(), any());
+				any(), any(), nullable(String.class));
 	}
 
 	@Test
@@ -145,7 +145,7 @@ class WorkFlowContinuationServiceImplTest {
 		when(this.workFlowTaskRepository.findByWorkFlowExecutionId(wfExecution.getId()))
 				.thenReturn(List.of(workFlowTaskExecution));
 		doThrow(new RuntimeException("JsonParseException")).when(workFlowExecutor).executeAsync(any(), any(), any(),
-				any());
+				any(), any());
 
 		// when
 		Exception exception = assertThrows(RuntimeException.class, () -> this.service.workFlowRunAfterStartup());
@@ -155,7 +155,7 @@ class WorkFlowContinuationServiceImplTest {
 		assertTrue(exception.getMessage().contains("JsonParseException"));
 
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		verify(this.workFlowExecutor, times(1)).executeAsync(any(), any(), any(), any());
+		verify(this.workFlowExecutor, times(1)).executeAsync(any(), any(), any(), any(), any());
 
 	}
 
@@ -166,6 +166,7 @@ class WorkFlowContinuationServiceImplTest {
 		workFlowExecution.setArguments("{\"test\": \"test\"}");
 		workFlowExecution.setWorkFlowExecutionContext(WorkFlowExecutionContext.builder()
 				.mainWorkFlowExecution(workFlowExecution).workContext(new WorkContext()).build());
+		workFlowExecution.setWorkFlowDefinition(sampleWorkFlowDefinition());
 		return workFlowExecution;
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/repository/WorkFlowRepositoryTest.java
@@ -35,9 +35,8 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 	@Test
 	public void testSave() {
 		// given
-		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder()
-				.workFlowDefinitionId(createWorkFlowDefinition().getId()).status(WorkStatus.IN_PROGRESS)
-				.projectId(createProject().getId()).build();
+		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinition(createWorkFlowDefinition())
+				.status(WorkStatus.IN_PROGRESS).projectId(createProject().getId()).build();
 		List<WorkFlowExecution> workFlowExecutions = workFlowRepository.findAll();
 		assertTrue(workFlowExecutions.isEmpty());
 
@@ -48,7 +47,7 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 		flowExecution = workFlowRepository.getById(workFlowExecution.getId());
 		assertNotNull(flowExecution);
 		assertNotNull(flowExecution.getId());
-		assertEquals(workFlowExecution.getWorkFlowDefinitionId(), flowExecution.getWorkFlowDefinitionId());
+		assertEquals(workFlowExecution.getWorkFlowDefinition(), flowExecution.getWorkFlowDefinition());
 		assertEquals(workFlowExecution.getProjectId(), flowExecution.getProjectId());
 		assertEquals(WorkStatus.IN_PROGRESS, flowExecution.getStatus());
 	}
@@ -86,9 +85,9 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 	public void testFindByMainWorkFlowExecution() {
 		// given
 		WorkFlowExecution mainWorkFlowExecution = createWorkFlowExecution();
-		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder()
-				.workFlowDefinitionId(createWorkFlowDefinition().getId()).status(WorkStatus.IN_PROGRESS)
-				.projectId(createProject().getId()).mainWorkFlowExecution(mainWorkFlowExecution).build();
+		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinition(createWorkFlowDefinition())
+				.status(WorkStatus.IN_PROGRESS).projectId(createProject().getId())
+				.mainWorkFlowExecution(mainWorkFlowExecution).build();
 		workFlowExecution = workFlowRepository.save(workFlowExecution);
 
 		// when
@@ -105,9 +104,9 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 	public void testFindByStatusInAndIsMain() {
 		// given
 		WorkFlowExecution mainWorkFlowExecution = createWorkFlowExecution();
-		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder()
-				.workFlowDefinitionId(createWorkFlowDefinition().getId()).status(WorkStatus.IN_PROGRESS)
-				.projectId(createProject().getId()).mainWorkFlowExecution(mainWorkFlowExecution).build();
+		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinition(createWorkFlowDefinition())
+				.status(WorkStatus.IN_PROGRESS).projectId(createProject().getId())
+				.mainWorkFlowExecution(mainWorkFlowExecution).build();
 		workFlowRepository.save(workFlowExecution);
 
 		// when
@@ -132,9 +131,8 @@ public class WorkFlowRepositoryTest extends RepositoryTestBase {
 	}
 
 	private WorkFlowExecution createWorkFlowExecution() {
-		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder()
-				.workFlowDefinitionId(createWorkFlowDefinition().getId()).status(WorkStatus.IN_PROGRESS)
-				.projectId(createProject().getId()).build();
+		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinition(createWorkFlowDefinition())
+				.status(WorkStatus.IN_PROGRESS).projectId(createProject().getId()).build();
 		return entityManager.persist(workFlowExecution);
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImplTest.java
@@ -1,0 +1,92 @@
+package com.redhat.parodos.workflow.execution.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.redhat.parodos.workflow.WorkFlowDelegate;
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class WorkFlowExecutorImplTest {
+
+	@Mock
+	private WorkFlowDelegate workFlowDelegate;
+
+	@Mock
+	private WorkFlowRepository workFlowRepository;
+
+	@Mock
+	private WorkFlow mainWorkFlow;
+
+	@Mock
+	private WorkFlow rollbackWorkFlow;
+
+	private WorkFlowExecutorImpl workFlowExecutor;
+
+	private static final WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().build();
+
+	private static final UUID projectId = UUID.randomUUID();
+
+	private static final String workflowName = "test-workflow";
+
+	private static final WorkContext workContext = new WorkContext();
+
+	private static final UUID executionId = UUID.randomUUID();
+
+	private static final String rollbackWorkflowName = "test-rollback-workflow";
+
+	@BeforeEach
+	public void init() {
+		when(workFlowDelegate.getWorkFlowByName(workflowName)).thenReturn(mainWorkFlow);
+		when(workFlowDelegate.getWorkFlowByName(rollbackWorkflowName)).thenReturn(rollbackWorkFlow);
+		when(workFlowRepository.findById(executionId)).thenReturn(Optional.of(workFlowExecution));
+		when(rollbackWorkFlow.execute(any())).thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+		when(mainWorkFlow.execute(any())).thenReturn(new DefaultWorkReport(WorkStatus.FAILED, workContext));
+		workFlowExecutor = new WorkFlowExecutorImpl(workFlowDelegate, workFlowRepository);
+	}
+
+	@Test
+	void execute_when_mainWorkflowIsFailed_and_rollbackIsFound_then_executeRollback() {
+		workFlowExecution.setStatus(WorkStatus.FAILED);
+		workFlowExecutor.execute(projectId, workflowName, workContext, executionId, rollbackWorkflowName);
+
+		verify(mainWorkFlow, Mockito.times(1)).execute(any(WorkContext.class));
+		verify(rollbackWorkFlow, Mockito.times(1)).execute(any(WorkContext.class));
+
+	}
+
+	@Test
+	void execute_when_mainWorkflowIsFailed_and_rollbackIsNotFound_then_notExecuteRollback() {
+		workFlowExecution.setStatus(WorkStatus.FAILED);
+		workFlowExecutor.execute(projectId, workflowName, workContext, executionId, null);
+
+		verify(mainWorkFlow, Mockito.times(1)).execute(any(WorkContext.class));
+		verify(rollbackWorkFlow, Mockito.never()).execute(any(WorkContext.class));
+	}
+
+	@Test
+	void execute_when_mainWorkflowIsCompleted_then_notExecuteRollback() {
+		workFlowExecution.setStatus(WorkStatus.COMPLETED);
+		workFlowExecutor.execute(projectId, workflowName, workContext, executionId, rollbackWorkflowName);
+
+		verify(mainWorkFlow, Mockito.times(1)).execute(any(WorkContext.class));
+		verify(rollbackWorkFlow, Mockito.never()).execute(any(WorkContext.class));
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegateTest.java
@@ -71,7 +71,7 @@ public class WorkFlowServiceDelegateTest {
 				.build();
 		workFlowDefinition.setId(workFlowDefinitionId);
 
-		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinitionId(workFlowDefinitionId)
+		WorkFlowExecution workFlowExecution = WorkFlowExecution.builder().workFlowDefinition(workFlowDefinition)
 				.status(WorkStatus.IN_PROGRESS).build();
 		workFlowExecution.setId(workFlowExecutionId);
 
@@ -85,7 +85,7 @@ public class WorkFlowServiceDelegateTest {
 		testSubWorkFlowDefinition1.setId(testSubWorkFlowDefinitionId1);
 		// sub workflow execution 1
 		WorkFlowExecution testSubWorkFlowExecution1 = WorkFlowExecution.builder().projectId(projectId)
-				.status(WorkStatus.IN_PROGRESS).workFlowDefinitionId(testSubWorkFlowDefinitionId1)
+				.status(WorkStatus.IN_PROGRESS).workFlowDefinition(testSubWorkFlowDefinition1)
 				.mainWorkFlowExecution(workFlowExecution).build();
 		testSubWorkFlowExecution1.setId(testSubWorkFlowExecutionId1);
 
@@ -363,7 +363,7 @@ public class WorkFlowServiceDelegateTest {
 					.workFlowTaskDefinitions(List.of(checkerWorkFlowTaskDefinition)).build();
 			checkerWorkflowDefinition.setId(checkerWorkFlowDefinitionId);
 			// workflow execution
-			checkerWorkflowExecution = WorkFlowExecution.builder().workFlowDefinitionId(checkerWorkFlowDefinitionId)
+			checkerWorkflowExecution = WorkFlowExecution.builder().workFlowDefinition(checkerWorkflowDefinition)
 					.status(WorkStatus.FAILED).build();
 			checkerWorkflowExecution.setId(checkerWorkFlowExecutionId);
 
@@ -382,7 +382,7 @@ public class WorkFlowServiceDelegateTest {
 			masterWorkflowDefinition = WorkFlowDefinition.builder().name(workFlowName).numberOfWorks(1).build();
 			masterWorkflowDefinition.setId(masterWorkFlowDefinitionId);
 
-			masterWorkflowExecution = WorkFlowExecution.builder().workFlowDefinitionId(masterWorkFlowDefinitionId)
+			masterWorkflowExecution = WorkFlowExecution.builder().workFlowDefinition(masterWorkflowDefinition)
 					.projectId(projectId).status(WorkStatus.IN_PROGRESS).build();
 			masterWorkflowExecution.setId(masterWorkFlowExecutionId);
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImplTest.java
@@ -1,6 +1,7 @@
 package com.redhat.parodos.workflow.registry;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
 import com.redhat.parodos.workflow.enums.WorkFlowProcessingType;
@@ -48,7 +49,7 @@ class BeanWorkFlowRegistryImplTest {
 
 		// then
 		verify(this.beanFactory, times(0)).getDependenciesForBean(any());
-		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any());
+		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -76,7 +77,7 @@ class BeanWorkFlowRegistryImplTest {
 		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
 
 		verify(this.workFlowDefinitionService, times(1)).save(eq(TEST), eq(WorkFlowType.ASSESSMENT), any(), anyList(),
-				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL));
+				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL), nullable(String.class));
 
 		assertEquals(registry.getWorkFlowByName(TEST), workFlow);
 	}
@@ -92,7 +93,7 @@ class BeanWorkFlowRegistryImplTest {
 		BeanDefinition beanDefinition = mock(BeanDefinition.class);
 		when(beanDefinition.getSource()).thenReturn(bean);
 		when(this.beanFactory.getBeanDefinition(any())).thenReturn(beanDefinition);
-
+		when(bean.getAnnotationAttributes(any())).thenReturn(Map.of());
 		when(this.beanFactory.getDependenciesForBean(eq(TEST_TASK))).thenReturn(new String[] { TASK_DEPENDENCY });
 
 		// when
@@ -106,7 +107,7 @@ class BeanWorkFlowRegistryImplTest {
 		// then
 		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
 		verify(this.workFlowDefinitionService, times(1)).save(eq("test"), eq(WorkFlowType.ASSESSMENT), any(), anyList(),
-				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL));
+				anyList(), eq(WorkFlowProcessingType.SEQUENTIAL), nullable(String.class));
 
 		verify(this.workFlowDefinitionService, times(0)).saveWorkFlowChecker(eq(TEST_TASK), eq(TASK_DEPENDENCY), any());
 	}
@@ -135,8 +136,7 @@ class BeanWorkFlowRegistryImplTest {
 		// then
 		assertNotNull(exception);
 
-		verify(this.beanFactory, times(1)).getDependenciesForBean(any());
-		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any());
+		verify(this.workFlowDefinitionService, times(0)).save(any(), any(), any(), any(), any(), any(), any());
 		assertEquals(registry.getWorkFlowByName(TEST), workFlow);
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
1) User may want to rollback executions if the workflow is failed

2) misleading swagger response with list:

<img width="545" alt="Screenshot 2023-05-09 at 4 22 54 PM" src="https://github.com/parodos-dev/parodos/assets/58698556/7797d78b-e456-4472-b5bd-399fddeeda4e">

**Which issue(s) this PR fixes**:
Fixes #[FLPATH-303](https://issues.redhat.com//browse/FLPATH-303) #[FLPATH-358](https://issues.redhat.com//browse/FLPATH-358)

**Change type**
- [x] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [x] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
