### PR TITLE
Use global exception handler in notification service

### DIFF
--- a/notification-service-sdk/api/openapi.yaml
+++ b/notification-service-sdk/api/openapi.yaml
@@ -32,6 +32,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorMessageDTO'
           description: Bad Request
+        "404":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorMessageDTO'
+          description: Not Found
       tags:
       - Notification Message
       x-content-type: application/json
@@ -113,6 +119,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/PageNotificationRecordResponseDTO'
           description: Forbidden
+        "404":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorMessageDTO'
+          description: Not Found
       summary: Return a list of notification records for the user
       tags:
       - Notification Record
@@ -159,6 +171,12 @@ paths:
                 format: int32
                 type: integer
           description: Forbidden
+        "404":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorMessageDTO'
+          description: Not Found
       summary: Return the number of the unread notification records for the user
       tags:
       - Notification Record
@@ -188,6 +206,12 @@ paths:
           description: Unauthorized
         "403":
           description: Forbidden
+        "404":
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorMessageDTO'
+          description: Not Found
       summary: Delete the specified notification record
       tags:
       - Notification Record
@@ -236,7 +260,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/NotificationRecordResponseDTO'
+                $ref: '#/components/schemas/ErrorMessageDTO'
           description: Not found
       summary: Update the specified notification record with user operation
       tags:

--- a/notification-service-sdk/docs/NotificationMessageApi.md
+++ b/notification-service-sdk/docs/NotificationMessageApi.md
@@ -66,4 +66,5 @@ No authorization required
 |-------------|-------------|------------------|
 | **201** | Created |  -  |
 | **400** | Bad Request |  -  |
+| **404** | Not Found |  -  |
 

--- a/notification-service-sdk/docs/NotificationRecordApi.md
+++ b/notification-service-sdk/docs/NotificationRecordApi.md
@@ -72,6 +72,7 @@ No authorization required
 | **400** | Bad Request |  -  |
 | **401** | Unauthorized |  -  |
 | **403** | Forbidden |  -  |
+| **404** | Not Found |  -  |
 
 <a name="deleteNotification"></a>
 # **deleteNotification**
@@ -134,6 +135,7 @@ No authorization required
 | **400** | Bad Request |  -  |
 | **401** | Unauthorized |  -  |
 | **403** | Forbidden |  -  |
+| **404** | Not Found |  -  |
 
 <a name="getNotifications"></a>
 # **getNotifications**
@@ -205,6 +207,7 @@ No authorization required
 | **400** | Bad request |  -  |
 | **401** | Unauthorized |  -  |
 | **403** | Forbidden |  -  |
+| **404** | Not Found |  -  |
 
 <a name="updateNotificationStatusById"></a>
 # **updateNotificationStatusById**

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationMessageApi.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationMessageApi.java
@@ -82,6 +82,11 @@ public class NotificationMessageApi {
 	 * <td>Bad Request</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public okhttp3.Call createCall(NotificationMessageCreateRequestDTO notificationMessageCreateRequestDTO,
@@ -165,6 +170,11 @@ public class NotificationMessageApi {
 	 * <td>Bad Request</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public void create(NotificationMessageCreateRequestDTO notificationMessageCreateRequestDTO) throws ApiException {
@@ -191,6 +201,11 @@ public class NotificationMessageApi {
 	 * <tr>
 	 * <td>400</td>
 	 * <td>Bad Request</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -223,6 +238,11 @@ public class NotificationMessageApi {
 	 * <tr>
 	 * <td>400</td>
 	 * <td>Bad Request</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>

--- a/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationRecordApi.java
+++ b/notification-service-sdk/src/main/java/com/redhat/parodos/notification/sdk/api/NotificationRecordApi.java
@@ -96,6 +96,11 @@ public class NotificationRecordApi {
 	 * <td>Forbidden</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public okhttp3.Call countUnreadNotificationsCall(String state, final ApiCallback _callback) throws ApiException {
@@ -193,6 +198,11 @@ public class NotificationRecordApi {
 	 * <td>Forbidden</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public Integer countUnreadNotifications(String state) throws ApiException {
@@ -231,6 +241,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -276,6 +291,11 @@ public class NotificationRecordApi {
 	 * <td>Forbidden</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public okhttp3.Call countUnreadNotificationsAsync(String state, final ApiCallback<Integer> _callback)
@@ -319,6 +339,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -413,6 +438,11 @@ public class NotificationRecordApi {
 	 * <td>Forbidden</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public void deleteNotification(UUID id) throws ApiException {
@@ -450,6 +480,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -491,6 +526,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -538,6 +578,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -653,6 +698,11 @@ public class NotificationRecordApi {
 	 * <td>Forbidden</td>
 	 * <td>-</td>
 	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
+	 * <td>-</td>
+	 * </tr>
 	 * </table>
 	 */
 	public PageNotificationRecordResponseDTO getNotifications(Integer page, Integer size, List<String> sort,
@@ -698,6 +748,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>
@@ -747,6 +802,11 @@ public class NotificationRecordApi {
 	 * <tr>
 	 * <td>403</td>
 	 * <td>Forbidden</td>
+	 * <td>-</td>
+	 * </tr>
+	 * <tr>
+	 * <td>404</td>
+	 * <td>Not Found</td>
 	 * <td>-</td>
 	 * </tr>
 	 * </table>

--- a/notification-service/generated/openapi.json
+++ b/notification-service/generated/openapi.json
@@ -43,6 +43,16 @@
               }
             },
             "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorMessageDTO"
+                }
+              }
+            },
+            "description" : "Not Found"
           }
         },
         "tags" : [ "Notification Message" ]
@@ -138,6 +148,16 @@
               }
             },
             "description" : "Forbidden"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorMessageDTO"
+                }
+              }
+            },
+            "description" : "Not Found"
           }
         },
         "summary" : "Return a list of notification records for the user",
@@ -199,6 +219,16 @@
               }
             },
             "description" : "Forbidden"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorMessageDTO"
