### PR TITLE
A notifier bean for interfacing with the notification service

### DIFF
--- a/hack/manifests/testing/parodos-patch.yaml
+++ b/hack/manifests/testing/parodos-patch.yaml
@@ -19,7 +19,7 @@ data:
   DATASOURCE_USERNAME: "parodos"
   DATASOURCE_PASSWORD: "parodos"
   SPRING_PROFILES_ACTIVE: "dev"
-  NOTIFICATION_SERVER_ADDRESS: "notification-service.default.svc.cluster.local"
+  NOTIFICATION_SERVER_URL: "http://notification-service.default.svc.cluster.local:8080"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/notification-service/src/main/resources/application-dev.yml
+++ b/notification-service/src/main/resources/application-dev.yml
@@ -38,3 +38,9 @@ spring:
 # ApplicationProperties class to have type-safe configuration
 # ===================================================================
 
+notification:
+  url: "${NOTIFICATION_SERVER_URL:http://localhost:8081}"
+  auth:
+    basic:
+      user: test
+      password: test

--- a/parodos-model-api/pom.xml
+++ b/parodos-model-api/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.parodos</groupId>
+            <artifactId>notification-service-sdk</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/infrastructure/Notifier.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/infrastructure/Notifier.java
@@ -1,0 +1,12 @@
+package com.redhat.parodos.workflow.task.infrastructure;
+
+import com.redhat.parodos.notification.sdk.api.ApiException;
+import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
+
+public interface Notifier {
+
+	void send(NotificationMessageCreateRequestDTO message);
+
+	void trySend(NotificationMessageCreateRequestDTO message) throws ApiException;
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTask.java
@@ -6,16 +6,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.redhat.parodos.notification.sdk.api.ApiClient;
 import com.redhat.parodos.notification.sdk.api.ApiException;
-import com.redhat.parodos.notification.sdk.api.Configuration;
-import com.redhat.parodos.notification.sdk.api.NotificationMessageApi;
 import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.parameter.WorkParameterType;
 import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.Notifier;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -23,30 +21,15 @@ import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 
 @Slf4j
 public class NotificationWorkFlowTask extends BaseWorkFlowTask {
 
-	private final NotificationMessageApi apiInstance;
+	private final Notifier notifier;
 
-	public NotificationWorkFlowTask(String basePath, String auth) {
-		this(basePath, null, auth);
-	}
-
-	protected NotificationWorkFlowTask(String basePath, NotificationMessageApi apiInstance) {
-		this(basePath, apiInstance, null);
-	}
-
-	private NotificationWorkFlowTask(String basePath, NotificationMessageApi apiInstance, String auth) {
-		if (apiInstance == null) {
-			ApiClient apiClient = Configuration.getDefaultApiClient();
-			apiClient.addDefaultHeader(HttpHeaders.AUTHORIZATION, auth);
-			apiClient.setBasePath(basePath);
-			apiInstance = new NotificationMessageApi(apiClient);
-		}
-		this.apiInstance = apiInstance;
+	public NotificationWorkFlowTask(Notifier notifier) {
+		this.notifier = notifier;
 	}
 
 	@Override
@@ -98,7 +81,7 @@ public class NotificationWorkFlowTask extends BaseWorkFlowTask {
 		}
 
 		try {
-			this.apiInstance.create(notificationMessageCreateRequestDTO);
+			notifier.trySend(notificationMessageCreateRequestDTO);
 		}
 		catch (ApiException e) {
 			log.error("Exception when calling NotificationMessageApi#create:", e);

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/notification/NotificationWorkFlowTaskTest.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.UUID;
 
 import com.redhat.parodos.notification.sdk.api.ApiException;
-import com.redhat.parodos.notification.sdk.api.NotificationMessageApi;
 import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.task.infrastructure.Notifier;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 
 public class NotificationWorkFlowTaskTest {
 
-	private static NotificationMessageApi apiInstanceMock;
+	private Notifier mockNotifier;
 
 	private static NotificationWorkFlowTask underTest;
 
@@ -33,8 +33,8 @@ public class NotificationWorkFlowTaskTest {
 
 	@Before
 	public void setUp() {
-		apiInstanceMock = mock(NotificationMessageApi.class);
-		underTest = new NotificationWorkFlowTask("http://localhost:8080", apiInstanceMock);
+		mockNotifier = mock(Notifier.class);
+		underTest = new NotificationWorkFlowTask(mockNotifier);
 		underTest.setBeanName("notificationWorkFlowTask");
 		ctx = new WorkContext();
 	}
@@ -50,7 +50,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, times(1)).create(dto);
+		verify(mockNotifier, times(1)).trySend(dto);
 	}
 
 	@Test
@@ -61,13 +61,13 @@ public class NotificationWorkFlowTaskTest {
 				Arrays.asList("test-group-1", "test-group-2"));
 		putParamsToCtx(dto, ctx);
 
-		doThrow(ApiException.class).when(apiInstanceMock).create(dto);
+		doThrow(ApiException.class).when(mockNotifier).trySend(dto);
 		underTest.preExecute(ctx);
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(ApiException.class, result.getError().getClass());
-		verify(apiInstanceMock, times(1)).create(dto);
+		verify(mockNotifier, times(1)).trySend(dto);
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, times(0)).create(dto);
+		verify(mockNotifier, times(0)).trySend(dto);
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, times(0)).create(dto);
+		verify(mockNotifier, times(0)).trySend(dto);
 	}
 
 	@Test
@@ -111,7 +111,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, times(0)).create(dto);
+		verify(mockNotifier, times(0)).trySend(dto);
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, times(1)).create(dto);
+		verify(mockNotifier, times(1)).trySend(dto);
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class NotificationWorkFlowTaskTest {
 		WorkReport result = underTest.execute(ctx);
 
 		assertEquals(WorkStatus.COMPLETED, result.getStatus());
-		verify(apiInstanceMock, times(1)).create(dto);
+		verify(mockNotifier, times(1)).trySend(dto);
 	}
 
 	@Test
