### PR TITLE
Update exception to concrete type

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
@@ -53,17 +53,15 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public UserResponseDTO getUserById(UUID id) {
-		return modelMapper.map(
-				userRepository.findById(id)
-						.orElseThrow(() -> new RuntimeException(String.format("User with id: %s not found", id))),
-				UserResponseDTO.class);
+		return modelMapper.map(userRepository.findById(id).orElseThrow(
+				() -> new ResourceNotFoundException(ResourceType.USER, IDType.ID, id)), UserResponseDTO.class);
 	}
 
 	@Override
 	public UserResponseDTO getUserByUsername(String username) {
 		Optional<User> user = userRepository.findByUsername(username);
 		if (!user.isPresent()) {
-			throw new RuntimeException(String.format("User with username: %s not found", username));
+			throw new ResourceNotFoundException(ResourceType.USER, IDType.NAME, username);
 		}
 		return modelMapper.map(user.get(), UserResponseDTO.class);
 	}

--- a/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/user/service/UserServiceImplTest.java
@@ -3,6 +3,7 @@ package com.redhat.parodos.user.service;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
 import com.redhat.parodos.user.dto.UserResponseDTO;
 import com.redhat.parodos.user.entity.User;
 import com.redhat.parodos.user.repository.UserRepository;
@@ -74,11 +75,12 @@ class UserServiceImplTest {
 		when(this.userRepository.findById(user.getId())).thenReturn(Optional.empty());
 
 		// when
-		Exception exception = assertThrows(RuntimeException.class, () -> this.service.getUserById(user.getId()));
+		Exception exception = assertThrows(ResourceNotFoundException.class,
+				() -> this.service.getUserById(user.getId()));
 
 		// then
 		assertNotNull(exception);
-		assertEquals(exception.getMessage(), format("User with id: %s not found", user.getId()));
+		assertEquals(exception.getMessage(), format("User with ID: %s not found", user.getId()));
 		verify(this.userRepository, times(1)).findById(any());
 	}
 
@@ -106,7 +108,7 @@ class UserServiceImplTest {
 		when(this.userRepository.findByUsername(user.getUsername())).thenReturn(Optional.empty());
 
 		// then
-		assertThrows(RuntimeException.class, () -> this.service.getUserByUsername(user.getUsername()));
+		assertThrows(ResourceNotFoundException.class, () -> this.service.getUserByUsername(user.getUsername()));
 		verify(this.userRepository, times(1)).findByUsername(any());
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to leverage the global exception handler, throw a specific type instead of RuntimeException to indicate a resource was not found.

**Which issue(s) this PR fixes** :
Fixes #[FLPATH-342](https://issues.redhat.com/browse/FLPATH-342)

**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
