### PR TITLE
Add DefaultWorkFlowPostInterceptor

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/DefaultWorkFlowPostInterceptor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/DefaultWorkFlowPostInterceptor.java
@@ -1,0 +1,25 @@
+package com.redhat.parodos.workflow.execution.aspect;
+
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.execution.service.WorkFlowService;
+import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
+import com.redhat.parodos.workflows.work.WorkReport;
+
+public class DefaultWorkFlowPostInterceptor implements WorkFlowPostInterceptor {
+
+	private WorkFlowService workFlowService;
+
+	private WorkFlowExecution workFlowExecution;
+
+	public DefaultWorkFlowPostInterceptor(WorkFlowServiceImpl workFlowService, WorkFlowExecution workFlowExecution) {
+		this.workFlowService = workFlowService;
+		this.workFlowExecution = workFlowExecution;
+	}
+
+	@Override
+	public WorkReport handlePostWorkFlowExecution() {
+		workFlowService.updateWorkFlow(workFlowExecution);
+		return null;
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/DefaultWorkFlowPostInterceptorTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/aspect/DefaultWorkFlowPostInterceptorTest.java
@@ -1,0 +1,36 @@
+package com.redhat.parodos.workflow.execution.aspect;
+
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
+import com.redhat.parodos.workflows.work.WorkReport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+public class DefaultWorkFlowPostInterceptorTest {
+
+	@Mock
+	private WorkFlowServiceImpl workFlowService;
+
+	@Mock
+	private WorkFlowExecution workFlowExecution;
+
+	@Test
+	public void handlePostWorkFlowExecution() {
+		// given
+		DefaultWorkFlowPostInterceptor underTest = new DefaultWorkFlowPostInterceptor(workFlowService,
+				workFlowExecution);
+
+		// when
+		WorkReport workReport = underTest.handlePostWorkFlowExecution();
+
+		// then
+		assertThat(workReport).isNull();
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of implementing a concrete handling for the default case, introducing DefaultWorkFlowPostInterceptor to handle cases in which the post executor of a workflow doesn't fall under the other cases.

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
