### PR TITLE
Add missing annotations

### DIFF
--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/WorkContext.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/WorkContext.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import lombok.Data;
+
 /**
  * Work execution context. This can be used to pass initial parameters to the workflow and
  * share data between work units.
@@ -35,6 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
+@Data
 public class WorkContext {
 
 	private final Map<String, Object> context = new ConcurrentHashMap<>();

--- a/workflow-service/src/main/java/com/redhat/parodos/project/entity/ProjectUserRole.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/project/entity/ProjectUserRole.java
@@ -15,13 +15,11 @@ import javax.persistence.ManyToOne;
 import com.redhat.parodos.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity(name = "prds_project_user_role")
-@Getter
-@Setter
+@Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -44,8 +42,7 @@ public class ProjectUserRole {
 
 	@Embeddable
 	@Builder
-	@Getter
-	@Setter
+	@Data
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class Id implements Serializable {


### PR DESCRIPTION
**What this PR does / why we need it**:
When the workflow service starts, it complains about missing functions:

```
2023-05-23 20:42:48.386  WARN 3563913 --- [         task-1] o.h.t.d.java.JavaTypeDescriptorRegistry  : HHH000481: Encountered Java type [class com.redhat.parodos.workflows.work.WorkContext] for which we could not locate a JavaTypeDescriptor and which does not appear to implement equals and/or hashCode.  This can lead to significant performance problems when performing equality/dirty checking involving this Java type.  Consider registering a custom JavaTypeDescriptor or at least implementing equals/hashCode.
2023-05-23 20:42:48.785  WARN 3563913 --- [         task-1] org.hibernate.mapping.RootClass          : HHH000038: Composite-id class does not override equals(): com.redhat.parodos.project.entity.ProjectUserRole$Id
2023-05-23 20:42:48.785  WARN 3563913 --- [         task-1] org.hibernate.mapping.RootClass          : HHH000039: Composite-id class does not override hashCode(): com.redhat.parodos.project.entity.ProjectUserRole$Idis
```

Those warnings can be solved by adding the @Data annotation which adds the needed functionality.


**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
