### PR TITLE
remove assessmentTask config value from app-config.yaml

### DIFF
--- a/hack/manifests/backstage/app-config.yaml
+++ b/hack/manifests/backstage/app-config.yaml
@@ -4,7 +4,6 @@ app:
 parodos:
   workflows:
     assessment: 'onboardingAssessment_ASSESSMENT_WORKFLOW'
-    assessmentTask: 'onboardingAssessmentTask'
   pollingInterval: 10000
 
 organization:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `assessmentTask` configuration field has been removed in the backstage frontend code


**Change type**
- [ ] New feature
- [X] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
