### PR TITLE
Refactor ResourceNotFoundException

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/ResourceNotFoundException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/ResourceNotFoundException.java
@@ -14,8 +14,8 @@ public class ResourceNotFoundException extends RuntimeException {
 		super(String.format("%s with %s: %s not found", resourceType.getName(), idType.getType(), resourceId));
 	}
 
-	public ResourceNotFoundException(ResourceType resourceType, IDType idType, UUID resourceId) {
-		super(String.format("%s with %s: %s not found", resourceType.getName(), idType.getType(),
+	public ResourceNotFoundException(ResourceType resourceType, UUID resourceId) {
+		super(String.format("%s with %s: %s not found", resourceType.getName(), IDType.ID.getType(),
 				resourceId.toString()));
 	}
 

--- a/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/service/ProjectServiceImpl.java
@@ -99,10 +99,8 @@ public class ProjectServiceImpl implements ProjectService {
 
 	@Override
 	public ProjectResponseDTO getProjectById(UUID id) {
-		return modelMapper.map(
-				projectRepository.findById(id)
-						.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, IDType.ID, id)),
-				ProjectResponseDTO.class);
+		return modelMapper.map(projectRepository.findById(id)
+				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, id)), ProjectResponseDTO.class);
 	}
 
 	@Override
@@ -127,7 +125,7 @@ public class ProjectServiceImpl implements ProjectService {
 	@Transactional
 	public ProjectUserRoleResponseDTO updateUserRolesToProject(UUID id, List<UserRoleRequestDTO> userRoleRequestDTOs) {
 		Project project = projectRepository.findById(id)
-				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, IDType.ID, id));
+				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, id));
 
 		Set<ProjectUserRole> projectUserRoles = userRoleRequestDTOs.stream()
 				.map(userRoleRequestDTO -> userRoleRequestDTO.getRoles().stream()
@@ -153,7 +151,7 @@ public class ProjectServiceImpl implements ProjectService {
 	@Override
 	public ProjectUserRoleResponseDTO removeUsersFromProject(UUID id, List<String> usernames) {
 		Project project = projectRepository.findById(id)
-				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, IDType.ID, id));
+				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.PROJECT, id));
 
 		projectUserRoleRepository.deleteAllByIdProjectIdAndIdUserIdIn(project.getId(),
 				userService.findAllUserEntitiesByUsernameIn(usernames).stream().map(AbstractEntity::getId).toList());

--- a/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/user/service/UserServiceImpl.java
@@ -53,8 +53,9 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public UserResponseDTO getUserById(UUID id) {
-		return modelMapper.map(userRepository.findById(id).orElseThrow(
-				() -> new ResourceNotFoundException(ResourceType.USER, IDType.ID, id)), UserResponseDTO.class);
+		return modelMapper.map(
+				userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException(ResourceType.USER, id)),
+				UserResponseDTO.class);
 	}
 
 	@Override
@@ -74,8 +75,7 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public User getUserEntityById(UUID id) {
-		return userRepository.findById(id)
-				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.USER, IDType.ID, id));
+		return userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException(ResourceType.USER, id));
 	}
 
 	@Override

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -197,7 +197,7 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 	@Override
 	public WorkFlowDefinitionResponseDTO getWorkFlowDefinitionById(UUID id) {
 		WorkFlowDefinition workFlowDefinition = workFlowDefinitionRepository.findById(id)
-				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.WORKFLOW_DEFINITION, IDType.ID, id));
+				.orElseThrow(() -> new ResourceNotFoundException(ResourceType.WORKFLOW_DEFINITION, id));
 		List<WorkFlowWorkDefinition> workFlowWorkDependencies = workFlowWorkRepository
 				.findByWorkFlowDefinitionIdOrderByCreateDateAsc(workFlowDefinition.getId()).stream()
 				.sorted(Comparator.comparing(WorkFlowWorkDefinition::getCreateDate)).toList();

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 
 import javax.annotation.PreDestroy;
 
-import com.redhat.parodos.common.exceptions.IDType;
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
 import com.redhat.parodos.common.exceptions.ResourceType;
 import com.redhat.parodos.project.dto.ProjectResponseDTO;
@@ -217,13 +216,12 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 	@Override
 	public WorkFlowStatusResponseDTO getWorkFlowStatus(UUID workFlowExecutionId) {
 		WorkFlowExecution workFlowExecution = workFlowRepository.findById(workFlowExecutionId).orElseThrow(() -> {
-			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, IDType.ID, workFlowExecutionId);
+			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, workFlowExecutionId);
 		});
 
 		WorkFlowDefinition workFlowDefinition = Optional.ofNullable(workFlowExecution.getWorkFlowDefinition())
 				.orElseThrow(() -> {
-					throw new ResourceNotFoundException(ResourceType.WORKFLOW_DEFINITION, IDType.ID,
-							workFlowExecution.getId());
+					throw new ResourceNotFoundException(ResourceType.WORKFLOW_DEFINITION, workFlowExecution.getId());
 				});
 
 		// check if it is not an inner workflow
@@ -245,7 +243,7 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 	public WorkFlowContextResponseDTO getWorkflowParameters(UUID workFlowExecutionId,
 			List<WorkContextDelegate.Resource> params) {
 		WorkFlowExecution workFlowExecution = workFlowRepository.findById(workFlowExecutionId).orElseThrow(() -> {
-			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, IDType.ID, workFlowExecutionId);
+			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, workFlowExecutionId);
 		});
 		Map options = Map.of();
 		if (params.contains(WorkContextDelegate.Resource.WORKFLOW_OPTIONS)) {
@@ -312,7 +310,7 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 			WorkStatus workFlowTaskStatus) {
 		// get main workflow associated to the execution id
 		WorkFlowExecution mainWorkFlowExecution = workFlowRepository.findById(workFlowExecutionId).orElseThrow(() -> {
-			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, IDType.ID, workFlowExecutionId);
+			throw new ResourceNotFoundException(ResourceType.WORKFLOW_EXECUTION, workFlowExecutionId);
 		});
 		// get workflow checker task definition
 		WorkFlowTaskDefinition workFlowTaskDefinition = workFlowTaskDefinitionRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
We'll use the c'tor to specify ID only when ID is the resource type to be used. Hence we can spare the redundant information from the signature of the c'tor.

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
