### PR TITLE
feat: Implement first phase of move2kube workflow

### DIFF
--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
@@ -1,0 +1,85 @@
+package com.redhat.parodos.tasks.git;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+@Slf4j
+@AllArgsConstructor
+public class GitBranchTask extends BaseWorkFlowTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return List.of(
+				WorkParameter.builder().key(GitUtils.getGitRepoPath()).type(WorkParameterType.TEXT).optional(true)
+						.description("path where the git repo is located").build(),
+				WorkParameter.builder().key(GitUtils.getBranch()).type(WorkParameterType.TEXT).optional(false)
+						.description("branch whichs need to be created").build());
+	}
+
+	public String getRepoPath(WorkContext workContext) {
+		return GitUtils.getRepoPath(workContext);
+	}
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		String branchName = null;
+		try {
+			branchName = this.getRequiredParameterValue(workContext, GitUtils.getBranch());
+		}
+		catch (MissingParameterException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+
+		String path = getRepoPath(workContext);
+		if (Strings.isNullOrEmpty(path)) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new IllegalArgumentException("The path parameter cannot be null or empty"));
+		}
+
+		try (Repository repo = getRepo(path)) {
+			Git git = new Git(repo);
+			Ref branchRef = repo.findRef(branchName);
+			if (branchRef != null) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						new IllegalArgumentException("Branch '%s' is already created".formatted(branchName)));
+			}
+			git.branchCreate().setName(branchName).call();
+			git.checkout().setName(branchName).call();
+		}
+		catch (IOException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("No repository at '%s' error: %s".formatted(path, e.getMessage())));
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Cannot create the branch on the repository: %s".formatted(e.getMessage())));
+		}
+
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+	}
+
+	private Repository getRepo(String path) throws IOException {
+		Path gitDir = Paths.get(path + "/.git");
+		return new FileRepositoryBuilder().setGitDir(gitDir.toFile()).build();
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.tasks.git;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -18,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -64,6 +66,10 @@ public class GitBranchTask extends BaseWorkFlowTask {
 			}
 			git.branchCreate().setName(branchName).call();
 			git.checkout().setName(branchName).call();
+		}
+		catch (FileNotFoundException | GitAPIException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Cannot create the branch for the repository: %s".formatted(e.getMessage())));
 		}
 		catch (IOException e) {
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext,

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
@@ -44,12 +43,12 @@ public class GitCloneTask extends BaseWorkFlowTask {
 		String gitBranch = null;
 
 		try {
-			gitUri = WorkContextDelegate.getRequiredValueFromRequestParams(workContext, GitUtils.getUri());
-			gitBranch = WorkContextDelegate.getOptionalValueFromRequestParams(workContext, GitUtils.getBranch(),
-					"main");
+			gitUri = this.getRequiredParameterValue(workContext, GitUtils.getUri());
+			gitBranch = this.getOptionalParameterValue(workContext, GitUtils.getBranch(), GitUtils.getDefaultBranch());
 			destination = cloneRepo(gitUri, gitBranch);
 		}
 		catch (MissingParameterException e) {
+			log.debug("Something failed with the parameters: {}", e.getMessage());
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
 		}
 		catch (TransportException e) {
@@ -63,10 +62,10 @@ public class GitCloneTask extends BaseWorkFlowTask {
 					new Exception("Remote repository " + gitUri + " is not available"));
 		}
 		catch (IOException | GitAPIException e) {
+			log.debug("Cannot clone repository: {} {}", gitUri, e.getMessage());
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
 					new Exception("cannot clone repository, error: " + e.getMessage()));
 		}
-
 		workContext.put(GitUtils.getContextUri(), gitUri);
 		workContext.put(GitUtils.getContextDestination(), destination);
 		workContext.put(GitUtils.getContextBranch(), gitBranch);

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
@@ -28,9 +28,9 @@ public class GitCloneTask extends BaseWorkFlowTask {
 	@Override
 	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
 		return List.of(
-				WorkParameter.builder().key(GitUtils.getUri()).type(WorkParameterType.TEXT).optional(false)
+				WorkParameter.builder().key(GitConstants.URI).type(WorkParameterType.TEXT).optional(false)
 						.description("Url to clone from").build(),
-				WorkParameter.builder().key(GitUtils.getBranch()).type(WorkParameterType.TEXT).optional(true)
+				WorkParameter.builder().key(GitConstants.BRANCH).type(WorkParameterType.TEXT).optional(true)
 						.description("Branch to clone from, default main").build(),
 				WorkParameter.builder().key("credentials").type(WorkParameterType.TEXT).optional(false)
 						.description("Git credential").build());
@@ -43,12 +43,12 @@ public class GitCloneTask extends BaseWorkFlowTask {
 		String gitBranch = null;
 
 		try {
-			gitUri = this.getRequiredParameterValue(workContext, GitUtils.getUri());
-			gitBranch = this.getOptionalParameterValue(workContext, GitUtils.getBranch(), GitUtils.getDefaultBranch());
+			gitUri = this.getRequiredParameterValue(GitConstants.URI);
+			gitBranch = this.getOptionalParameterValue(GitConstants.BRANCH, GitConstants.DEFAULT_BRANCH);
 			destination = cloneRepo(gitUri, gitBranch);
 		}
 		catch (MissingParameterException e) {
-			log.debug("Something failed with the parameters: {}", e.getMessage());
+			log.debug("Failed to resolve required parameter: {}", e.getMessage());
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
 		}
 		catch (TransportException e) {
@@ -66,9 +66,9 @@ public class GitCloneTask extends BaseWorkFlowTask {
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
 					new Exception("cannot clone repository, error: " + e.getMessage()));
 		}
-		workContext.put(GitUtils.getContextUri(), gitUri);
-		workContext.put(GitUtils.getContextDestination(), destination);
-		workContext.put(GitUtils.getContextBranch(), gitBranch);
+		workContext.put(GitConstants.CONTEXT_URI, gitUri);
+		workContext.put(GitConstants.CONTEXT_DESTINATION, destination);
+		workContext.put(GitConstants.CONTEXT_BRANCH, gitBranch);
 		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
 	}
 

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
@@ -1,0 +1,81 @@
+package com.redhat.parodos.tasks.git;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+@Slf4j
+@AllArgsConstructor
+public class GitCommitTask extends BaseWorkFlowTask {
+
+	private static String gitfolder = "/.git";
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return List.of(
+				WorkParameter.builder().key(GitUtils.getGitRepoPath()).type(WorkParameterType.TEXT).optional(true)
+						.description("path where the git repo is located").build(),
+				WorkParameter.builder().key(GitUtils.getGitCommitMessage()).type(WorkParameterType.TEXT).optional(false)
+						.description("Commit message for all the files").build());
+	}
+
+	public String getRepoPath(WorkContext workContext) {
+		return GitUtils.getRepoPath(workContext);
+	}
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		String commitMessage = null;
+		try {
+			commitMessage = this.getRequiredParameterValue(workContext, GitUtils.getGitCommitMessage());
+		}
+		catch (MissingParameterException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+
+		String path = getRepoPath(workContext);
+		if (Strings.isNullOrEmpty(path)) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new IllegalArgumentException("The path parameter cannot be null or empty"));
+		}
+
+		try (Repository repo = getRepo(path)) {
+			Git git = new Git(repo);
+			git.add().addFilepattern(".").call();
+			git.commit().setSign(false).setMessage(commitMessage).call();
+		}
+		catch (IOException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("No repository at '%s' error: %s".formatted(path, e.getMessage())));
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Cannot create the branch on the repository: %s".formatted(e)));
+		}
+
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+	}
+
+	private Repository getRepo(String path) throws IOException {
+		Path gitDir = Paths.get(path + gitfolder);
+		return new FileRepositoryBuilder().setGitDir(gitDir.toFile()).build();
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
@@ -1,8 +1,6 @@
 package com.redhat.parodos.tasks.git;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import com.google.common.base.Strings;
@@ -19,21 +17,18 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 @Slf4j
 @AllArgsConstructor
 public class GitCommitTask extends BaseWorkFlowTask {
 
-	private static String gitfolder = "/.git";
-
 	@Override
 	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
 		return List.of(
-				WorkParameter.builder().key(GitUtils.getGitRepoPath()).type(WorkParameterType.TEXT).optional(true)
+				WorkParameter.builder().key(GitConstants.GIT_REPO_PATH).type(WorkParameterType.TEXT).optional(true)
 						.description("path where the git repo is located").build(),
-				WorkParameter.builder().key(GitUtils.getGitCommitMessage()).type(WorkParameterType.TEXT).optional(false)
-						.description("Commit message for all the files").build());
+				WorkParameter.builder().key(GitConstants.GIT_COMMIT_MESSAGE).type(WorkParameterType.TEXT)
+						.optional(false).description("Commit message for all the files").build());
 	}
 
 	public String getRepoPath(WorkContext workContext) {
@@ -44,7 +39,7 @@ public class GitCommitTask extends BaseWorkFlowTask {
 	public WorkReport execute(WorkContext workContext) {
 		String commitMessage = null;
 		try {
-			commitMessage = this.getRequiredParameterValue(workContext, GitUtils.getGitCommitMessage());
+			commitMessage = this.getRequiredParameterValue(GitConstants.GIT_COMMIT_MESSAGE);
 		}
 		catch (MissingParameterException e) {
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
@@ -74,8 +69,7 @@ public class GitCommitTask extends BaseWorkFlowTask {
 	}
 
 	private Repository getRepo(String path) throws IOException {
-		Path gitDir = Paths.get(path + gitfolder);
-		return new FileRepositoryBuilder().setGitDir(gitDir.toFile()).build();
+		return GitUtils.getRepo(path);
 	}
 
 }

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitConstants.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitConstants.java
@@ -1,0 +1,19 @@
+package com.redhat.parodos.tasks.git;
+
+public class GitConstants {
+
+	static final String GIT_REPO_PATH = "path";
+	static final String GIT_COMMIT_MESSAGE = "commitMessage";
+	static final String URI = "uri";
+	static final String BRANCH = "branch";
+	static final String DEFAULT_BRANCH = "main";
+	static final String CONTEXT_URI = "gitUri";
+	static final String CONTEXT_BRANCH = "gitBranch";
+	static final String CONTEXT_DESTINATION = "gitDestination";
+	static final String CONTEXT_ARCHIVE_PATH = "gitArchivePath";
+
+	static final String GIT_FOLDER = ".git/";
+	static final String GIT_HEAD = "HEAD";
+	static final String SRC_FOLDER = "src/";
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
@@ -13,10 +13,16 @@ public abstract class GitUtils {
 	static final String gitRepoPath = "path";
 
 	@Getter
+	static final String gitCommitMessage = "commitMessage";
+
+	@Getter
 	static final String uri = "uri";
 
 	@Getter
 	static final String branch = "branch";
+
+	@Getter
+	static final String defaultBranch = "main";
 
 	@Getter
 	static final String ContextUri = "gitUri";

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitUtils.java
@@ -1,47 +1,31 @@
 package com.redhat.parodos.tasks.git;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflows.work.WorkContext;
-import lombok.Getter;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 public abstract class GitUtils {
 
 	private GitUtils() {
 	}
 
-	@Getter
-	static final String gitRepoPath = "path";
-
-	@Getter
-	static final String gitCommitMessage = "commitMessage";
-
-	@Getter
-	static final String uri = "uri";
-
-	@Getter
-	static final String branch = "branch";
-
-	@Getter
-	static final String defaultBranch = "main";
-
-	@Getter
-	static final String ContextUri = "gitUri";
-
-	@Getter
-	static final String ContextBranch = "gitBranch";
-
-	@Getter
-	static final String contextDestination = "gitDestination";
-
-	@Getter
-	static final String contextArchivePath = "gitArchivePath";
-
 	public static String getRepoPath(WorkContext workContext) {
-		var dest = workContext.get(contextDestination);
+		var dest = workContext.get(GitConstants.CONTEXT_DESTINATION);
 		if (dest == null) {
-			return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, getGitRepoPath(), "");
+			return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, GitConstants.GIT_REPO_PATH, "");
 		}
-		return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, getGitRepoPath(), dest.toString());
+		return WorkContextDelegate.getOptionalValueFromRequestParams(workContext, GitConstants.GIT_REPO_PATH,
+				dest.toString());
+	}
+
+	public static Repository getRepo(String path) throws IOException {
+		Path gitDir = Paths.get(path).resolve(GitConstants.GIT_FOLDER);
+		return new FileRepositoryBuilder().setGitDir(gitDir.toFile()).build();
 	}
 
 }

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitArchiveTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitArchiveTaskTest.java
@@ -60,7 +60,7 @@ public class GitArchiveTaskTest {
 		// given
 		createSingleFileInRepo();
 		WorkContext workContext = new WorkContext();
-		workContext.put("path", this.repository.getDirectory().toString());
+		workContext.put("path", tempDir.toString());
 
 		// when
 		var result = this.gitArchiveTask.execute(workContext);
@@ -76,7 +76,7 @@ public class GitArchiveTaskTest {
 		// given
 		createSingleFileInRepo();
 		WorkContext workContext = new WorkContext();
-		workContext.put("gitDestination", this.repository.getDirectory().toString());
+		workContext.put("gitDestination", tempDir.toString());
 
 		// when
 		var result = this.gitArchiveTask.execute(workContext);

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitBranchTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitBranchTaskTest.java
@@ -1,0 +1,171 @@
+package com.redhat.parodos.tasks.git;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.InitCommand;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Slf4j
+class GitBranchTaskTest {
+
+	private static String defaultBranch = "main";
+
+	private GitBranchTask gitBranchTask;
+
+	private Path gitRepoPath;
+
+	private Repository repository;
+
+	private Path tempDir;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		gitBranchTask = new GitBranchTask();
+		gitBranchTask.setBeanName("GitBranchTask");
+		tempDir = Files.createTempDirectory("git-repo");
+
+		gitRepoPath = tempDir.resolve(".git");
+
+		InitCommand command = new InitCommand();
+		command.setInitialBranch("main");
+		command.setDirectory(tempDir.toFile());
+		Git git = command.call();
+		assertNotNull(git);
+		assertEquals(git.getRepository().getFullBranch(), "refs/heads/main");
+		assertEquals(git.getRepository().getBranch(), "main");
+		repository = git.getRepository();
+
+		log.info("Created a new repository at '{}'", this.repository.getDirectory());
+		this.createSingleFileInRepo();
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		assertDoesNotThrow(() -> {
+			repository.close();
+		});
+		try (Stream<Path> walk = Files.walk(tempDir)) {
+			walk.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile).forEach(p -> {
+				assertDoesNotThrow(() -> Files.delete(p.toPath()));
+			});
+		}
+	}
+
+	@Test
+	public void testBranchCheckout() {
+		// given
+		createSingleFileInRepo();
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", tempDir.toString());
+		WorkContextUtils.addParameter(workContext, "branch", "newBranch");
+		WorkContextUtils.addParameter(workContext, "path", tempDir.toString());
+
+		// when
+		var result = this.gitBranchTask.execute(workContext);
+
+		// then
+		assertNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.COMPLETED);
+
+		assertDoesNotThrow(() -> {
+			Ref branchRef = repository.findRef("newBranch");
+			assertNotNull(branchRef);
+			assertEquals(repository.getBranch(), "newBranch");
+		});
+	}
+
+	@Test
+	public void testBranchWithAlreadyBranch() {
+		// given
+		createSingleFileInRepo();
+
+		assertDoesNotThrow(() -> {
+			assertEquals(repository.getBranch(), defaultBranch);
+		});
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", tempDir.toString());
+		WorkContextUtils.addParameter(workContext, "branch", defaultBranch);
+
+		// when
+		var result = this.gitBranchTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+	}
+
+	@Test
+	public void testWitMissingParams() {
+		// given
+		WorkContext workContext = new WorkContext();
+
+		// when
+		var result = this.gitBranchTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertThat(result.getError()).isInstanceOf(MissingParameterException.class);
+	}
+
+	@Test
+	public void testWithNoPath() {
+		// given
+		WorkContext workContext = new WorkContext();
+		WorkContextUtils.addParameter(workContext, "branch", defaultBranch);
+
+		// when
+		var result = this.gitBranchTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+		assertThat(result.getError()).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void testWithInvalidPath() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", "/tmp/failingone");
+		WorkContextUtils.addParameter(workContext, "branch", defaultBranch);
+
+		// when
+		var result = this.gitBranchTask.execute(workContext);
+
+		// then
+		assertNotNull(result.getError());
+		assertThat(result.getError()).isInstanceOf(RuntimeException.class);
+		assertThat(result.getError().toString()).contains("Ref HEAD cannot be resolved");
+		assertEquals(result.getStatus(), WorkStatus.FAILED);
+	}
+
+	private void createSingleFileInRepo() {
+		Path filePath = tempDir.resolve("file.txt");
+		assertDoesNotThrow(() -> {
+			Files.write(filePath, "Hello, world!".getBytes());
+			Git git = new Git(repository);
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("Initial commit").setSign(false).call();
+		});
+	}
+
+}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitCommitTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/git/GitCommitTaskTest.java
@@ -1,0 +1,178 @@
+package com.redhat.parodos.tasks.git;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Slf4j
+class GitCommitTaskTest {
+
+	private GitCommitTask gitCommitTask;
+
+	private Path gitRepoPath;
+
+	private Repository repository;
+
+	private static String commitMessageCtxKey = "commitMessage";
+
+	private Path tempDir;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		gitCommitTask = new GitCommitTask();
+		gitCommitTask.setBeanName("GitCommitTask");
+		tempDir = Files.createTempDirectory("git-repo");
+
+		gitRepoPath = tempDir.resolve(".git");
+
+		this.repository = FileRepositoryBuilder.create(gitRepoPath.toFile());
+		this.repository.create();
+		log.info("Created a new repository at '{}'", this.repository.getDirectory());
+		this.createSingleFileInRepo();
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		assertDoesNotThrow(() -> {
+			repository.close();
+		});
+		try (Stream<Path> walk = Files.walk(tempDir)) {
+			walk.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile).forEach(p -> {
+				assertDoesNotThrow(() -> Files.delete(p.toPath()));
+			});
+		}
+	}
+
+	@Test
+	public void testWithValidData() {
+		// given
+		String message = "My commit message";
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", tempDir.toString());
+		WorkContextUtils.addParameter(workContext, commitMessageCtxKey, message);
+
+		// when
+		WorkReport report = gitCommitTask.execute(workContext);
+
+		// then
+		assertNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+
+		assertDoesNotThrow(() -> {
+			RevCommit commit = getLastCommit();
+			assertEquals(commit.getFullMessage(), message);
+		});
+	}
+
+	@Test
+	public void testWithNoCommitMessage() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", tempDir.toString());
+		// when
+		WorkReport report = gitCommitTask.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(MissingParameterException.class);
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	@Test
+	public void testWithMissingRepo() {
+		// given
+		WorkContext workContext = new WorkContext();
+		WorkContextUtils.addParameter(workContext, commitMessageCtxKey, "new one");
+
+		// when
+		WorkReport report = gitCommitTask.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(IllegalArgumentException.class);
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	@Test
+	public void testWithEmptyRepo() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", "");
+		WorkContextUtils.addParameter(workContext, commitMessageCtxKey, "new one");
+
+		// when
+		WorkReport report = gitCommitTask.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(IllegalArgumentException.class);
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	@Test
+	public void testWithInvalidRepo() {
+		// given
+		WorkContext workContext = new WorkContext();
+		workContext.put("path", "/tmp/invalidRepo");
+		WorkContextUtils.addParameter(workContext, commitMessageCtxKey, "new one");
+
+		// when
+		WorkReport report = gitCommitTask.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(Exception.class);
+		assertThat(report.getError().getMessage()).contains("Commit on repo without HEAD currently not supported");
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	private void createSingleFileInRepo() {
+		Path filePath = tempDir.resolve("file.txt");
+		assertDoesNotThrow(() -> {
+			Files.write(filePath, "Hello, world!".getBytes());
+			Git git = Git.init().setDirectory(tempDir.toFile()).call();
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("Initial commit").setSign(false).call();
+		});
+	}
+
+	private RevCommit getLastCommit() throws IOException {
+
+		Ref head = repository.exactRef("HEAD");
+		ObjectId headId = head.getObjectId();
+		assertNotNull(headId);
+		// Create a RevWalk instance to walk through commits
+		RevWalk revWalk = new RevWalk(repository);
+		assertNotNull(revWalk);
+
+		// Parse the HEAD commit
+		RevCommit headCommit = revWalk.parseCommit(headId);
+		assertNotNull(headCommit);
+		return headCommit;
+	}
+
+}

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -22,6 +22,7 @@
     <properties>
         <freemarker.version>2.3.30</freemarker.version>
         <fabric8.version>6.5.1</fabric8.version>
+        <move2kube.version>v1.0.3</move2kube.version>
     </properties>
     <dependencies>
         <dependency>
@@ -42,6 +43,11 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>${freemarker.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.parodos</groupId>
+            <artifactId>move2kube</artifactId>
+            <version>${move2kube.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.parodos</groupId>
@@ -109,6 +115,28 @@
             <artifactId>sdk-utils</artifactId>
             <scope>test</scope>
             <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -1,0 +1,84 @@
+package com.redhat.parodos.examples.move2kube.checker;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.base.Strings;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiClient;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.ProjectsApi;
+import dev.parodos.move2kube.client.model.Project;
+import dev.parodos.move2kube.client.model.ProjectOutputsValue;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TransformChecker extends BaseWorkFlowCheckerTask {
+
+	private ApiClient client = null;
+
+	private static String transformContextKey = "move2KubeTransformID";
+
+	private static String workspaceContextKey = "move2KubeWorkspaceID";
+
+	@Getter
+	protected static String projectContextKey = "move2KubeProjectID";
+
+	public TransformChecker(String server) {
+		super();
+		client = new ApiClient();
+		client.setBasePath(server);
+	}
+
+	@Override
+	public WorkReport checkWorkFlowStatus(WorkContext workContext) {
+
+		String workspaceID = (String) workContext.get(workspaceContextKey);
+		String projectID = (String) workContext.get(projectContextKey);
+		String transformID = (String) workContext.get(transformContextKey);
+		if (Strings.isNullOrEmpty(transformID)) {
+			return new DefaultWorkReport(WorkStatus.PENDING, workContext,
+					new IllegalArgumentException("There is no transform ID"));
+		}
+		ProjectsApi project = new ProjectsApi(client);
+		try {
+			Project res = project.getProject(workspaceID, projectID);
+			ProjectOutputsValue output = Objects.requireNonNull(res.getOutputs()).get(transformID);
+			if (output == null) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						new IllegalArgumentException("Cannot get the project transformation output from the list"));
+			}
+			if (!Objects.equals(output.getStatus(), "done")) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+			}
+		}
+		catch (ApiException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, new IllegalArgumentException(
+					"Cannot get current project for the workflow, error:" + e.getMessage()));
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new IllegalArgumentException("Transform checker cannot be validated:" + e.getMessage()));
+		}
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+	@Override
+	public List<WorkParameter> getWorkFlowTaskParameters() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+		return Collections.emptyList();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -33,7 +33,6 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 	protected static String projectContextKey = "move2KubeProjectID";
 
 	public TransformChecker(String server) {
-		super();
 		client = new ApiClient();
 		client.setBasePath(server);
 	}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/move2kubeWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/move2kubeWorkFlowConfiguration.java
