### PR TITLE
Change parameter key of workflow definition to non-empty

### DIFF
--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -1295,6 +1295,8 @@ components:
           type: string
         workName:
           type: string
+      required:
+      - key
       type: object
     WorkParameterValueResponseDTO:
       example:

--- a/workflow-service-sdk/docs/WorkParameterValueRequestDTO.md
+++ b/workflow-service-sdk/docs/WorkParameterValueRequestDTO.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**key** | **String** |  |  [optional] |
+|**key** | **String** |  |  |
 |**value** | **String** |  |  [optional] |
 |**workName** | **String** |  |  [optional] |
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkParameterValueRequestDTO.java
@@ -63,7 +63,7 @@ public class WorkParameterValueRequestDTO {
 	 * Get key
 	 * @return key
 	 **/
-	@javax.annotation.Nullable
+	@javax.annotation.Nonnull
 
 	public String getKey() {
 		return key;
@@ -167,6 +167,7 @@ public class WorkParameterValueRequestDTO {
 
 		// a set of required properties/fields (JSON key names)
 		openapiRequiredFields = new HashSet<String>();
+		openapiRequiredFields.add("key");
 	}
 
 	/**
@@ -200,7 +201,17 @@ public class WorkParameterValueRequestDTO {
 						entry.getKey(), jsonObj.toString()));
 			}
 		}
-		if ((jsonObj.get("key") != null && !jsonObj.get("key").isJsonNull()) && !jsonObj.get("key").isJsonPrimitive()) {
+
+		// check to make sure all required properties/fields are present in the JSON
+		// string
+		for (String requiredField : WorkParameterValueRequestDTO.openapiRequiredFields) {
+			if (jsonObj.get(requiredField) == null) {
+				throw new IllegalArgumentException(
+						String.format("The required field `%s` is not found in the JSON string: %s", requiredField,
+								jsonObj.toString()));
+			}
+		}
+		if (!jsonObj.get("key").isJsonPrimitive()) {
 			throw new IllegalArgumentException(
 					String.format("Expected the field `key` to be a primitive type in the JSON string but got `%s`",
 							jsonObj.get("key").toString()));

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -1309,6 +1309,7 @@
         }
       },
       "WorkParameterValueRequestDTO" : {
+        "required" : [ "key" ],
         "type" : "object",
         "properties" : {
           "key" : {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionController.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import javax.validation.Valid;
+
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkParameterValueResponseDTO;
@@ -116,7 +118,7 @@ public class WorkFlowDefinitionController {
 	@PostMapping("/{workflowDefinitionName}/parameters/update/{valueProviderName}")
 	public ResponseEntity<List<WorkParameterValueResponseDTO>> updateParameter(
 			@PathVariable String workflowDefinitionName, @PathVariable String valueProviderName,
-			@RequestBody List<WorkParameterValueRequestDTO> workParameterValueRequestDTOS) {
+			@RequestBody @Valid List<WorkParameterValueRequestDTO> workParameterValueRequestDTOS) {
 		return ResponseEntity.ok(workParameterService.getValues(workflowDefinitionName, valueProviderName,
 				workParameterValueRequestDTOS));
 	}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkParameterValueRequestDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkParameterValueRequestDTO.java
@@ -1,5 +1,7 @@
 package com.redhat.parodos.workflow.definition.dto;
 
+import javax.validation.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class WorkParameterValueRequestDTO {
 
+	@NotEmpty
 	private String key;
 
 	private String value;

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
@@ -7,8 +7,10 @@ import com.redhat.parodos.ControllerMockClient;
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
 import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
+import com.redhat.parodos.workflow.definition.dto.WorkParameterValueRequestDTO;
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
 import org.hamcrest.Matchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +67,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 	}
 
 	@Test
-	public void ListWorkfFlowDefinitionsWithinvalidCredentials() throws Exception {
+	public void ListWorkflowDefinitionsWithInvalidCredentials() throws Exception {
 		// when
 		this.mockMvc.perform(this.getRequestWithInValidCredentials("/api/v1/workflowdefinitions"))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
@@ -121,6 +123,44 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 
 		// then
 		verify(this.workFlowDefinitionService, never()).getWorkFlowDefinitionById(any());
+	}
+
+	@Test
+	public void testUpdateParameter() throws Exception {
+		// given
+		String workflowDefinitionName = "workflow-foo";
+		String valueProviderName = "valueProvider-foo";
+		WorkParameterValueRequestDTO requestDTO = new WorkParameterValueRequestDTO("param1", "value1",
+				workflowDefinitionName);
+		List<WorkParameterValueRequestDTO> workParameterValueRequestDTOs = List.of(requestDTO);
+
+		// when
+		// then
+		String content = JSONObject.valueToString(workParameterValueRequestDTOs);
+		this.mockMvc.perform(this
+				.postRequestWithValidCredentials(String.format("/api/v1/workflowdefinitions/%s/parameters/update/%s",
+						workflowDefinitionName, valueProviderName))
+				.content(content)).andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
+	public void testUpdateParameter_EmptyParameterKey() throws Exception {
+		// given
+		String workflowDefinitionName = "workflow-foo";
+		String valueProviderName = "valueProvider-foo";
+		WorkParameterValueRequestDTO requestDTO = new WorkParameterValueRequestDTO(null, "value1",
+				workflowDefinitionName);
+		List<WorkParameterValueRequestDTO> workParameterValueRequestDTOs = List.of(requestDTO);
+
+		// when
+		// then
+		String content = JSONObject.valueToString(workParameterValueRequestDTOs);
+		this.mockMvc
+				.perform(this.postRequestWithValidCredentials(
+						String.format("/api/v1/workflowdefinitions/%s/parameters/update/%s", workflowDefinitionName,
+								valueProviderName))
+						.content(content))
+				.andExpect(MockMvcResultMatchers.status().isBadRequest());
 	}
 
 	private WorkFlowDefinitionResponseDTO createSampleWorkFlowDefinition(String name) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We'd like to validate the incoming request parameters and make sure any parameter has a key.

**Which issue(s) this PR fixes**:
Fixes #[FLPATH-333](https://issues.redhat.com//browse/FLPATH-333)


**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