+                }
+              }
+            },
+            "description" : "Not Found"
           }
         },
         "summary" : "Return the number of the unread notification records for the user",
@@ -236,6 +266,16 @@
           },
           "403" : {
             "description" : "Forbidden"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorMessageDTO"
+                }
+              }
+            },
+            "description" : "Not Found"
           }
         },
         "summary" : "Delete the specified notification record",
@@ -295,7 +335,7 @@
             "content" : {
               "*/*" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/NotificationRecordResponseDTO"
+                  "$ref" : "#/components/schemas/ErrorMessageDTO"
                 }
               }
             },

--- a/notification-service/src/main/java/com/redhat/parodos/notification/controller/advice/ControllerExceptionHandler.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/controller/advice/ControllerExceptionHandler.java
@@ -8,11 +8,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
+import com.redhat.parodos.notification.exceptions.NotificationRecordNotFoundException;
+import com.redhat.parodos.notification.exceptions.UnsupportedStateException;
+import com.redhat.parodos.notification.exceptions.UsernameNotFoundException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
 
 @ControllerAdvice
 public class ControllerExceptionHandler {
@@ -30,6 +35,27 @@ public class ControllerExceptionHandler {
 
 		ErrorMessageDTO message = new ErrorMessageDTO(new Date(), errorMessage, "Incorrect request parameters");
 		return message;
+	}
+
+	@ExceptionHandler(value = { UsernameNotFoundException.class, NotificationRecordNotFoundException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.NOT_FOUND)
+	public ErrorMessageDTO resourceNotFoundException(UsernameNotFoundException ex, WebRequest request) {
+		return new ErrorMessageDTO(new Date(), ex.getMessage(), "Resource not found");
+	}
+
+	@ExceptionHandler(value = { UnsupportedStateException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public ErrorMessageDTO unsupportedStateException(UnsupportedStateException ex, WebRequest request) {
+		return new ErrorMessageDTO(new Date(), ex.getMessage(), "Unsupported notification state");
+	}
+
+	@ExceptionHandler(value = { UnsupportedOperationException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public ErrorMessageDTO unsupportedOperationException(UnsupportedStateException ex, WebRequest request) {
+		return new ErrorMessageDTO(new Date(), ex.getMessage(), "Unsupported operation");
 	}
 
 	record ErrorMessageDTO(Date date, String message, String description) {

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
@@ -15,6 +15,8 @@
  */
 package com.redhat.parodos.notification.exceptions;
 
+import java.util.UUID;
+
 /**
  * The NotificationRecordNotFoundException wraps unchecked standard Java exception and
  * enriches them with a custom error code. You can use this execution when there is a miss
@@ -27,8 +29,8 @@ public class NotificationRecordNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public NotificationRecordNotFoundException(String message) {
-		super(message);
+	public NotificationRecordNotFoundException(UUID id) {
+		super("Notification record not found: %s".formatted(id));
 	}
 
 }

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UnsupportedStateException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UnsupportedStateException.java
@@ -16,9 +16,8 @@
 package com.redhat.parodos.notification.exceptions;
 
 /**
- * The StateNotFoundOrUnsupportedException wraps unchecked standard Java exception and
- * enriches them with a custom error code. You can use this execution when a Notification
- * State is not found or is unsupported.
+ * The UnsupportedStateException is used when a Notification State is not found or is
+ * unsupported.
  *
  * @author Gloria Ciavarrini (Github: gciavarrini)
  */

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
@@ -26,8 +26,8 @@ public class UsernameNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public UsernameNotFoundException(String message) {
-		super(message);
+	public UsernameNotFoundException(String username) {
+		super("Username not found: %s".formatted(username));
 	}
 
 }

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
@@ -25,6 +25,7 @@ import com.redhat.parodos.notification.enums.SearchCriteria;
 import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.exceptions.NotificationRecordNotFoundException;
 import com.redhat.parodos.notification.exceptions.UnsupportedStateException;
+import com.redhat.parodos.notification.exceptions.UsernameNotFoundException;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
@@ -33,13 +34,11 @@ import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository
 import com.redhat.parodos.notification.service.NotificationRecordService;
 import com.redhat.parodos.notification.util.SearchUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpStatus;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 /**
  * @author Richard Wang (Github: RichardW98)
@@ -136,7 +135,7 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 		Optional<NotificationUser> notificationsUser = this.notificationUserRepository.findByUsername(username);
 		if (notificationsUser.isEmpty()) {
 			log.error("Unable to find the username:{}", username);
-			throw new ResponseStatusException(HttpStatus.SC_NOT_FOUND, "Username not found: " + username, null);
+			throw new UsernameNotFoundException(username);
 		}
 		return notificationsUser.get();
 	}
@@ -156,8 +155,7 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 	private Optional<NotificationRecord> findRecordById(UUID id) {
 		Optional<NotificationRecord> notificationsRecordOptional = this.notificationRecordRepository.findById(id);
 		if (notificationsRecordOptional.isEmpty()) {
-			throw new NotificationRecordNotFoundException(
-					String.format("Could not find NotificationRecord for id = %s", id));
+			throw new NotificationRecordNotFoundException(id);
 		}
 		return notificationsRecordOptional;
 	}

--- a/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationRecordServiceTests.java
+++ b/notification-service/src/test/java/com/redhat/parodos/notification/service/NotificationRecordServiceTests.java
@@ -25,6 +25,7 @@ import com.redhat.parodos.notification.enums.State;
 import com.redhat.parodos.notification.exceptions.NotificationRecordNotFoundException;
 import com.redhat.parodos.notification.exceptions.SearchByStateAndTermNotSupportedException;
 import com.redhat.parodos.notification.exceptions.UnsupportedStateException;
+import com.redhat.parodos.notification.exceptions.UsernameNotFoundException;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
@@ -39,7 +40,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -100,7 +100,7 @@ public class NotificationRecordServiceTests {
 
 		// Notification User doesn't exist
 		when(this.notificationUserRepository.findByUsername(userName)).thenReturn(emptyOptional);
-		Exception exception = assertThrows(ResponseStatusException.class, () -> {
+		Exception exception = assertThrows(UsernameNotFoundException.class, () -> {
 			this.notificationRecordServiceImpl.getNotificationRecords(pageable, userName, State.UNREAD, searchTerm);
 		});
 
@@ -203,7 +203,7 @@ public class NotificationRecordServiceTests {
 			Exception exception = assertThrows(NotificationRecordNotFoundException.class, () -> {
 				this.notificationRecordServiceImpl.updateNotificationStatus(uuid, operation);
 			});
-			assertEquals(String.format("Could not find NotificationRecord for id = %s", uuid), exception.getMessage());
+			assertEquals("Notification record not found: %s".formatted(uuid), exception.getMessage());
 		}
 
 		// Test READ operation and record exists


### PR DESCRIPTION
**What this PR does / why we need it**:
There should be a separation between the layers:
The service layer shouldn't be aware of response errors.
The translation of business exceptions to the rest layer is done via a global exception handler.

The PR also updates the exception to better reflect their roles.

**Which issue(s) this PR fixes**:
Fixes #[FLPATH-397](https://issues.redhat.com/browse/FLPATH-397)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [x] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [x] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
