### PR TITLE
Improve waiting strategy for Integration tests

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/EscalationFlowTest.java
@@ -24,7 +24,7 @@ public class EscalationFlowTest {
 	private static final String WORKFLOW_NAME = "workflowStartingCheckingAndEscalation";
 
 	@Test
-	public void runEscalationFlow() throws ApiException, InterruptedException {
+	public void runEscalationFlow() throws ApiException {
 		log.info("******** Running The Escalation workFlow ********");
 		TestComponents components = new WorkFlowTestBuilder().withDefaultProject().withWorkFlowDefinition(WORKFLOW_NAME)
 				.build();

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleRollbackWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleRollbackWorkFlowTest.java
@@ -30,7 +30,7 @@ public class SimpleRollbackWorkFlowTest {
 	private static final String WORKFLOW_NAME = "simpleFailedWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW;
 
 	@Test
-	public void runRollbackWorkFlow() throws ApiException, InterruptedException {
+	public void runRollbackWorkFlow() throws ApiException {
 		log.info("******** Running The Simple WorkFlow ********");
 		TestComponents components = new WorkFlowTestBuilder().withDefaultProject()
 				.withWorkFlowDefinition(WORKFLOW_NAME, getWorkFlowDefinitionResponseConsumer()).build();

--- a/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/RetryExecutorService.java
+++ b/sdk-utils/src/main/java/com/redhat/parodos/sdkutils/RetryExecutorService.java
@@ -1,0 +1,87 @@
+package com.redhat.parodos.sdkutils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class RetryExecutorService<T> implements AutoCloseable {
+
+	private final ExecutorService executor;
+
+	public RetryExecutorService() {
+		executor = Executors.newFixedThreadPool(1);
+	}
+
+	/**
+	 * Submit a task to the executor service, retrying on failure until the task succeeds
+	 * @param task The task to submit
+	 * @return The result of the task
+	 */
+	public T submitWithRetry(Callable<T> task) {
+		// @formatter:off
+		return submitWithRetry(task, () -> {}, () -> {}, 10 * 60 * 1000, 5000);
+		// @formatter:on
+	}
+
+	/**
+	 * Submit a task to the executor service, retrying on failure until the task
+	 * @param task The task to submit
+	 * @param onSuccess A callback to invoke when the task succeeds
+	 * @param onFailure A callback to invoke when the task fails
+	 * @param maxRetryTime The maximum time to retry the task for
+	 * @param retryDelay The delay between retries
+	 * @return The result of the task
+	 */
+	public T submitWithRetry(Callable<T> task, Runnable onSuccess, Runnable onFailure, long maxRetryTime,
+			long retryDelay) {
+		Future<T> future = executor.submit(() -> {
+			long startTime = System.currentTimeMillis();
+			long endTime = startTime + maxRetryTime;
+
+			while (System.currentTimeMillis() < endTime) {
+				try {
+					T result = task.call();
+					onSuccess.run();
+					return result; // Success, no need to retry
+				}
+				catch (Exception e) {
+					// Task failed, invoke onFailure callback
+					onFailure.run();
+
+					// Sleep for the retry delay
+					try {
+						// FIXME: This is a blocking call, we should use a non-blocking
+						// sleep
+						Thread.sleep(retryDelay);
+					}
+					catch (InterruptedException ex) {
+						Thread.currentThread().interrupt();
+						return null; // Interrupted, exit the task
+					}
+				}
+			}
+
+			return null; // Retry limit reached
+		});
+
+		try {
+			return future.get();
+		}
+		catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		executor.shutdown();
+		boolean awaited = executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+		if (!awaited) {
+			throw new RuntimeException("Failed to await termination of executor service");
+		}
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of relying on okhttp async implementation, we use executor service to invoke recurring requests to the service till completion.
This is designed to decrease the CPU load even lower while maintaining more readable and easier-to-maintain code.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (FLPATH-xxxx)*:
Fixes #[FLPATH-399](https://issues.redhat.com/browse/FLPATH-399)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [x] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
