### PR TITLE
Release to GH and Publish Maven Packages using github action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,58 @@
+name: Full Release on Tag Push
+on:
+  push:
+    tags:
+      - v**
+jobs:
+  GitHub-Release:
+    runs-on: ubuntu-latest
+    steps:
+       steps:
+        - run: gh release create ${{  github.ref_name }} --generate-notes
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  Maven-Publish:
+    runs-on: ubuntu-latest
+      - uses: actions/checkout@v3
+
+      - name: "Set up Maven Central Repository"
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: "Publish package to maven repo"
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+
+  Container-Publish:
+    - name: "Build container images"
+      run: |
+        make build-images GIT_BRANCH=${GITHUB_REF##*/}
+        make tag-images GIT_BRANCH=${GITHUB_REF##*/}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        registry: "quay.io"
+        username: "parodos-dev+githubpush"
+        password: "${{ secrets.QUAY_GITHUB_TOKEN }}"
+
+    - name: "Push container images"
+      run: |
+        make push-images GIT_BRANCH=${GITHUB_REF##*/}
+
+  Bump-Next:
+    - name: "Bump to next version"
+      run: |
+        git config --global user.name 'GitHub workflow committer for $GITHUB_REPOSITORY'
+        git config --global user.email 'github-workflow-committer@users.noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        make bump-version install bump-git-commit
+        git push origin
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,6 +38,6 @@ jobs:
           username: "parodos-dev+githubpush"
           password: "${{ secrets.QUAY_GITHUB_TOKEN }}"
 
-      - name: "Build container images"
+      - name: "Push container images"
         run: |
           make push-images GIT_BRANCH=${GITHUB_REF##*/}

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,12 @@ git-tag: ## tag commit and prepare for image release
 	git tag -a $(TAG) -m "$(TAG)"
 	$(eval TAG=$(TAG))
 
+# Officially release using local machine. Deprecated.
 release-all: update-version release git-release git-tag build-images tag-images push-images bump-version install bump-git-commit
+
+# Officially release using github automation
+release-tag-push: update-version git-release git-tag
+	git push origin v$(RELEASE_VERSION)
 
 ##@ Run
 .PHONY: docker-run docker-stop


### PR DESCRIPTION
This action will push the packages when a tag v* is pushed.

To initiated it:
    ```
    make release-tag-push
    ```

That would promote the version of the pom ,tag with v*, and push the tag
to origin. A github action would kick in and:

- create a github release
- push modules to maven
- build container images
- push container images
- bump the next version
- push the a commit with next


Signed-off-by: Roy Golan <rgolan@redhat.com>
