### PR TITLE
Replace powermock.mock with mockito.mock

### DIFF
--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -126,18 +126,6 @@
             <artifactId>aspectjweaver</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubePlanTest.java
@@ -24,7 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 public class Move2KubePlanTest {
 

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieveTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/move2kube/task/Move2KubeRetrieveTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @Slf4j
 public class Move2KubeRetrieveTest {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `Mockito.when` instead of `Powermock.when`

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
