### PR TITLE
Create Makefile target `deploy-to-kind`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,3 +230,13 @@ stop-postgres:
 format-files:
 	mvn spring-javaformat:apply
 	mvn impsort:sort
+
+.PHONY: install-kubernetes-dependencies-and-wait deploy-to-kind
+
+install-kubernetes-dependencies-and-wait: install-kubernetes-dependencies
+	sleep 10
+
+deploy-to-kind: install-kubernetes-dependencies-and-wait wait-kubernetes-dependencies build-images tag-images push-images-to-kind
+	kubectl kustomize hack/manifests/testing | kubectl apply -f -
+	kubectl wait --timeout=300s --for=condition=Ready pods --all -n default
+	kubectl get pods -A


### PR DESCRIPTION
**What this PR does / why we need it**:
To ease the deploying of Parodos in a Kind cluster use this new `make deploy-to-kind` target

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
