### PR TITLE
fix: check workflow exists when executing

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
@@ -82,6 +82,10 @@ public class WorkFlowExecutionAspect {
 
 		/* get workflow definition entity */
 		WorkFlowDefinition workFlowDefinition = this.workFlowDefinitionRepository.findFirstByName(workflowName);
+		if (workFlowDefinition == null) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, new Exception("Cannot find workflow '"+ workflowName + "'"));
+		}
+
 		WorkFlowExecutionInterceptor executionHandler = workFlowExecutionFactory
 				.createExecutionHandler(workFlowDefinition, workContext);
 		WorkFlowExecution workFlowExecution = executionHandler.handlePreWorkFlowExecution();

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspect.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.execution.aspect;
 
+import com.redhat.parodos.common.exceptions.IDType;
+import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
+import com.redhat.parodos.common.exceptions.ResourceType;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
 import com.redhat.parodos.workflow.enums.WorkFlowType;
@@ -83,9 +86,9 @@ public class WorkFlowExecutionAspect {
 		/* get workflow definition entity */
 		WorkFlowDefinition workFlowDefinition = this.workFlowDefinitionRepository.findFirstByName(workflowName);
 		if (workFlowDefinition == null) {
-			return new DefaultWorkReport(WorkStatus.FAILED, workContext, new Exception("Cannot find workflow '"+ workflowName + "'"));
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new ResourceNotFoundException(ResourceType.WORKFLOW_DEFINITION, IDType.NAME, workflowName));
 		}
-
 		WorkFlowExecutionInterceptor executionHandler = workFlowExecutionFactory
 				.createExecutionHandler(workFlowDefinition, workContext);
 		WorkFlowExecution workFlowExecution = executionHandler.handlePreWorkFlowExecution();

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowExecutionAspectTest.java
@@ -137,6 +137,27 @@ class WorkFlowExecutionAspectTest {
 	}
 
 	@Test
+	void ExecuteAroundAdviceWithInProgressWorkFlowTestWithoutWorkFlowDefinition() {
+		// given
+		WorkContext workContext = new WorkContext();
+		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(null);
+		ProceedingJoinPoint proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+		WorkFlow workFlow = mock(WorkFlow.class);
+		when(proceedingJoinPoint.getTarget()).thenReturn(workFlow);
+		when(workFlow.getName()).thenReturn(TEST_WORK_FLOW);
+
+
+		// when
+		WorkReport workReport = this.workFlowExecutionAspect.executeAroundAdvice(proceedingJoinPoint, workContext);
+
+		// then
+		assertNotNull(workReport);
+		assertEquals(workReport.getStatus().toString(), FAILED);
+		assertNotNull(workReport.getError());
+		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(TEST_WORK_FLOW);
+	}
+
+	@Test
 	void ExecuteAroundAdviceWithInProgressWorkFlowTest() {
 		// given
 		UUID projectID = UUID.randomUUID();


### PR DESCRIPTION
User may introduce a typo and the output is not great:

```
2023-05-11 10:23:13.200 ERROR 52759 --- [         task-6] .a.i.SimpleAsyncUncaughtExceptionHandler : Unexpected exception occurred invoking async method: public void com.redhat.parodos.workflow.execution.service.WorkFlowExecutorImpl.executeAsync(java.util.UUID,java.lang.String,com.redhat.parodos.workflows.work.WorkContext,java.util.UUID)

java.lang.NullPointerException: Cannot invoke "com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition.getName()" because "workflow" is null
        at com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.isMainWorkFlow(WorkFlowExecutionFactory.java:55) ~[classes!/:na]
        at com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionFactory.createExecutionHandler(WorkFlowExecutionFactory.java:38) ~[classes!/:na]
        at com.redhat.parodos.workflow.execution.aspect.WorkFlowExecutionAspect.executeAroundAdvice(WorkFlowExecutionAspect.java:86) ~[classes!/:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at com.redhat.parodos.workflows.workflow.ParallelFlow$$EnhancerBySpringCGLIB$$7530a326.execute(<generated>) ~[workflow-engine-1.0.11-SNAPSHOT.jar!/:na]
        at com.redhat.parodos.workflows.engine.WorkFlowEngineImpl.run(WorkFlowEngineImpl.java:38) ~[workflow-engine-1.0.11-SNAPSHOT.jar!/:na]
        at com.redhat.parodos.workflow.execution.service.WorkFlowExecutorImpl.execute(WorkFlowExecutorImpl.java:35) ~[classes!/:na]
        at com.redhat.parodos.workflow.execution.service.WorkFlowExecutorImpl.executeAsync(WorkFlowExecutorImpl.java:27) ~[classes!/:na]
        at com.redhat.parodos.workflow.execution.service.WorkFlowExecutorImpl$$FastClassBySpringCGLIB$$510b4225.invoke(<generated>) ~[classes!/:na]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[workflow-examples-1.0.11-SNAPSHOT-jar-with-dependencies.jar:5.3.20]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) ~[spring-aop-5.3.20.jar!/:5.3.20]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- If the PR includes auto generated code, make sure to add this code in different commit (last commit), to make the review process easier.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (FLPATH-xxxx)*:
Fixes #

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