@@ -1,6 +1,6 @@
 package com.redhat.parodos.examples.move2kube;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Executors;
 
 import com.redhat.parodos.examples.move2kube.checker.TransformChecker;
@@ -75,7 +75,7 @@ public class move2kubeWorkFlowConfiguration {
 	@Bean
 	Move2KubeTransform move2KubeTransform(@Qualifier("transformWorkFlowChecker") WorkFlow transformWorkFlowChecker) {
 		Move2KubeTransform move2KubeTransform = new Move2KubeTransform(getMove2KubeAPIEndpoint());
-		move2KubeTransform.setWorkFlowCheckers(Arrays.asList(transformWorkFlowChecker));
+		move2KubeTransform.setWorkFlowCheckers(List.of(transformWorkFlowChecker));
 		return move2KubeTransform;
 	}
 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/move2kubeWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/move2kubeWorkFlowConfiguration.java
@@ -1,0 +1,123 @@
+package com.redhat.parodos.examples.move2kube;
+
+import java.util.Arrays;
+import java.util.concurrent.Executors;
+
+import com.redhat.parodos.examples.move2kube.checker.TransformChecker;
+import com.redhat.parodos.examples.move2kube.task.GitArchiveTask;
+import com.redhat.parodos.examples.move2kube.task.GitBranchTask;
+import com.redhat.parodos.examples.move2kube.task.GitCommitTask;
+import com.redhat.parodos.examples.move2kube.task.Move2KubePlan;
+import com.redhat.parodos.examples.move2kube.task.Move2KubeRetrieve;
+import com.redhat.parodos.examples.move2kube.task.Move2KubeTask;
+import com.redhat.parodos.examples.move2kube.task.Move2KubeTransform;
+import com.redhat.parodos.tasks.git.GitCloneTask;
+import com.redhat.parodos.workflow.annotation.Checker;
+import com.redhat.parodos.workflow.annotation.Infrastructure;
+import com.redhat.parodos.workflow.consts.WorkFlowConstants;
+import com.redhat.parodos.workflows.workflow.ParallelFlow;
+import com.redhat.parodos.workflows.workflow.SequentialFlow;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class move2kubeWorkFlowConfiguration {
+
+	@Bean
+	GitCloneTask gitCloneTask() {
+		return new GitCloneTask();
+	}
+
+	@Bean
+	GitArchiveTask gitArchiveTask() {
+		return new GitArchiveTask();
+	}
+
+	@Bean
+	GitCommitTask gitCommitTask() {
+		return new GitCommitTask();
+	}
+
+	@Bean
+	GitBranchTask gitBranchTask() {
+		return new GitBranchTask();
+	}
+
+	private String getMove2KubeAPIEndpoint() {
+		return "http://localhost:8081/api/v1";
+	}
+
+	@Bean
+	Move2KubeTask move2KubeTask() {
+		return new Move2KubeTask(getMove2KubeAPIEndpoint());
+	}
+
+	@Bean
+	Move2KubeRetrieve move2KubeRetrieve() {
+		return new Move2KubeRetrieve(getMove2KubeAPIEndpoint());
+	}
+
+	@Bean
+	TransformChecker transformChecker() {
+		return new TransformChecker(getMove2KubeAPIEndpoint());
+	}
+
+	@Bean(name = "transformWorkFlowChecker")
+	@Checker(cronExpression = "*/5 * * * * ?")
+	WorkFlow transformWorkFlowChecker(@Qualifier("transformChecker") TransformChecker transformChecker) {
+		return SequentialFlow.Builder.aNewSequentialFlow().named("transformWorkFlowChecker").execute(transformChecker)
+				.build();
+	}
+
+	@Bean
+	Move2KubeTransform move2KubeTransform(@Qualifier("transformWorkFlowChecker") WorkFlow transformWorkFlowChecker) {
+		Move2KubeTransform move2KubeTransform = new Move2KubeTransform(getMove2KubeAPIEndpoint());
+		move2KubeTransform.setWorkFlowCheckers(Arrays.asList(transformWorkFlowChecker));
+		return move2KubeTransform;
+	}
+
+	@Bean
+	Move2KubePlan move2KubePlan() {
+		return new Move2KubePlan(getMove2KubeAPIEndpoint());
+	}
+
+	@Bean(name = "move2KubeProject")
+	@Infrastructure
+	WorkFlow move2KubeProject(@Qualifier("move2KubeTask") Move2KubeTask move2KubeTask) {
+		return SequentialFlow.Builder.aNewSequentialFlow().named("move2KubeProject").execute(move2KubeTask).build();
+	}
+
+	@Bean(name = "getSources")
+	@Infrastructure
+	WorkFlow getSources(@Qualifier("gitCloneTask") GitCloneTask gitCloneTask,
+			@Qualifier("gitArchiveTask") GitArchiveTask gitArchiveTask) {
+		return SequentialFlow.Builder.aNewSequentialFlow().named("getSources").execute(gitCloneTask)
+				.then(gitArchiveTask).build();
+	}
+
+	@Bean(name = "preparationWorkflow")
+	@Infrastructure
+	WorkFlow preparationWorkflow(@Qualifier("getSources") WorkFlow getSources,
+			@Qualifier("move2KubeProject") WorkFlow move2KubeProject) {
+		return ParallelFlow.Builder.aNewParallelFlow().named("preparationWorkflow")
+				.execute(move2KubeProject, getSources).with(Executors.newFixedThreadPool(2)).build();
+	}
+
+	@Bean(name = "move2KubeWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+	@Infrastructure
+	WorkFlow move2kubeWorkflow(@Qualifier("preparationWorkflow") WorkFlow preparationWorkflow,
+			@Qualifier("move2KubePlan") Move2KubePlan move2KubePlan,
+			@Qualifier("move2KubeTransform") Move2KubeTransform move2KubeTransform,
+			@Qualifier("gitBranchTask") GitBranchTask gitBranchTask,
+			@Qualifier("move2KubeRetrieve") Move2KubeRetrieve move2KubeRetrieve,
+			@Qualifier("gitCommitTask") GitCommitTask gitCommitTask) {
+		return SequentialFlow.Builder.aNewSequentialFlow()
+				.named("move2KubeWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW).execute(preparationWorkflow)
+				.then(move2KubePlan).then(move2KubeTransform).then(gitBranchTask).then(move2KubeRetrieve)
+				.then(gitCommitTask).build();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTask.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.List;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflows.work.WorkContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GitArchiveTask extends com.redhat.parodos.tasks.git.GitArchiveTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return List.of();
+	}
+
+	public String getRepoPath(WorkContext workContext) {
+		// comes from GitClonePrebuiltTask
+		return workContext.get("gitDestination").toString();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitBranchTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitBranchTask.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflows.work.WorkContext;
+import lombok.NonNull;
+
+public class GitBranchTask extends com.redhat.parodos.tasks.git.GitBranchTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return super.getWorkFlowTaskParameters().stream().filter(param -> !param.getKey().equals("path"))
+				.collect(Collectors.toList());
+	}
+
+	public String getRepoPath(WorkContext workContext) {
+		// comes from GitClonePrebuiltTask
+		return workContext.get("gitDestination").toString();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitCommitTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/GitCommitTask.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflows.work.WorkContext;
+import lombok.NonNull;
+
+public class GitCommitTask extends com.redhat.parodos.tasks.git.GitCommitTask {
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		return super.getWorkFlowTaskParameters().stream().filter(param -> !param.getKey().equals("path"))
+				.collect(Collectors.toList());
+	}
+
+	public String getRepoPath(WorkContext workContext) {
+		// comes from GitClonePrebuiltTask
+		return workContext.get("gitDestination").toString();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeBase.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeBase.java
@@ -1,0 +1,44 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.List;
+
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import dev.parodos.move2kube.ApiClient;
+import lombok.Getter;
+
+public class Move2KubeBase extends BaseInfrastructureWorkFlowTask {
+
+	@Getter
+	protected static String workspaceContextKey = "move2KubeWorkspaceID";
+
+	@Getter
+	protected static String projectContextKey = "move2KubeProjectID";
+
+	@Getter
+	protected static String transformContextKey = "move2KubeTransformID";
+
+	protected ApiClient client = null;
+
+	protected void setClient(String server) {
+		this.client = new ApiClient();
+		this.client.setBasePath(server);
+	}
+
+	public void setAPIClient(ApiClient ApiClient) {
+		client = ApiClient;
+	}
+
+	@Override
+	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+		return List.of();
+	}
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		return null;
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlan.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlan.java
@@ -1,0 +1,89 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.io.File;
+import java.util.List;
+
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiClient;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.PlanApi;
+import dev.parodos.move2kube.api.ProjectInputsApi;
+import dev.parodos.move2kube.client.model.GetPlan200Response;
+import lombok.extern.slf4j.Slf4j;
+
+import static java.lang.Thread.sleep;
+
+@Slf4j
+public class Move2KubePlan extends Move2KubeBase {
+
+	PlanApi planApi;
+
+	ProjectInputsApi projectInputsApi;
+
+	public Move2KubePlan(String server) {
+		super();
+		this.setClient(server);
+		planApi = new PlanApi(client);
+
+		ApiClient clientFormData = client;
+		clientFormData.addDefaultHeader("Content-Type", "multipart/form-data");
+		ProjectInputsApi projectInputsApi = new ProjectInputsApi(clientFormData);
+	}
+
+	// only used for testing
+	public Move2KubePlan(String server, PlanApi plan, ProjectInputsApi projectInputs) {
+		super();
+		this.setClient(server);
+		planApi = plan;
+		projectInputsApi = projectInputs;
+	}
+
+	public WorkReport execute(WorkContext workContext) {
+		String workspaceID = (String) workContext.get(getWorkspaceContextKey());
+		String projectID = (String) workContext.get(getProjectContextKey());
+		addSourceCode(workspaceID, projectID, (String) workContext.get("gitArchivePath"));
+		try {
+			planApi.startPlanning(workspaceID, projectID);
+
+			for (int i = 1; i <= 10; ++i) {
+				GetPlan200Response plan = planApi.getPlan(workspaceID, projectID);
+				if (plan == null) {
+					try {
+						sleep(i * 1000);
+					}
+					catch (Exception e) {
+						continue;
+					}
+					continue;
+				}
+				log.error("Plan is here in the {} attempt", i);
+				break;
+			}
+		}
+		catch (ApiException e) {
+			log.error("Cannot execute plan, error: {}", e.getMessage());
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+		}
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+	private void addSourceCode(String workspaceID, String projectID, String ZIPPath) {
+		File file = new File(ZIPPath);
+		try {
+			projectInputsApi.createProjectInput(workspaceID, projectID, "sources", "Id", "source code", file);
+		}
+		catch (Exception e) {
+			log.error("cannot append source code! {}", e.getMessage());
+		}
+	}
+
+	@Override
+	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlan.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlan.java
@@ -1,9 +1,7 @@
 package com.redhat.parodos.examples.move2kube.task;
 
 import java.io.File;
-import java.util.List;
 
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -20,9 +18,9 @@ import static java.lang.Thread.sleep;
 @Slf4j
 public class Move2KubePlan extends Move2KubeBase {
 
-	PlanApi planApi;
+	private PlanApi planApi;
 
-	ProjectInputsApi projectInputsApi;
+	private ProjectInputsApi projectInputsApi;
 
 	public Move2KubePlan(String server) {
 		super();
@@ -31,12 +29,12 @@ public class Move2KubePlan extends Move2KubeBase {
 
 		ApiClient clientFormData = client;
 		clientFormData.addDefaultHeader("Content-Type", "multipart/form-data");
-		ProjectInputsApi projectInputsApi = new ProjectInputsApi(clientFormData);
+		projectInputsApi = new ProjectInputsApi(clientFormData);
 	}
 
 	// only used for testing
 	public Move2KubePlan(String server, PlanApi plan, ProjectInputsApi projectInputs) {
-		super();
+		new Move2KubePlan(server);
 		this.setClient(server);
 		planApi = plan;
 		projectInputsApi = projectInputs;
@@ -79,11 +77,6 @@ public class Move2KubePlan extends Move2KubeBase {
 		catch (Exception e) {
 			log.error("cannot append source code! {}", e.getMessage());
 		}
-	}
-
-	@Override
-	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
-		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
 	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieve.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieve.java
@@ -32,8 +32,7 @@ public class Move2KubeRetrieve extends Move2KubeBase {
 	}
 
 	public Move2KubeRetrieve(String server, ProjectOutputsApi outputsApi) {
-		super();
-		this.setClient(server);
+		new Move2KubeRetrieve(server);
 		output = outputsApi;
 	}
 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieve.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieve.java
@@ -1,0 +1,92 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.api.ProjectOutputsApi;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.FileUtils;
+
+@Slf4j
+public class Move2KubeRetrieve extends Move2KubeBase {
+
+	private String plan;
+
+	private ProjectOutputsApi output;
+
+	public Move2KubeRetrieve(String server) {
+		super();
+		this.setClient(server);
+		output = new ProjectOutputsApi(client);
+	}
+
+	public Move2KubeRetrieve(String server, ProjectOutputsApi outputsApi) {
+		super();
+		this.setClient(server);
+		output = outputsApi;
+	}
+
+	public WorkReport execute(WorkContext workContext) {
+		String workspaceID = (String) workContext.get(getWorkspaceContextKey());
+		String projectID = (String) workContext.get(getProjectContextKey());
+		String transformID = (String) workContext.get(getTransformContextKey());
+		String sourcePath = (String) workContext.get("gitDestination").toString();
+		Path tempDir = null;
+		try {
+			File file = output.getProjectOutput(workspaceID, projectID, transformID);
+			if (file == null) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						new RuntimeException("Couldn't get file from transformation"));
+			}
+			tempDir = Files.createTempDirectory(String.format("move2kube-transform-%s", transformID));
+			extractZipFile(file, tempDir);
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+
+		try {
+			Path finalPath = Files.newDirectoryStream(Paths.get(tempDir.toString() + "/output/")).iterator().next();
+			log.info("FinalPath is --->{} and GitPath is {}", finalPath, sourcePath);
+			FileUtils.copyDirectory(finalPath.resolve(Paths.get("deploy")).toFile(),
+					Paths.get(sourcePath).resolve("deploy").toFile());
+			FileUtils.copyDirectory(finalPath.resolve(Paths.get("scripts")).toFile(),
+					Paths.get(sourcePath).resolve("scripts").toFile());
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+	public static void extractZipFile(File zipFile, Path extractPath) throws IOException {
+		try (ZipFile zip = new ZipFile(zipFile)) {
+			for (ZipArchiveEntry entry : Collections.list(zip.getEntries())) {
+				File entryFile = new File(extractPath.toString() + "/" + entry.getName());
+				if (entry.isDirectory()) {
+					entryFile.mkdirs();
+					continue;
+				}
+				File parentDir = entryFile.getParentFile();
+				if (parentDir != null && !parentDir.exists()) {
+					parentDir.mkdirs();
+				}
+				try (FileOutputStream fos = new FileOutputStream(entryFile)) {
+					zip.getInputStream(entry).transferTo(fos);
+				}
+			}
+		}
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTask.java
@@ -1,12 +1,10 @@
 package com.redhat.parodos.examples.move2kube.task;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import com.google.common.base.Strings;
-import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
@@ -40,13 +38,12 @@ public class Move2KubeTask extends Move2KubeBase {
 
 		ApiClient clientFormData = client;
 		clientFormData.addDefaultHeader("Content-Type", "multipart/form-data");
-		ProjectInputsApi projectInputsApi = new ProjectInputsApi(clientFormData);
+		projectInputsApi = new ProjectInputsApi(clientFormData);
 	}
 
 	// constructor only used for testing.
 	Move2KubeTask(String server, WorkspacesApi wrk, ProjectsApi projects, ProjectInputsApi projectInputs) {
-		super();
-		this.setClient(server);
+		new Move2KubeTask(server);
 		workspacesApi = wrk;
 		projectsApi = projects;
 		projectInputsApi = projectInputs;
@@ -83,11 +80,6 @@ public class Move2KubeTask extends Move2KubeBase {
 		}
 
 		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
-	}
-
-	@Override
-	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
-		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
 	}
 
 	private Optional<Workspace> setWorkspace() throws ApiException {

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTask.java
@@ -1,0 +1,118 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.google.common.base.Strings;
+import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiClient;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.ProjectInputsApi;
+import dev.parodos.move2kube.api.ProjectsApi;
+import dev.parodos.move2kube.api.WorkspacesApi;
+import dev.parodos.move2kube.client.model.CreateProject201Response;
+import dev.parodos.move2kube.client.model.Project;
+import dev.parodos.move2kube.client.model.ProjectInputsValue;
+import dev.parodos.move2kube.client.model.Workspace;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Move2KubeTask extends Move2KubeBase {
+
+	private WorkspacesApi workspacesApi;
+
+	private ProjectsApi projectsApi;
+
+	private ProjectInputsApi projectInputsApi;
+
+	public Move2KubeTask(String server) {
+		super();
+		this.setClient(server);
+		workspacesApi = new WorkspacesApi(client);
+		projectsApi = new ProjectsApi(client);
+
+		ApiClient clientFormData = client;
+		clientFormData.addDefaultHeader("Content-Type", "multipart/form-data");
+		ProjectInputsApi projectInputsApi = new ProjectInputsApi(clientFormData);
+	}
+
+	// constructor only used for testing.
+	Move2KubeTask(String server, WorkspacesApi wrk, ProjectsApi projects, ProjectInputsApi projectInputs) {
+		super();
+		this.setClient(server);
+		workspacesApi = wrk;
+		projectsApi = projects;
+		projectInputsApi = projectInputs;
+	}
+
+	/**
+	 * Executed by the InfrastructureTask engine as part of the Workflow
+	 */
+	public WorkReport execute(WorkContext workContext) {
+		log.debug("Init Move2Kube Project initialization!");
+		String workspaceID = null;
+		Map<String, ProjectInputsValue> workspaceInputs = null;
+		try {
+			Optional<Workspace> workspace = setWorkspace();
+			if (workspace.isEmpty()) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						new RuntimeException("No move2kube workspace found"));
+			}
+			workspaceID = workspace.get().getId();
+			workspaceInputs = workspace.get().getInputs();
+			workContext.put("move2KubeWorkspaceID", workspaceID);
+
+			String projectId = setProject(workspaceID, workspaceInputs,
+					WorkContextUtils.getMainExecutionId(workContext));
+			if (Strings.isNullOrEmpty(projectId)) {
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						new RuntimeException("Cannot create project on move2kube server"));
+			}
+			workContext.put("move2KubeProjectID", projectId);
+		}
+		catch (ApiException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Cannot setup the project on move2kube: %s".formatted(e.getMessage())));
+		}
+
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+	@Override
+	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
+	}
+
+	private Optional<Workspace> setWorkspace() throws ApiException {
+		return workspacesApi.getWorkspaces().stream().findFirst();
+	}
+
+	private String setProject(String workspaceId, Map<String, ProjectInputsValue> inputs, UUID workflowId)
+			throws ApiException {
+		Project project = new Project();
+		project.setName("WorkFlowID: " + workflowId.toString());
+		project.description("Project for workflow execution id: " + workflowId.toString());
+
+		CreateProject201Response res = projectsApi.createProject(workspaceId, project);
+		project.setId(res.getId());
+
+		if (inputs == null) {
+			return project.getId();
+		}
+
+		for (Map.Entry<String, ProjectInputsValue> v : inputs.entrySet()) {
+			projectInputsApi.createProjectInput(workspaceId, project.getId(), "reference", v.getValue().getId(),
+					v.getValue().getDescription(), null);
+		}
+
+		return project.getId();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
@@ -1,0 +1,115 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.redhat.parodos.examples.ocponboarding.task.dto.notification.NotificationRequest;
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.PlanApi;
+import dev.parodos.move2kube.api.ProjectOutputsApi;
+import dev.parodos.move2kube.client.model.GetPlan200Response;
+import dev.parodos.move2kube.client.model.StartTransformation202Response;
+import dev.parodos.move2kube.client.model.StartTransformationRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
+@Slf4j
+public class Move2KubeTransform extends Move2KubeBase {
+
+	PlanApi planApi;
+
+	ProjectOutputsApi projectOutputsApi;
+
+	private String plan;
+
+	public Move2KubeTransform(String server) {
+		super();
+		this.setClient(server);
+		planApi = new PlanApi(client);
+		projectOutputsApi = new ProjectOutputsApi(client);
+	}
+
+	public Move2KubeTransform(String server, PlanApi plan, ProjectOutputsApi projectOutputs) {
+		super();
+		this.setClient(server);
+		planApi = plan;
+		projectOutputsApi = projectOutputs;
+	}
+
+	public WorkReport execute(WorkContext workContext) {
+		String workspaceId = (String) workContext.get(getWorkspaceContextKey());
+		String projectId = (String) workContext.get(getProjectContextKey());
+		try {
+			isPlanCreated(workspaceId, projectId);
+		}
+		catch (ApiException | RuntimeException e) {
+			String errorMessage = "Plan for workspace '%s'' and project '%s' is not created".formatted(workspaceId,
+					projectId);
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, new IllegalArgumentException(errorMessage));
+		}
+
+		try {
+			String transformId = transform(workspaceId, projectId);
+			workContext.put(getTransformContextKey(), transformId);
+		}
+		catch (IllegalArgumentException | IOException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+		catch (ApiException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+
+		String userId = String.valueOf(WorkContextUtils.getUserId(workContext));
+		if (!sendNotification(userId, workspaceId, projectId)) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Cannot notify user about the transformation status"));
+		}
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+	private boolean sendNotification(String userID, String workspaceID, String projectID) {
+
+		String url = String.format("http://localhost:8081/workspaces/%s/projects/%s", workspaceID, projectID);
+		String message = String.format(
+				"You need to complete some information for your transformation in the following url <a href=\"%s\"> %s</a>",
+				url, url);
+
+		// @TODO userID is the ID, but we need the username, so hardcode it here for now.
+		NotificationRequest request = NotificationRequest.builder().usernames(List.of("test"))
+				.subject("Complete the Move2Kube transformation steps").body(message).build();
+
+		HttpEntity<NotificationRequest> notificationRequestHttpEntity = RestUtils.getRequestWithHeaders(request, "test",
+				"test");
+		ResponseEntity<String> response = RestUtils.executePost("http://localhost:8082/api/v1/messages",
+				notificationRequestHttpEntity);
+
+		return response.getStatusCode().is2xxSuccessful();
+	}
+
+	private String transform(String workspaceID, String projectID)
+			throws IllegalArgumentException, ApiException, IOException {
+		StartTransformation202Response response = projectOutputsApi.startTransformation(workspaceID, projectID,
+				StartTransformationRequest.fromJson(plan));
+		if (response == null) {
+			throw new IllegalArgumentException("Cannot start transformation");
+		}
+		return response.getId();
+	}
+
+	private void isPlanCreated(String workspaceID, String projectID) throws ApiException {
+		GetPlan200Response response = planApi.getPlan(workspaceID, projectID);
+		if (response == null) {
+			throw new RuntimeException("Plan cannot be retrieved");
+		}
+		this.plan = response.toJson();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
@@ -24,9 +24,9 @@ import org.springframework.http.ResponseEntity;
 @Slf4j
 public class Move2KubeTransform extends Move2KubeBase {
 
-	PlanApi planApi;
+	private PlanApi planApi;
 
-	ProjectOutputsApi projectOutputsApi;
+	private ProjectOutputsApi projectOutputsApi;
 
 	private String plan;
 
@@ -38,8 +38,7 @@ public class Move2KubeTransform extends Move2KubeBase {
 	}
 
 	public Move2KubeTransform(String server, PlanApi plan, ProjectOutputsApi projectOutputs) {
-		super();
-		this.setClient(server);
+		new Move2KubeTransform(server);
 		planApi = plan;
 		projectOutputsApi = projectOutputs;
 	}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/ocponboarding/OcpOnboardingWorkFlowConfiguration.java
@@ -54,6 +54,13 @@ public class OcpOnboardingWorkFlowConfiguration {
 	}
 
 	@Bean
+	WorkFlowOption move2kube() {
+		return new WorkFlowOption.Builder("move2kube", "move2KubeWorkFlow_INFRASTRUCTURE_WORKFLOW")
+				.addToDetails("Transform the application into a Kubernetes application.").displayName("move2kube")
+				.setDescription("Transform application using move2kube").build();
+	}
+
+	@Bean
 	WorkFlowOption badRepoOption() {
 		return new WorkFlowOption.Builder("badRepoOption",
 				"simpleSequentialWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
@@ -74,8 +81,10 @@ public class OcpOnboardingWorkFlowConfiguration {
 	OnboardingOcpAssessmentTask onboardingAssessmentTask(
 			@Qualifier("onboardingOcpOption") WorkFlowOption onboardingOcpOption,
 			@Qualifier("badRepoOption") WorkFlowOption badRepoOption,
-			@Qualifier("notSupportOption") WorkFlowOption notSupportOption) {
-		return new OnboardingOcpAssessmentTask(List.of(onboardingOcpOption, badRepoOption, notSupportOption));
+			@Qualifier("notSupportOption") WorkFlowOption notSupportOption,
+			@Qualifier("move2kube") WorkFlowOption move2kube) {
+		return new OnboardingOcpAssessmentTask(
+				List.of(onboardingOcpOption, badRepoOption, notSupportOption, move2kube));
 	}
 
 	// A Workflow designed to execute and return WorkflowOption(s) that can be executed

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTaskTest.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitArchiveTaskTest {
+
+	@Test
+	public void testArchiveParams() {
+		assertEquals(new GitArchiveTask().getWorkFlowTaskParameters().size(), 0);
+	}
+
+	@Test
+	public void testGetRepoPath() {
+		GitArchiveTask task = new GitArchiveTask();
+		WorkContext ctx = new WorkContext();
+		ctx.put("gitDestination", "/invalid");
+		assertEquals(task.getRepoPath(ctx), "/invalid");
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitArchiveTaskTest.java
@@ -3,13 +3,13 @@ package com.redhat.parodos.examples.move2kube.task;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitArchiveTaskTest {
 
 	@Test
 	public void testArchiveParams() {
-		assertEquals(new GitArchiveTask().getWorkFlowTaskParameters().size(), 0);
+		assertThat(new GitArchiveTask().getWorkFlowTaskParameters().size()).isEqualTo(0);
 	}
 
 	@Test
@@ -17,7 +17,7 @@ public class GitArchiveTaskTest {
 		GitArchiveTask task = new GitArchiveTask();
 		WorkContext ctx = new WorkContext();
 		ctx.put("gitDestination", "/invalid");
-		assertEquals(task.getRepoPath(ctx), "/invalid");
+		assertThat(task.getRepoPath(ctx)).isEqualTo("/invalid");
 	}
 
 }

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitBranchTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitBranchTaskTest.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitBranchTaskTest {
+
+	@Test
+	public void testBranchParams() {
+		assertEquals(new GitBranchTask().getWorkFlowTaskParameters().size(), 1);
+	}
+
+	@Test
+	public void testGetRepoPath() {
+		GitBranchTask task = new GitBranchTask();
+		WorkContext ctx = new WorkContext();
+		ctx.put("gitDestination", "/invalid");
+		assertEquals(task.getRepoPath(ctx), "/invalid");
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitBranchTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitBranchTaskTest.java
@@ -3,13 +3,13 @@ package com.redhat.parodos.examples.move2kube.task;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitBranchTaskTest {
 
 	@Test
 	public void testBranchParams() {
-		assertEquals(new GitBranchTask().getWorkFlowTaskParameters().size(), 1);
+		assertThat(new GitBranchTask().getWorkFlowTaskParameters().size()).isEqualTo(1);
 	}
 
 	@Test
@@ -17,7 +17,7 @@ public class GitBranchTaskTest {
 		GitBranchTask task = new GitBranchTask();
 		WorkContext ctx = new WorkContext();
 		ctx.put("gitDestination", "/invalid");
-		assertEquals(task.getRepoPath(ctx), "/invalid");
+		assertThat(task.getRepoPath(ctx)).isEqualTo("/invalid");
 	}
 
 }

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitCommitTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitCommitTaskTest.java
@@ -1,0 +1,23 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitCommitTaskTest {
+
+	@Test
+	public void testCommitParams() {
+		assertEquals(new GitCommitTask().getWorkFlowTaskParameters().size(), 1);
+	}
+
+	@Test
+	public void testGetRepoPath() {
+		GitCommitTask task = new GitCommitTask();
+		WorkContext ctx = new WorkContext();
+		ctx.put("gitDestination", "/invalid");
+		assertEquals(task.getRepoPath(ctx), "/invalid");
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitCommitTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/GitCommitTaskTest.java
@@ -3,13 +3,13 @@ package com.redhat.parodos.examples.move2kube.task;
 import com.redhat.parodos.workflows.work.WorkContext;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitCommitTaskTest {
 
 	@Test
 	public void testCommitParams() {
-		assertEquals(new GitCommitTask().getWorkFlowTaskParameters().size(), 1);
+		assertThat(new GitCommitTask().getWorkFlowTaskParameters().size()).isEqualTo(1);
 	}
 
 	@Test
@@ -17,7 +17,7 @@ public class GitCommitTaskTest {
 		GitCommitTask task = new GitCommitTask();
 		WorkContext ctx = new WorkContext();
 		ctx.put("gitDestination", "/invalid");
-		assertEquals(task.getRepoPath(ctx), "/invalid");
+		assertThat(task.getRepoPath(ctx)).isEqualTo("/invalid");
 	}
 
 }

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeBaseTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeBaseTest.java
@@ -1,0 +1,27 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Move2KubeBaseTest {
+
+	@Test
+	public void testOutputs() {
+		assertThat(new Move2KubeBase().getWorkFlowTaskOutputs().size()).isEqualTo(0);
+	}
+
+	public void testExecute() {
+		// given
+
+		Move2KubeBase task = new Move2KubeBase();
+
+		// when
+		WorkReport report = task.execute(new WorkContext());
+		// then
+		assertThat(report).isNull();
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
@@ -15,12 +15,16 @@ import dev.parodos.move2kube.api.PlanApi;
 import dev.parodos.move2kube.api.ProjectInputsApi;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 public class Move2KubePlanTest {
 
@@ -28,23 +32,23 @@ public class Move2KubePlanTest {
 
 	private static String project = "project";
 
-	Move2KubePlan task;
+	private Move2KubePlan task;
 
-	ProjectInputsApi projectInputsApi;
+	private ProjectInputsApi projectInputsApi;
 
-	PlanApi planApi;
+	private PlanApi planApi;
 
 	@Before
 	public void setup() {
-		projectInputsApi = Mockito.mock(ProjectInputsApi.class);
-		planApi = Mockito.mock(PlanApi.class);
+		projectInputsApi = mock(ProjectInputsApi.class);
+		planApi = mock(PlanApi.class);
 
 		task = new Move2KubePlan("http://localhost:8080", planApi, projectInputsApi);
 	}
 
 	@Test
 	public void testParameters() {
-		assertEquals(task.getWorkFlowTaskParameters().size(), 0);
+		assertThat(task.getWorkFlowTaskParameters().size()).isEqualTo(0);
 	}
 
 	@Test
@@ -52,21 +56,19 @@ public class Move2KubePlanTest {
 		// given
 		WorkContext context = getWorkContext();
 		assertDoesNotThrow(() -> {
-			Mockito.when(projectInputsApi.createProjectInput(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-					Mockito.any(), Mockito.any())).thenReturn(null);
+			when(projectInputsApi.createProjectInput(any(), any(), any(), any(), any(), any())).thenReturn(null);
 		});
 
 		// when
-
 		WorkReport report = task.execute(context);
 
 		// then
-		assertNull(report.getError());
-		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+		assertThat(report.getError()).isNull();
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.COMPLETED);
 
 		assertDoesNotThrow(() -> {
-			Mockito.verify(projectInputsApi, Mockito.times(1)).createProjectInput(Mockito.eq(workspace),
-					Mockito.eq(project), Mockito.eq("sources"), Mockito.eq("Id"), Mockito.anyString(), Mockito.any());
+			verify(projectInputsApi, times(1)).createProjectInput(eq(workspace), eq(project), eq("sources"), eq("Id"),
+					anyString(), any());
 		});
 	}
 
@@ -95,9 +97,9 @@ public class Move2KubePlanTest {
 		for (String fileName : fileNames) {
 			File file = new File("%s%s".formatted(tempDir, fileName));
 			if (file.getParentFile() != null && !file.getParentFile().exists()) {
-				assertTrue(file.getParentFile().mkdirs());
+				assertThat(file.getParentFile().mkdirs()).isTrue();
 			}
-			assertTrue(file.createNewFile());
+			assertThat(file.createNewFile()).isTrue();
 
 			ZipEntry zipEntry = new ZipEntry(fileName);
 			zos.putNextEntry(zipEntry);

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
@@ -1,0 +1,119 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.api.PlanApi;
+import dev.parodos.move2kube.api.ProjectInputsApi;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Move2KubePlanTest {
+
+	private static String workspace = "workspace";
+
+	private static String project = "project";
+
+	Move2KubePlan task;
+
+	ProjectInputsApi projectInputsApi;
+
+	PlanApi planApi;
+
+	@Before
+	public void setup() {
+		projectInputsApi = Mockito.mock(ProjectInputsApi.class);
+		planApi = Mockito.mock(PlanApi.class);
+
+		task = new Move2KubePlan("http://localhost:8080", planApi, projectInputsApi);
+	}
+
+	@Test
+	public void testParameters() {
+		assertEquals(task.getWorkFlowTaskParameters().size(), 0);
+	}
+
+	@Test
+	public void testExecute() {
+		// given
+		WorkContext context = getWorkContext();
+		assertDoesNotThrow(() -> {
+			Mockito.when(projectInputsApi.createProjectInput(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+					Mockito.any(), Mockito.any())).thenReturn(null);
+		});
+
+		// when
+
+		WorkReport report = task.execute(context);
+
+		// then
+		assertNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+
+		assertDoesNotThrow(() -> {
+			Mockito.verify(projectInputsApi, Mockito.times(1)).createProjectInput(Mockito.eq(workspace),
+					Mockito.eq(project), Mockito.eq("sources"), Mockito.eq("Id"), Mockito.anyString(), Mockito.any());
+		});
+	}
+
+	WorkContext getWorkContext() {
+		WorkContext context = new WorkContext();
+		context.put("move2KubeWorkspaceID", "workspace");
+		context.put("move2KubeProjectID", "project");
+		assertDoesNotThrow(() -> {
+			context.put("gitArchivePath", createSampleZip().getAbsolutePath().toString());
+		});
+		return context;
+	}
+
+	private static File createSampleZip() throws IOException {
+		String zipFileName = "/tmp/test%s.zip".formatted(UUID.randomUUID());
+		String tempDir = "/tmp/%s/".formatted(UUID.randomUUID().toString());
+		File zipFile = new File(zipFileName);
+		String[] fileNames = { "output/project-name/deploy/bar.txt", "output/project-name/deploy/foo.txt",
+				"output/project-name/scripts/bar.sh", "output/project-name/scripts/foo.sh" };
+
+		byte[] buffer = new byte[1024];
+
+		FileOutputStream fos = new FileOutputStream(zipFile);
+		ZipOutputStream zos = new ZipOutputStream(fos);
+
+		for (String fileName : fileNames) {
+			File file = new File("%s%s".formatted(tempDir, fileName));
+			if (file.getParentFile() != null && !file.getParentFile().exists()) {
+				assertTrue(file.getParentFile().mkdirs());
+			}
+			assertTrue(file.createNewFile());
+
+			ZipEntry zipEntry = new ZipEntry(fileName);
+			zos.putNextEntry(zipEntry);
+
+			FileInputStream fis = new FileInputStream(file);
+			int length;
+			while ((length = fis.read(buffer)) > 0) {
+				zos.write(buffer, 0, length);
+			}
+
+			fis.close();
+			zos.closeEntry();
+		}
+
+		zos.close();
+		return zipFile;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieveTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieveTest.java
@@ -1,0 +1,164 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.ProjectOutputsApi;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+public class Move2KubeRetrieveTest {
+
+	private static String move2KubeWorkspaceIDCtxKey = "move2KubeWorkspaceID";
+
+	private static String move2KubeProjectIDCtxKey = "move2KubeProjectID";
+
+	private static String move2KubeTransformIDCtxKey = "move2KubeTransformID";
+
+	private static String gitDestinationCtxKey = "gitDestination";
+
+	private ProjectOutputsApi output;
+
+	private Move2KubeRetrieve task;
+
+	@Before
+	public void setup() {
+		output = Mockito.mock(ProjectOutputsApi.class);
+		task = new Move2KubeRetrieve("http://localhost/", output);
+	}
+
+	@Test
+	public void testValidExecution() {
+		// given
+		WorkContext context = getSampleWorkContext();
+		assertDoesNotThrow(() -> {
+			Mockito.when(output.getProjectOutput(Mockito.any(), Mockito.any(), Mockito.any()))
+					.thenReturn(createSampleZip());
+		});
+		// when
+		WorkReport report = task.execute(context);
+
+		// then
+		assertNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+
+		String path = (String) context.get(gitDestinationCtxKey);
+		assertNotNull(path);
+		File gitPath = new File(path);
+
+		String[] fileNames = { "deploy/bar.txt", "deploy/foo.txt", "scripts/bar.sh", "scripts/foo.sh" };
+
+		for (String fileName : fileNames) {
+			assertTrue(gitPath.toPath().resolve(fileName).toFile().exists(), "Failed on file '%s'".formatted(fileName));
+		}
+	}
+
+	@Test
+	public void testWithInvalidOutputExecution() {
+		// given
+		WorkContext context = getSampleWorkContext();
+
+		assertDoesNotThrow(() -> {
+			Mockito.when(output.getProjectOutput(Mockito.any(), Mockito.any(), Mockito.any()))
+					.thenThrow(ApiException.class);
+		});
+
+		// when
+		WorkReport report = task.execute(context);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(ApiException.class);
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	@Test
+	public void testWithInvalidOutputFile() {
+		// given
+		WorkContext context = getSampleWorkContext();
+
+		assertDoesNotThrow(() -> {
+			Mockito.when(output.getProjectOutput(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(null);
+		});
+
+		// when
+		WorkReport report = task.execute(context);
+
+		// then
+		assertNotNull(report.getError());
+		assertThat(report.getError()).isInstanceOf(RuntimeException.class);
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+	}
+
+	public WorkContext getSampleWorkContext() {
+		WorkContext workContext = new WorkContext();
+		workContext.put(move2KubeTransformIDCtxKey, move2KubeProjectIDCtxKey);
+		workContext.put(move2KubeProjectIDCtxKey, move2KubeProjectIDCtxKey);
+		workContext.put(move2KubeWorkspaceIDCtxKey, move2KubeWorkspaceIDCtxKey);
+		assertDoesNotThrow(() -> {
+			workContext.put(gitDestinationCtxKey, createTempDir());
+		});
+		return workContext;
+	}
+
+	private String createTempDir() throws IOException {
+		return Files.createTempDirectory("test").toAbsolutePath().toString();
+	}
+
+	private static File createSampleZip() throws IOException {
+		String zipFileName = "/tmp/test%s.zip".formatted(UUID.randomUUID());
+		String tempDir = "/tmp/%s/".formatted(UUID.randomUUID().toString());
+		File zipFile = new File(zipFileName);
+		String[] fileNames = { "output/project-name/deploy/bar.txt", "output/project-name/deploy/foo.txt",
+				"output/project-name/scripts/bar.sh", "output/project-name/scripts/foo.sh" };
+
+		byte[] buffer = new byte[1024];
+
+		FileOutputStream fos = new FileOutputStream(zipFile);
+		ZipOutputStream zos = new ZipOutputStream(fos);
+
+		for (String fileName : fileNames) {
+			File file = new File("%s%s".formatted(tempDir, fileName));
+			if (file.getParentFile() != null && !file.getParentFile().exists()) {
+				assertTrue(file.getParentFile().mkdirs());
+			}
+			assertTrue(file.createNewFile());
+
+			ZipEntry zipEntry = new ZipEntry(fileName);
+			zos.putNextEntry(zipEntry);
+
+			FileInputStream fis = new FileInputStream(file);
+			int length;
+			while ((length = fis.read(buffer)) > 0) {
+				zos.write(buffer, 0, length);
+			}
+
+			fis.close();
+			zos.closeEntry();
+		}
+
+		zos.close();
+		return zipFile;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTaskTest.java
@@ -21,12 +21,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 public class Move2KubeTaskTest {
@@ -45,9 +47,9 @@ public class Move2KubeTaskTest {
 
 	@Before
 	public void BeforeEach() {
-		workspacesApi = Mockito.mock(WorkspacesApi.class);
-		projectsApi = Mockito.mock(ProjectsApi.class);
-		projectInputsApi = Mockito.mock(ProjectInputsApi.class);
+		workspacesApi = mock(WorkspacesApi.class);
+		projectsApi = mock(ProjectsApi.class);
+		projectInputsApi = mock(ProjectInputsApi.class);
 
 		task = new Move2KubeTask("http://localhost", workspacesApi, projectsApi, projectInputsApi);
 		log.error("Move2KubeTask BeforeEach");
@@ -70,24 +72,23 @@ public class Move2KubeTaskTest {
 		workspace.setInputs(inputs);
 
 		assertDoesNotThrow(() -> {
-			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(List.of(workspace));
-			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenReturn(getSampleProject("test"));
+			when(workspacesApi.getWorkspaces()).thenReturn(List.of(workspace));
+			when(projectsApi.createProject(any(), any())).thenReturn(getSampleProject("test"));
 		});
 
 		// when
 		WorkReport report = task.execute(workContext);
 
 		// then
-		assertNull(report.getError());
-		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
-		assertNotNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
-		assertNotNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+		assertThat(report.getError()).isNull();
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+		assertThat(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey)).isNotNull();
+		assertThat(report.getWorkContext().get(move2KubeProjectIDCtxKey)).isNotNull();
 
 		assertDoesNotThrow(() -> {
-			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
-			Mockito.verify(projectsApi, Mockito.times(1)).createProject(Mockito.any(), Mockito.any());
-			Mockito.verify(projectInputsApi, Mockito.times(2)).createProjectInput(Mockito.any(), Mockito.any(),
-					Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+			verify(workspacesApi, times(1)).getWorkspaces();
+			verify(projectsApi, times(1)).createProject(any(), any());
+			verify(projectInputsApi, times(2)).createProjectInput(any(), any(), any(), any(), any(), any());
 		});
 	}
 
@@ -96,22 +97,22 @@ public class Move2KubeTaskTest {
 		// given
 		WorkContext workContext = getSampleWorkContext();
 		assertDoesNotThrow(() -> {
-			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(Collections.emptyList());
-			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenReturn(getSampleProject("test"));
+			when(workspacesApi.getWorkspaces()).thenReturn(Collections.emptyList());
+			when(projectsApi.createProject(any(), any())).thenReturn(getSampleProject("test"));
 		});
 
 		// when
 		WorkReport report = task.execute(workContext);
 
 		// then
-		assertNotNull(report.getError());
-		assertEquals(report.getStatus(), WorkStatus.FAILED);
-		assertNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
-		assertNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+		assertThat(report.getError()).isNotNull();
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey)).isNull();
+		assertThat(report.getWorkContext().get(move2KubeProjectIDCtxKey)).isNull();
 
 		assertDoesNotThrow(() -> {
-			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
-			Mockito.verify(projectsApi, Mockito.times(0)).createProject(Mockito.any(), Mockito.any());
+			verify(workspacesApi, times(1)).getWorkspaces();
+			verify(projectsApi, times(0)).createProject(any(), any());
 		});
 	}
 
@@ -120,22 +121,22 @@ public class Move2KubeTaskTest {
 		// given
 		WorkContext workContext = getSampleWorkContext();
 		assertDoesNotThrow(() -> {
-			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(List.of(getSampleWorkspace("test")));
-			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenThrow(ApiException.class);
+			when(workspacesApi.getWorkspaces()).thenReturn(List.of(getSampleWorkspace("test")));
+			when(projectsApi.createProject(any(), any())).thenThrow(ApiException.class);
 		});
 
 		// when
 		WorkReport report = task.execute(workContext);
 
 		// then
-		assertNotNull(report.getError());
-		assertEquals(report.getStatus(), WorkStatus.FAILED);
-		assertNotNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
-		assertNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+		assertThat(report.getError()).isNotNull();
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey)).isNotNull();
+		assertThat(report.getWorkContext().get(move2KubeProjectIDCtxKey)).isNull();
 
 		assertDoesNotThrow(() -> {
-			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
-			Mockito.verify(projectsApi, Mockito.times(1)).createProject(Mockito.any(), Mockito.any());
+			verify(workspacesApi, times(1)).getWorkspaces();
+			verify(projectsApi, times(1)).createProject(any(), any());
 		});
 	}
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTaskTest.java
@@ -1,0 +1,169 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.ApiException;
+import dev.parodos.move2kube.api.ProjectInputsApi;
+import dev.parodos.move2kube.api.ProjectsApi;
+import dev.parodos.move2kube.api.WorkspacesApi;
+import dev.parodos.move2kube.client.model.CreateProject201Response;
+import dev.parodos.move2kube.client.model.ProjectInputsValue;
+import dev.parodos.move2kube.client.model.Workspace;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+public class Move2KubeTaskTest {
+
+	Move2KubeTask task;
+
+	private WorkspacesApi workspacesApi;
+
+	private ProjectsApi projectsApi;
+
+	private ProjectInputsApi projectInputsApi;
+
+	private static String move2KubeWorkspaceIDCtxKey = "move2KubeWorkspaceID";
+
+	private static String move2KubeProjectIDCtxKey = "move2KubeProjectID";
+
+	@Before
+	public void BeforeEach() {
+		workspacesApi = Mockito.mock(WorkspacesApi.class);
+		projectsApi = Mockito.mock(ProjectsApi.class);
+		projectInputsApi = Mockito.mock(ProjectInputsApi.class);
+
+		task = new Move2KubeTask("http://localhost", workspacesApi, projectsApi, projectInputsApi);
+		log.error("Move2KubeTask BeforeEach");
+	}
+
+	@After
+	public void AfterEach() {
+		log.error("Move2KubeTask AfterEach");
+	}
+
+	@Test
+	public void testValidExecution() {
+		// given
+		WorkContext workContext = getSampleWorkContext();
+		Workspace workspace = getSampleWorkspace("test");
+
+		Map<String, ProjectInputsValue> inputs = new HashMap<String, ProjectInputsValue>();
+		inputs.put("test1", getSampleProjectInput("test1"));
+		inputs.put("test2", getSampleProjectInput("test2"));
+		workspace.setInputs(inputs);
+
+		assertDoesNotThrow(() -> {
+			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(List.of(workspace));
+			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenReturn(getSampleProject("test"));
+		});
+
+		// when
+		WorkReport report = task.execute(workContext);
+
+		// then
+		assertNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+		assertNotNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
+		assertNotNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+
+		assertDoesNotThrow(() -> {
+			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
+			Mockito.verify(projectsApi, Mockito.times(1)).createProject(Mockito.any(), Mockito.any());
+			Mockito.verify(projectInputsApi, Mockito.times(2)).createProjectInput(Mockito.any(), Mockito.any(),
+					Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+		});
+	}
+
+	@Test
+	public void testWithoutValidWorkspace() {
+		// given
+		WorkContext workContext = getSampleWorkContext();
+		assertDoesNotThrow(() -> {
+			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(Collections.emptyList());
+			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenReturn(getSampleProject("test"));
+		});
+
+		// when
+		WorkReport report = task.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+		assertNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
+		assertNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+
+		assertDoesNotThrow(() -> {
+			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
+			Mockito.verify(projectsApi, Mockito.times(0)).createProject(Mockito.any(), Mockito.any());
+		});
+	}
+
+	@Test
+	public void testWithIssuesCreatingProject() {
+		// given
+		WorkContext workContext = getSampleWorkContext();
+		assertDoesNotThrow(() -> {
+			Mockito.when(workspacesApi.getWorkspaces()).thenReturn(List.of(getSampleWorkspace("test")));
+			Mockito.when(projectsApi.createProject(Mockito.any(), Mockito.any())).thenThrow(ApiException.class);
+		});
+
+		// when
+		WorkReport report = task.execute(workContext);
+
+		// then
+		assertNotNull(report.getError());
+		assertEquals(report.getStatus(), WorkStatus.FAILED);
+		assertNotNull(report.getWorkContext().get(move2KubeWorkspaceIDCtxKey));
+		assertNull(report.getWorkContext().get(move2KubeProjectIDCtxKey));
+
+		assertDoesNotThrow(() -> {
+			Mockito.verify(workspacesApi, Mockito.times(1)).getWorkspaces();
+			Mockito.verify(projectsApi, Mockito.times(1)).createProject(Mockito.any(), Mockito.any());
+		});
+	}
+
+	public Workspace getSampleWorkspace(String workspace) {
+		var wrk = new Workspace();
+		wrk.setId(UUID.randomUUID().toString());
+		wrk.setName(workspace);
+		return wrk;
+	}
+
+	public CreateProject201Response getSampleProject(String name) {
+		CreateProject201Response project = new CreateProject201Response();
+		project.setId(UUID.randomUUID().toString());
+		return project;
+	}
+
+	public WorkContext getSampleWorkContext() {
+		WorkContext workContext = new WorkContext();
+		WorkContextUtils.setMainExecutionId(workContext, UUID.randomUUID());
+		return workContext;
+	}
+
+	public ProjectInputsValue getSampleProjectInput(String name) {
+		ProjectInputsValue projectInput = new ProjectInputsValue();
+		projectInput.setName(name);
+		projectInput.setDescription(name);
+		projectInput.setId(UUID.randomUUID().toString());
+		return projectInput;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransformTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransformTest.java
@@ -1,0 +1,97 @@
+package com.redhat.parodos.examples.move2kube.task;
+
+import java.util.UUID;
+
+import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import dev.parodos.move2kube.api.PlanApi;
+import dev.parodos.move2kube.api.ProjectOutputsApi;
+import dev.parodos.move2kube.client.model.GetPlan200Response;
+import dev.parodos.move2kube.client.model.StartTransformation202Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mockStatic;
+
+public class Move2KubeTransformTest {
+
+	Move2KubeTransform task;
+
+	private static String move2KubeWorkspaceIDCtxKey = "move2KubeWorkspaceID";
+
+	private static String move2KubeProjectIDCtxKey = "move2KubeProjectID";
+
+	PlanApi planApi;
+
+	ProjectOutputsApi projectOutputsApi;
+
+	@Before
+	public void setup() throws Exception {
+		planApi = Mockito.mock(PlanApi.class);
+		projectOutputsApi = Mockito.mock(ProjectOutputsApi.class);
+		task = new Move2KubeTransform("http://localhost:8080", planApi, projectOutputsApi);
+	}
+
+	@Test
+	public void testParameters() {
+		assertEquals(this.task.getWorkFlowTaskParameters().size(), 0);
+	}
+
+	@Test
+	public void testValidExecution() {
+
+		// given
+		WorkContext context = getSampleWorkContext();
+		GetPlan200Response response = new GetPlan200Response();
+		StartTransformation202Response transformResponse = new StartTransformation202Response();
+		transformResponse.setId("foo");
+
+		assertDoesNotThrow(() -> {
+			Mockito.when(planApi.getPlan(Mockito.any(), Mockito.any())).thenReturn(new GetPlan200Response());
+			Mockito.when(projectOutputsApi.startTransformation(Mockito.any(), Mockito.any(), Mockito.any()))
+					.thenReturn(transformResponse);
+		});
+
+		try (MockedStatic<RestUtils> mockedStatic = mockStatic(RestUtils.class)) {
+			ResponseEntity<String> responseo = ResponseEntity.ok("ok");
+			responseo.getStatusCode();
+
+			mockedStatic.when(
+					(MockedStatic.Verification) RestUtils.executePost(Mockito.any(), (HttpEntity<?>) Mockito.any()))
+					.thenReturn(ResponseEntity.ok("ok"));
+
+			// when
+			WorkReport report = this.task.execute(context);
+
+			// then
+			assertNull(report.getError());
+			assertEquals(report.getStatus(), WorkStatus.COMPLETED);
+		}
+
+		assertDoesNotThrow(() -> {
+			Mockito.verify(projectOutputsApi, Mockito.times(1)).startTransformation(
+					Mockito.eq(move2KubeWorkspaceIDCtxKey), Mockito.eq(move2KubeProjectIDCtxKey), Mockito.any());
+		});
+
+	}
+
+	public WorkContext getSampleWorkContext() {
+		WorkContext workContext = new WorkContext();
+		workContext.put(move2KubeProjectIDCtxKey, move2KubeProjectIDCtxKey);
+		workContext.put(move2KubeWorkspaceIDCtxKey, move2KubeWorkspaceIDCtxKey);
+		WorkContextUtils.setUserId(workContext, UUID.randomUUID());
+		return workContext;
+	}
+
+}


### PR DESCRIPTION
This commit adds the first phase of the move2kube workflow example. A user give any git repo, and it'll will be transformed using move2kube, two new folders will be commited (deploy and scripts) inside the repository where the transformed application can be used.

This PR introduces a new 3party dependency that it's the openapi client from move2kube.

The workflow is the following one:

```mermaid
sequenceDiagram
    participant User
    participant Parodos
    participant API as Move2Kube API
    participant web as Move2kube Web
    participant k8s as OpenshiftCluster

    rect rgb(221, 255, 221)
    User ->> Parodos: Enter params
    Note over User,Parodos: Parameters needed:<br/>- Git Repo<br/>- Git Credentials<br/>- GitTargetBranch<br/>- Profile as workspaceID?
    end

    rect rgb(221, 255, 221)
    Parodos ->> API: Get Workspace
    API ->> Parodos: return workspace ID
    Parodos ->> API: Post Project (Workflow ID as project ID)
    API ->> Parodos: Return project ID
    end

    Note over Parodos,API: Here Parodos prepare the plan
    rect rgb(221, 255, 221)
    Parodos --> Parodos: Git Clone
    Parodos --> Parodos: Git archive
    end

    rect rgb(221, 255, 221)
    Parodos --> API: Push ZIP file as project input1 POST /workspaces/{workspace-id}/projects/{project-id}/inputs

    Parodos ->> API: POST /workspaces/{workspace-id}/projects/{project-id}/plan
    Parodos ->> API: Get /workspaces/{workspace-id}/projects/{project-id}/plan

    Note over API,User: Here user get notified to start transformation
    Parodos ->> User: Link to project-id move2kube page
    User ->> web: User execute the transformation step in move2kube

    loop Every minute
        Parodos ->> API: Is transformation ready?
    end

    Note over API,User: Trasnformation completed successfully
    Parodos ->> API: Get outputs
    Parodos ->> Parodos: Branch code
    Parodos ->> Parodos: Commit changes

    end

    Parodos ->> Parodos: Push code to the specified branch

    Note over Parodos: Openshift deployment
    Parodos ->> Parodos: Build images for project
    Parodos ->> k8s: Apply all manifests
    Parodos ->> User: Workflow completed successfully with route
```

All the green boxes are created, the not-highlight ones are the ones for the next PR.

For move2kube an workspace need to be created, and the config that I used is the following one:

```
move2kube:
  containerruntime: docker
  minreplicas: "2"
  services:
    demo:
      "8080":
        servicetype: Ingress
        urlpath: /
      enable: true
      port: "8080"
  target:
    default:
      clustertype: Kubernetes
      ingress:
        host: localhost
        ingressclassname: ""
        tls: ""
    imageregistry:
      quay.io:
        logintype: no authentication
      namespace: parodos
      url: quay.com
  transformers:
    types:
      - ArgoCD
      - Buildconfig
      - ClusterSelector
      - ComposeAnalyser
      - ComposeGenerator
      - ContainerImagesPushScriptGenerator
      - DockerfileDetector
      - DockerfileImageBuildScript
      - DockerfileParser
      - DotNetCore-Dockerfile
      - Gradle
      - Jar
      - Jboss
      - Kubernetes
      - KubernetesVersionChanger
      - Liberty
      - Maven
      - Parameterizer
      - ReadMeGenerator
      - Tomcat
      - WarAnalyser
      - WarRouter
      - WinWebApp-Dockerfile
      - ZuulAnalyser
  transformerselector: ""
```

To run move2kube the easiest way that I find is the following command:
```
docker run --rm -it -p 8081:8080 quay.io/konveyor/move2kube-ui
```

Fix: https://issues.redhat.com/browse/FLPATH-356
Partial-Fix: https://issues.redhat.com/browse/FLPATH-355

Demo: https://drive.google.com/file/d/1k9RwRI4PPBwinDWRyARvTsbFGiQD6vjh/view?usp=sharing

