### PR TITLE
Remove execute and rename executeAsync to execute

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImpl.java
@@ -77,7 +77,7 @@ public class WorkFlowContinuationServiceImpl implements WorkFlowContinuationServ
 
 	@Override
 	public void continueWorkFlow(ExecutionContext executionContext) {
-		workFlowExecutor.executeAsync(executionContext);
+		workFlowExecutor.execute(executionContext);
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutor.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutor.java
@@ -3,7 +3,6 @@ package com.redhat.parodos.workflow.execution.service;
 import java.util.UUID;
 
 import com.redhat.parodos.workflows.work.WorkContext;
-import com.redhat.parodos.workflows.work.WorkReport;
 import lombok.Builder;
 
 import org.springframework.scheduling.annotation.Async;
@@ -11,9 +10,7 @@ import org.springframework.scheduling.annotation.Async;
 public interface WorkFlowExecutor {
 
 	@Async
-	void executeAsync(ExecutionContext context);
-
-	WorkReport execute(ExecutionContext context);
+	void execute(ExecutionContext context);
 
 	@Builder
 	record ExecutionContext(UUID projectId, UUID userId, String workFlowName, WorkContext workContext, UUID executionId,

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowExecutorImpl.java
@@ -25,23 +25,18 @@ public class WorkFlowExecutorImpl implements WorkFlowExecutor {
 	}
 
 	@Override
-	public void executeAsync(ExecutionContext executionContext) {
-		execute(executionContext);
-	}
-
-	@Override
-	public WorkReport execute(ExecutionContext context) {
+	public void execute(ExecutionContext context) {
 		WorkFlow workFlow = workFlowDelegate.getWorkFlowByName(context.workFlowName());
 		log.info("execute workflow {} (ID: {})", context.workFlowName(), context.executionId());
 		WorkContextUtils.updateWorkContextPartially(context.workContext(), context.projectId(), context.userId(),
 				context.workFlowName(), context.executionId());
 		WorkReport report = WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(workFlow, context.workContext());
+		log.info("work report for  {} (ID: {}): {}", context.workFlowName(), context.executionId(), report);
 		if (isExecutionFailed(context)) {
 			log.error("workflow {} (ID: {}) failed. Check the logs for errors coming from the tasks in this workflow.",
 					context.workFlowName(), context.executionId());
 			executeRollbackWorkFlowIfNeeded(context);
 		}
-		return report;
 	}
 
 	private void executeRollbackWorkFlowIfNeeded(ExecutionContext context) {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -157,10 +157,9 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 		WorkFlowExecution workFlowExecution = saveWorkFlow(projectId, user.getId(),
 				workFlowDefinitionRepository.findFirstByName(workflowName), WorkStatus.IN_PROGRESS, null, arguments);
 		WorkContextUtils.setMainExecutionId(workContext, workFlowExecution.getId());
-		workFlowExecutor
-				.executeAsync(WorkFlowExecutor.ExecutionContext.builder().projectId(projectId).userId(user.getId())
-						.workFlowName(workflowName).workContext(workContext).executionId(workFlowExecution.getId())
-						.rollbackWorkFlowName(workFlowDefinitionResponseDTO.getRollbackWorkflow()).build());
+		workFlowExecutor.execute(WorkFlowExecutor.ExecutionContext.builder().projectId(projectId).userId(user.getId())
+				.workFlowName(workflowName).workContext(workContext).executionId(workFlowExecution.getId())
+				.rollbackWorkFlowName(workFlowDefinitionResponseDTO.getRollbackWorkflow()).build());
 		return new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext, null);
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationServiceImplTest.java
@@ -73,7 +73,7 @@ class WorkFlowContinuationServiceImplTest {
 
 		// then
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		verify(this.workFlowExecutor, times(0)).executeAsync(any(ExecutionContext.class));
+		verify(this.workFlowExecutor, times(0)).execute(any(ExecutionContext.class));
 	}
 
 	@Test
@@ -146,8 +146,7 @@ class WorkFlowContinuationServiceImplTest {
 
 		when(this.workFlowTaskRepository.findByWorkFlowExecutionId(wfExecution.getId()))
 				.thenReturn(List.of(workFlowTaskExecution));
-		doThrow(new RuntimeException("JsonParseException")).when(workFlowExecutor)
-				.executeAsync(any(ExecutionContext.class));
+		doThrow(new RuntimeException("JsonParseException")).when(workFlowExecutor).execute(any(ExecutionContext.class));
 
 		// when
 		Exception exception = assertThrows(RuntimeException.class, () -> this.service.workFlowRunAfterStartup());
@@ -157,7 +156,7 @@ class WorkFlowContinuationServiceImplTest {
 		assertTrue(exception.getMessage().contains("JsonParseException"));
 
 		verify(this.workFlowRepository, times(1)).findByStatusInAndIsMain(workFlowStatuses);
-		verify(this.workFlowExecutor, times(1)).executeAsync(any(ExecutionContext.class));
+		verify(this.workFlowExecutor, times(1)).execute(any(ExecutionContext.class));
 
 	}
 
@@ -189,7 +188,7 @@ class WorkFlowContinuationServiceImplTest {
 
 	private void verifyAsyncExecution(WorkFlowExecution workFlowExecution) {
 		var argument = ArgumentCaptor.forClass(ExecutionContext.class);
-		verify(this.workFlowExecutor, times(1)).executeAsync(argument.capture());
+		verify(this.workFlowExecutor, times(1)).execute(argument.capture());
 		assertThat(argument.getValue().projectId()).isEqualTo(workFlowExecution.getProjectId());
 		assertThat(argument.getValue().userId()).isEqualTo(workFlowExecution.getUser().getId());
 		assertThat(argument.getValue().workFlowName()).isEqualTo(TEST_WORKFLOW);


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- If the PR includes auto generated code, make sure to add this code in different commit (last commit), to make the review process easier.
-->

**What this PR does / why we need it**:
This PR removes the former `execute` method and rename `executeAsync` to `execute` as the `WorkReport` returned by the former `execute` method was not used.

The test `executeTestWithValidData` has to be removed as it was explicitly testing the returned `WorkReport` and as other tests are testing async execution.

**Which issue(s) this PR fixes** 

Fixes #[FLPATH-425](https://issues.redhat.com//browse/FLPATH-425)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
