### PR TITLE
FLPATH-394 - Speedup integration test execution

### DIFF
--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/SdkUtils.java
@@ -286,9 +286,6 @@ public abstract class SdkUtils {
 	public static ProjectResponseDTO getProjectAsync(ApiClient apiClient, String projectName, String projectDescription)
 			throws InterruptedException, ApiException {
 		ProjectApi projectApi = new ProjectApi(apiClient);
-		log.info("Wait project to be ready on {}", apiClient.getBasePath());
-		waitProjectStart(projectApi);
-		log.info("Project is ✔️ on {}", apiClient.getBasePath());
 
 		ProjectResponseDTO testProject;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Integration tests execution currently requires 8m 40s ( see [Run integration tests](https://github.com/parodos-dev/parodos/actions/runs/4990582754/jobs/8936101871) step) .

This PR drop the execution time to about 35 seconds (see [Run integration tests](https://github.com/gciavarrini/parodos/actions/runs/4993743211/jobs/8943438767) of a developing branch).

Fixes [FLPATH-394](https://issues.redhat.com/browse/FLPATH-394)
Depends on #281 

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [x] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
