### PR TITLE
Add task for deploying application manifests

### DIFF
--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -19,6 +19,7 @@
         <azure-core-version>1.37.0</azure-core-version>
         <azure-identity-version>1.8.1</azure-identity-version>
         <azure-resourcemanager-version>2.24.0</azure-resourcemanager-version>
+        <fabric8.version>6.6.2</fabric8.version>
     </properties>
 
     <repositories>
@@ -158,6 +159,31 @@
             <version>${azure-resourcemanager-version}</version>
         </dependency>
         <!-- End libraries for Azure access -->
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>${fabric8.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+            <version>${fabric8.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-server-mock</artifactId>
+            <version>${fabric8.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- This specific version is needed for openshift server mock -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployApplicationTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployApplicationTask.java
@@ -1,0 +1,246 @@
+package com.redhat.parodos.tasks.deploy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.parameter.WorkParameterType;
+import com.redhat.parodos.workflow.task.BaseWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteIngress;
+import io.fabric8.openshift.client.OpenShiftClient;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DeployApplicationTask extends BaseWorkFlowTask {
+
+	private final OpenShiftClientCreator clientCreator;
+
+	public DeployApplicationTask() {
+		this.clientCreator = new DefaultOpenShiftClientCreator();
+	}
+
+	// Constructor for testing purposes for mocking openshift client in unit-tests
+	public DeployApplicationTask(OpenShiftClientCreator clientCreator) {
+		this.clientCreator = clientCreator;
+	}
+
+	@Override
+	public @NonNull List<WorkParameter> getWorkFlowTaskParameters() {
+		// @formatter:off
+		return List.of(
+				WorkParameter.builder()
+					.key(DeployConstants.KUBECONFIG)
+					.type(WorkParameterType.TEXT)
+					.optional(false)
+					.description("kubeconfig file of the target cluster in json format")
+					.build(),
+				WorkParameter.builder()
+					.key(DeployConstants.MANIFESTS_PATH)
+					.type(WorkParameterType.TEXT)
+					.optional(false)
+					.description("The path to the manifests to deploy the application")
+					.build(),
+				WorkParameter.builder()
+					.key(DeployConstants.NAMESPACE)
+					.type(WorkParameterType.TEXT)
+					.optional(false)
+					.description("The namespace in which the application should be deployed")
+					.build());
+		// @formatter:on
+	}
+
+	/**
+	 * Executes the task logic, based on the following steps:
+	 * <ol>
+	 * Verify parameters are present
+	 * </ol>
+	 * <ol>
+	 * Load the manifests
+	 * </ol>
+	 * <ol>
+	 * Deploy the manifests
+	 * </ol>
+	 * <ol>
+	 * Update the context with the installed application routes
+	 * </ol>
+	 * @param workContext context in which this unit of work is being executed
+	 * @return a {@link WorkReport} with the result of the execution
+	 */
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		final Input params;
+
+		// Verify parameters are present
+		try {
+			params = getTaskParameters(workContext);
+		}
+		catch (MissingParameterException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+
+		// Load the manifests
+		final Set<Path> manifests;
+		try {
+			manifests = loadManifests(params.manifestsPath);
+		}
+		catch (IOException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Failed to read manifest files from path %s with error %s"
+							.formatted(params.manifestsPath, e.getMessage()), e));
+		}
+
+		if (manifests.isEmpty()) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("No manifest files found in path %s".formatted(params.manifestsPath)));
+		}
+
+		// Deploy the manifests
+		List<String> hostnames = new ArrayList<>();
+		try (OpenShiftClient osClient = createOpenShiftClient(params.kubeconfig)) {
+			for (Path manifest : manifests) {
+				Optional.of(applyManifest(osClient, params.namespace, manifest)).ifPresent(hostnames::addAll);
+			}
+		}
+		catch (ManifestDeployException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);
+		}
+		catch (KubernetesClientException e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext, new RuntimeException(
+					"Failed to create OpenShift client with error %s".formatted(e.getMessage()), e));
+		}
+		catch (Exception e) {
+			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+					new RuntimeException("Failed to deploy manifests with error %s".formatted(e.getMessage()), e));
+		}
+
+		workContext.put(DeployConstants.APPLICATION_HOSTNAMES, hostnames);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+	}
+
+	private static Set<Path> loadManifests(String manifestsPath) throws IOException {
+		final Set<Path> manifests;
+		try (Stream<Path> walk = Files.walk(Paths.get(manifestsPath))) {
+			manifests = walk.filter(Files::isRegularFile).filter(DeployApplicationTask::hasManifestSuffix)
+					.collect(Collectors.toSet());
+		}
+
+		return manifests;
+	}
+
+	private static boolean hasManifestSuffix(Path file) {
+		return file.toString().endsWith(".yaml") || file.toString().endsWith(".yml")
+				|| file.toString().endsWith(".json");
+	}
+
+	private static Input getTaskParameters(WorkContext workContext) throws MissingParameterException {
+		String kubeconfig = WorkContextDelegate.getRequiredValueFromRequestParams(workContext,
+				DeployConstants.KUBECONFIG);
+		String manifestsPath = WorkContextDelegate.getRequiredValueFromRequestParams(workContext,
+				DeployConstants.MANIFESTS_PATH);
+		String namespace = WorkContextDelegate.getRequiredValueFromRequestParams(workContext,
+				DeployConstants.NAMESPACE);
+		return new Input(kubeconfig, manifestsPath, namespace);
+	}
+
+	/**
+	 * Deploys manifest from a file to a namespace
+	 * @param osClient an initialized openshift client of the target cluster
+	 * @param namespace the namespace to deploy the manifest on
+	 * @param manifest the manifest to deploy
+	 * @return returns the routes to the installed application exposed via the Route
+	 * resource
+	 * @throws ManifestDeployException if the manifest could not be deployed
+	 */
+	private List<String> applyManifest(OpenShiftClient osClient, String namespace, Path manifest)
+			throws ManifestDeployException {
+		log.info("Deploying manifest %s".formatted(manifest));
+		try (InputStream stream = Files.newInputStream(manifest)) {
+			List<HasMetadata> resources = osClient.load(stream).inNamespace(namespace).create();
+			log.info("Manifest %s deployed successfully".formatted(manifest));
+
+			// obtain the hostnames from the routes
+			return getHostnamesFromRoute(osClient, resources);
+		}
+		catch (IOException e) {
+			throw new ManifestDeployException(
+					"Failed to read manifest %s with error: %s".formatted(manifest, e.getMessage()), e);
+		}
+		catch (KubernetesClientException e) {
+			throw new ManifestDeployException(
+					"Failed to create manifest %s on cluster with error: %s".formatted(manifest, e.getMessage()), e);
+		}
+	}
+
+	private List<String> getHostnamesFromRoute(OpenShiftClient osClient, List<HasMetadata> resources)
+			throws ManifestDeployException {
+		List<String> hostnames = new ArrayList<>();
+		for (HasMetadata resource : resources) {
+			if ("Route".equals(resource.getKind())) {
+				Route route;
+				String namespace = resource.getMetadata().getNamespace();
+				String name = resource.getMetadata().getName();
+				try {
+					route = osClient.routes().inNamespace(namespace).withName(name).get();
+				}
+				catch (KubernetesClientException e) {
+					throw new ManifestDeployException(
+							"Failed to get route %s/%s with error: %s".formatted(namespace, name, e.getMessage()), e);
+				}
+
+				if (route != null) {
+					hostnames.addAll(route.getStatus().getIngress().stream().map(RouteIngress::getHost).toList());
+				}
+				else {
+					throw new ManifestDeployException("Route %s/%s not found".formatted(namespace, name), null);
+				}
+			}
+		}
+
+		return hostnames;
+	}
+
+	private OpenShiftClient createOpenShiftClient(String kubeConfigString) {
+		return this.clientCreator.create(kubeConfigString);
+	}
+
+	private record Input(String kubeconfig, String manifestsPath, String namespace) {
+	}
+
+	interface OpenShiftClientCreator {
+
+		OpenShiftClient create(String kubeConfigString);
+
+	}
+
+	private static class DefaultOpenShiftClientCreator implements OpenShiftClientCreator {
+
+		@Override
+		public OpenShiftClient create(String kubeConfigString) {
+			Config config = Config.fromKubeconfig(kubeConfigString);
+			return new KubernetesClientBuilder().withConfig(config).build().adapt(OpenShiftClient.class);
+		}
+
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployConstants.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployConstants.java
@@ -1,0 +1,13 @@
+package com.redhat.parodos.tasks.deploy;
+
+public class DeployConstants {
+
+	public static final String KUBECONFIG = "kubeconfig";
+
+	public static final String MANIFESTS_PATH = "manifestsPath";
+
+	public static final String NAMESPACE = "namespace";
+
+	public static final String APPLICATION_HOSTNAMES = "applicationHostnames";
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/ManifestDeployException.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/ManifestDeployException.java
@@ -1,0 +1,9 @@
+package com.redhat.parodos.tasks.deploy;
+
+public class ManifestDeployException extends RuntimeException {
+
+	public ManifestDeployException(String error, Throwable e) {
+		super(error, e);
+	}
+
+}

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/deploy/DeployApplicationTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/deploy/DeployApplicationTaskTest.java
@@ -1,0 +1,477 @@
+package com.redhat.parodos.tasks.deploy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.UUID;
+
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.parameter.WorkParameter;
+import com.redhat.parodos.workflow.utils.WorkContextUtils;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteIngressBuilder;
+import io.fabric8.openshift.api.model.RouteStatusBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.redhat.parodos.tasks.deploy.DeployConstants.APPLICATION_HOSTNAMES;
+import static com.redhat.parodos.tasks.deploy.DeployConstants.KUBECONFIG;
+import static com.redhat.parodos.tasks.deploy.DeployConstants.MANIFESTS_PATH;
+import static com.redhat.parodos.tasks.deploy.DeployConstants.NAMESPACE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class DeployApplicationTaskTest {
+
+	private DeployApplicationTask underTest;
+
+	private OpenShiftClient osClient;
+
+	private OpenShiftServer mockServer;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		underTest = new DeployApplicationTask(kubeConfigString -> osClient);
+	}
+
+	@Test
+	public void getWorkFlowTaskParameters() {
+		// when
+		List<WorkParameter> params = underTest.getWorkFlowTaskParameters();
+
+		// then
+		assertThat(params).isNotNull();
+		assertThat(params.size()).isEqualTo(3);
+		assertThat(params.stream().map(WorkParameter::getKey).toList()).contains(KUBECONFIG, NAMESPACE, MANIFESTS_PATH);
+	}
+
+	@Test
+	public void execute_missing_parameters() {
+		// given
+		WorkContext workContext = getIncompleteWorkContext();
+
+		// when
+		underTest.preExecute(workContext);
+		WorkReport report = underTest.execute(workContext);
+
+		// then
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(report.getError()).isNotNull();
+		assertThat(report.getError()).isInstanceOf(MissingParameterException.class);
+		assertThat(report.getError().getMessage()).contains(MANIFESTS_PATH);
+	}
+
+	@Test
+	public void execute_manifests_path_does_not_exist() {
+		// given
+		String manifestsPath = UUID.randomUUID().toString();
+		WorkContext workContext = getCompleteWorkContext(manifestsPath);
+
+		// when
+		underTest.preExecute(workContext);
+		WorkReport report = underTest.execute(workContext);
+
+		// then
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(report.getError()).isNotNull();
+		assertThat(report.getError()).isInstanceOf(RuntimeException.class);
+		assertThat(report.getError().getMessage()).contains("Failed to read manifest files from path")
+				.contains(manifestsPath);
+	}
+
+	@SneakyThrows(IOException.class)
+	@Test
+	public void execute_no_files_with_manifests_suffix() {
+		// given
+		Path tempDirectory = ManifestsProvider.createTempDirectory();
+		Path tempFile = Files.createTempFile(tempDirectory, "test", ".txt");
+		String manifestsPath = tempDirectory.toAbsolutePath().toString();
+		WorkContext workContext = getCompleteWorkContext(manifestsPath);
+
+		// when
+		underTest.preExecute(workContext);
+		WorkReport report = underTest.execute(workContext);
+
+		// then
+		assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+		assertThat(report.getError()).isNotNull();
+		assertThat(report.getError()).isInstanceOf(RuntimeException.class);
+		assertThat(report.getError().getMessage()).contains("No manifest files found in path").contains(manifestsPath);
+
+		// cleanup
+		assertThatNoException().isThrownBy(() -> {
+			Files.deleteIfExists(tempFile);
+			Files.deleteIfExists(tempDirectory);
+		});
+	}
+
+	@Nested
+	class TestWithInvalidOpenShiftServer {
+
+		private ManifestsProvider.ManifestFiles manifestFiles;
+
+		@BeforeEach
+		public void setUp() throws Exception {
+			manifestFiles = ManifestsProvider.createManifests();
+
+			underTest = new DeployApplicationTask(kubeConfigString -> {
+				throw new KubernetesClientException("Error");
+			});
+		}
+
+		@AfterEach
+		public void tearDown() {
+			assertThatNoException().isThrownBy(() -> ManifestsProvider.deleteManifests(manifestFiles));
+		}
+
+		@Test
+		public void execute_invalid_openshift_client() {
+			// given
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+			assertThat(report.getError()).isNotNull();
+			assertThat(report.getError()).isInstanceOf(RuntimeException.class);
+			assertThat(report.getError().getMessage()).contains("Failed to create OpenShift client with error");
+		}
+
+	}
+
+	@Nested
+	class TestWithOpenShiftServer {
+
+		private ManifestsProvider.ManifestFiles manifestFiles;
+
+		@BeforeEach
+		public void setUp() throws Exception {
+			manifestFiles = ManifestsProvider.createManifests();
+			mockServer = new OpenShiftServer(false, false);
+			mockServer.before();
+			osClient = mockServer.getOpenshiftClient();
+			underTest = new DeployApplicationTask(kubeConfigString -> osClient);
+		}
+
+		@AfterEach
+		public void tearDown() {
+			mockServer.after();
+			assertThatNoException().isThrownBy(() -> ManifestsProvider.deleteManifests(manifestFiles));
+		}
+
+		@Test
+		public void execute_successfully() {
+			// given
+			// @formatter:off
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+			Deployment deployment = new DeploymentBuilder().withNewMetadata()
+					.withName("my-deployment")
+					.withNamespace("default").and().build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/apps/v1/namespaces/default/deployments")
+					.andReturn(200, deployment)
+					.once();
+
+			Route route = new RouteBuilder().withNewMetadata()
+				.withName("my-route")
+				.withNamespace("default")
+				.endMetadata()
+				.withNewSpec()
+				.withHost("my-host")
+				.endSpec()
+				.build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes")
+					.andReturn(200, route)
+					.once();
+
+			mockServer.expect()
+					.get()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes/my-route")
+					.andReturn(200, new RouteBuilder().withNewMetadata()
+							.withName("my-route")
+							.withNamespace("default")
+							.endMetadata()
+							.withNewSpec()
+							.withHost("my-host")
+							.endSpec()
+							.withStatus(new RouteStatusBuilder().withIngress(
+									new RouteIngressBuilder().withHost("my-host").build()
+							).build())
+							.build())
+					.once();
+			// @formatter:on
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.COMPLETED);
+			assertThat(report.getError()).isNull();
+			assertThat(report.getWorkContext().getContext()).isNotNull();
+			Object appHostnames = report.getWorkContext().getContext().get(APPLICATION_HOSTNAMES);
+			assertThat(appHostnames).isNotNull();
+			assertThat(appHostnames).isInstanceOf(List.class);
+			@SuppressWarnings("unchecked")
+			List<String> appHostnamesList = (List<String>) appHostnames;
+			assertThat(appHostnamesList).containsExactly("my-host");
+		}
+
+		@Test
+		public void execute_failed_applying_manifests() {
+			// given
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+			assertThat(report.getError()).isNotNull();
+			assertThat(report.getError()).isInstanceOf(ManifestDeployException.class);
+			assertThat(report.getError().getMessage()).contains("Failed to create manifest");
+		}
+
+		@Test
+		public void execute_failed_creating_routes() {
+			// given
+			// @formatter:off
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+			Deployment deployment = new DeploymentBuilder().withNewMetadata()
+					.withName("my-deployment")
+					.withNamespace("default").and().build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/apps/v1/namespaces/default/deployments")
+					.andReturn(200, deployment)
+					.once();
+
+			Route route = new RouteBuilder().withNewMetadata()
+					.withName("my-route")
+					.withNamespace("default")
+					.endMetadata()
+					.withNewSpec()
+					.withHost("my-host")
+					.endSpec()
+					.build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes")
+					.andReturn(400, route)
+					.once();
+			// @formatter:on
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+			assertThat(report.getError()).isNotNull();
+			assertThat(report.getError()).isInstanceOf(ManifestDeployException.class);
+		}
+
+		@Test
+		public void execute_failed_reading_routes() {
+			// given
+			// @formatter:off
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+			Deployment deployment = new DeploymentBuilder().withNewMetadata()
+					.withName("my-deployment")
+					.withNamespace("default").and().build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/apps/v1/namespaces/default/deployments")
+					.andReturn(200, deployment)
+					.once();
+
+			Route route = new RouteBuilder().withNewMetadata()
+					.withName("my-route")
+					.withNamespace("default")
+					.endMetadata()
+					.withNewSpec()
+					.withHost("my-host")
+					.endSpec()
+					.build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes")
+					.andReturn(200, route)
+					.once();
+
+			mockServer.expect()
+					.get()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes/my-route")
+					.andReturn(400, "Some error")
+					.once();
+			// @formatter:on
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+			assertThat(report.getError()).isNotNull();
+			assertThat(report.getError()).isInstanceOf(ManifestDeployException.class);
+			assertThat(report.getError().getMessage()).contains("Failed to get route").contains("default/my-route");
+		}
+
+		@Test
+		public void execute_failed_finding_routes() {
+			// given
+			// @formatter:off
+			WorkContext workContext = getCompleteWorkContext(manifestFiles.manifestsPath.toAbsolutePath().toString());
+			Deployment deployment = new DeploymentBuilder().withNewMetadata()
+					.withName("my-deployment")
+					.withNamespace("default").and().build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/apps/v1/namespaces/default/deployments")
+					.andReturn(200, deployment)
+					.once();
+
+			Route route = new RouteBuilder().withNewMetadata()
+					.withName("my-route")
+					.withNamespace("default")
+					.endMetadata()
+					.withNewSpec()
+					.withHost("my-host")
+					.endSpec()
+					.build();
+			mockServer.expect()
+					.post()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes")
+					.andReturn(200, route)
+					.once();
+
+			mockServer.expect()
+					.get()
+					.withPath("/apis/route.openshift.io/v1/namespaces/default/routes/my-route")
+					.andReturn(404, "Not found")
+					.once();
+			// @formatter:on
+
+			// when
+			underTest.preExecute(workContext);
+			WorkReport report = underTest.execute(workContext);
+
+			// then
+			assertThat(report.getStatus()).isEqualTo(WorkStatus.FAILED);
+			assertThat(report.getError()).isNotNull();
+			assertThat(report.getError()).isInstanceOf(ManifestDeployException.class);
+			assertThat(report.getError().getMessage()).contains("not found").contains("default/my-route");
+		}
+
+	}
+
+	private WorkContext getCompleteWorkContext(String manifestsPath) {
+		WorkContext workContext = new WorkContext();
+		WorkContextUtils.setMainExecutionId(workContext, UUID.randomUUID());
+		workContext.put(KUBECONFIG, "kubeconfig-content");
+		workContext.put(NAMESPACE, "default");
+		workContext.put(MANIFESTS_PATH, manifestsPath);
+		return workContext;
+	}
+
+	private WorkContext getIncompleteWorkContext() {
+		WorkContext workContext = new WorkContext();
+		WorkContextUtils.setMainExecutionId(workContext, UUID.randomUUID());
+		workContext.put(KUBECONFIG, "kubeconfig");
+		return workContext;
+	}
+
+	private static class ManifestsProvider {
+
+		@SneakyThrows(IOException.class)
+		static Path createTempDirectory() {
+			return Files.createTempDirectory("deploy");
+		}
+
+		@SneakyThrows(IOException.class)
+		static Path createRouterFile(Path parentDir) {
+			// Define the content of the OpenShift route in YAML format
+			// @formatter:off
+			String routeContent = """
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: my-route
+spec:
+  host: example.com
+  to:
+    kind: Service
+    name: my-service""";
+			// @formatter:on
+			Path routeFile = Files.createTempFile(parentDir, "openshift-route", ".yaml");
+			Files.write(routeFile, routeContent.getBytes(), StandardOpenOption.WRITE);
+			return routeFile;
+		}
+
+		@SneakyThrows(IOException.class)
+		static Path createDeploymentFile(Path parentDir) {
+			// @formatter:off
+			String deploymentContent = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+      - name: my-container
+        image: my-image:latest""";
+			// @formatter:on
+			Path deploymentFile = Files.createTempFile(parentDir, "deployment", ".yml");
+			Files.write(deploymentFile, deploymentContent.getBytes(), StandardOpenOption.WRITE);
+			return deploymentFile;
+		}
+
+		static ManifestFiles createManifests() {
+			Path manifestsPath = createTempDirectory();
+			Path deploymentFile = createDeploymentFile(manifestsPath);
+			Path routerFile = createRouterFile(manifestsPath);
+			return new ManifestFiles(manifestsPath, deploymentFile, routerFile);
+		}
+
+		static void deleteManifests(ManifestFiles manifestFiles) throws IOException {
+			Files.deleteIfExists(manifestFiles.deploymentFile);
+			Files.deleteIfExists(manifestFiles.routerFile);
+			Files.deleteIfExists(manifestFiles.manifestsPath);
+		}
+
+		record ManifestFiles(Path manifestsPath, Path deploymentFile, Path routerFile) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds a workflow task to read manifests from a given path and apply them to OCP cluster.
Once the resources are applied, the work context should be updated with the routers to the deployed application.

**Which issue(s) this PR fixes**:
Fixes [FLPATH-411](https://issues.redhat.com/browse/FLPATH-411)

**Change type**
- [x] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