@@ -151,7 +151,7 @@ public class NotificationWorkFlowTaskTest {
 
 		assertEquals(WorkStatus.FAILED, result.getStatus());
 		assertEquals(MissingParameterException.class, result.getError().getClass());
-		verify(apiInstanceMock, times(0)).create(dto);
+		verify(mockNotifier, times(0)).trySend(dto);
 	}
 
 	private NotificationMessageCreateRequestDTO buildNotificationMessageCreateRequestDTO(String type, String body,

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/prebuilt/PrebuiltWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/prebuilt/PrebuiltWorkFlowConfiguration.java
@@ -1,11 +1,9 @@
 package com.redhat.parodos.examples.prebuilt;
 
-import java.util.Optional;
-
 import com.redhat.parodos.tasks.notification.NotificationWorkFlowTask;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflow.consts.WorkFlowConstants;
-import com.redhat.parodos.workflow.utils.CredUtils;
+import com.redhat.parodos.workflow.task.infrastructure.Notifier;
 import com.redhat.parodos.workflows.workflow.SequentialFlow;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +17,8 @@ import org.springframework.context.annotation.Configuration;
 public class PrebuiltWorkFlowConfiguration {
 
 	@Bean
-	NotificationWorkFlowTask notificationTask() {
-		String serverIp = Optional.ofNullable(System.getenv("NOTIFICATION_SERVER_ADDRESS")).orElse("localhost");
-		String serverPort = Optional.ofNullable(System.getenv("NOTIFICATION_SERVER_PORT")).orElse("8080");
-		String notificationWorkFlowBasePath = "http://" + serverIp + ":" + serverPort;
-		log.info("NotificationWorkFlowTask basePath: {}", notificationWorkFlowBasePath);
-		return new NotificationWorkFlowTask(notificationWorkFlowBasePath,
-				"Basic " + CredUtils.getBase64Creds("test", "test"));
+	NotificationWorkFlowTask notificationTask(Notifier notifier) {
+		return new NotificationWorkFlowTask(notifier);
 	}
 
 	@Bean(name = "prebuiltWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)

--- a/workflow-service/src/main/java/com/redhat/parodos/NotificationSender.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/NotificationSender.java
@@ -1,0 +1,47 @@
+package com.redhat.parodos;
+
+import java.util.Base64;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import com.redhat.parodos.notification.sdk.api.ApiClient;
+import com.redhat.parodos.notification.sdk.api.ApiException;
+import com.redhat.parodos.notification.sdk.api.NotificationMessageApi;
+import com.redhat.parodos.notification.sdk.model.NotificationMessageCreateRequestDTO;
+import com.redhat.parodos.workflow.task.infrastructure.Notifier;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class NotificationSender implements Notifier {
+
+	private final NotificationMessageApi client;
+
+	public NotificationSender(@Value("${notification.url}") String url,
+			@Value("${notification.auth.basic.user}") String user,
+			@Value("${notification.auth.basic.password}") String password) {
+		ApiClient apiClient = new com.redhat.parodos.notification.sdk.api.ApiClient().setBasePath(url).addDefaultHeader(
+				HttpHeaders.AUTHORIZATION,
+				"Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes()));
+		client = new NotificationMessageApi(apiClient);
+	}
+
+	@Override
+	public void send(NotificationMessageCreateRequestDTO message) {
+		try {
+			trySend(message);
+		}
+		catch (ApiException e) {
+			log.error("failed sending notification message due to: " + e);
+		}
+	}
+
+	@Override
+	public void trySend(NotificationMessageCreateRequestDTO message) throws ApiException {
+		client.create(message);
+	}
+
+}

--- a/workflow-service/src/main/resources/application-dev.yml
+++ b/workflow-service/src/main/resources/application-dev.yml
@@ -18,3 +18,9 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: "25s"
 
+notification:
+  url: "${NOTIFICATION_SERVER_URL:http://localhost:8081}"
+  auth:
+    basic:
+      user: test
+      password: test

--- a/workflow-service/src/main/resources/application-local.yml
+++ b/workflow-service/src/main/resources/application-local.yml
@@ -33,3 +33,9 @@ logging:
 # ApplicationProperties class to have type-safe configuration
 # ===================================================================
 
+notification:
+  url: "${NOTIFICATION_SERVER_URL:http://localhost:8081}"
+  auth:
+    basic:
+      user: test
+      password: test


### PR DESCRIPTION
Tasks of workflows need a builtin conveient way of sending notifications
and for a lot of reasons it makes more sense then a special notificaion
tasks - specially when the input for the message exists in the task
context and its waste or just too much to pass on the context for a
special notification task. It also doesn't need plumbing the task into a
workflow which is combersome.

To send a notificaion just inject a Notifier into a bean:

@Bean
SomeTask createSomeTask(Notifier notifier) {
      new SomeTask(notifier)...
}

class SomeTask {
    SomeTask(Notifier notifier) { this.notifier = notifier; ... }

    execute(WorkContext ctx) {
        ... //work
        var m = new NotificationMessageCreateRequestDTO();
        m.setBody("body");
        notifier.send(m);
    }
}

Signed-off-by: Roy Golan <rgolan@redhat.com>
