### PR TITLE
Propagte security context to threads created by spring

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.data.util.Pair;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -95,6 +96,7 @@ public class BeanWorkFlowRegistryImpl implements WorkFlowRegistry {
 
 	@PostConstruct
 	void postInit() {
+		SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
 		workFlowDefinitionService.cleanAllDefinitionMappings();
 		saveWorkFlow();
 		saveChecker();


### PR DESCRIPTION
Motivation
All flow and task execution are async (@Async) and All
of them are lacking the security context. This means sending
notification or any other action that needs this info is lacking it.

Modification
Configure the context strategy on bootup time so every thread that
spring creates will inherit the security context.

Result
Sending notifications using the Notifier interface doesn't need any user
information

Gaps
Workflows that are continued upon server restart are probably missing
this information and we need to probably fetch the user info from the DB
and rebuild the security context.

Signed-off-by: Roy Golan <rgolan@redhat.com>
