### PR TITLE
FLPATH-445: Add support to display alert message for tasks waiting user interference 

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/FailedWithAlertMessageWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/FailedWithAlertMessageWorkFlowTest.java
@@ -1,0 +1,99 @@
+package com.redhat.parodos.flows.negative;
+
+import java.util.function.Consumer;
+
+import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
+import com.redhat.parodos.flows.common.WorkFlowTestBuilder.TestComponents;
+import com.redhat.parodos.sdk.api.WorkflowApi;
+import com.redhat.parodos.sdk.invoker.ApiException;
+import com.redhat.parodos.sdk.model.WorkDefinitionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO.ProcessingTypeEnum;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO.TypeEnum;
+import com.redhat.parodos.sdk.model.WorkFlowExecutionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowExecutionResponseDTO.WorkStatusEnum;
+import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
+import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO.StatusEnum;
+import com.redhat.parodos.sdk.model.WorkStatusResponseDTO;
+import com.redhat.parodos.sdkutils.WorkFlowServiceUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class FailedWithAlertMessageWorkFlowTest {
+
+	private static final String WORKFLOW_NAME = "failedWithAlertMessageWorkFlow";
+
+	@Test
+	public void runSequentialFailedWorkFlow() throws ApiException {
+		log.info("******** Running The FailedWithAlertMessageWorkFlow ********");
+		TestComponents components = new WorkFlowTestBuilder().withDefaultProject()
+				.withWorkFlowDefinition(WORKFLOW_NAME, getWorkFlowDefinitionResponseConsumer()).build();
+
+		WorkFlowRequestDTO workFlowRequestDTO = new WorkFlowRequestDTO();
+		workFlowRequestDTO.setProjectId(components.project().getId());
+		workFlowRequestDTO.setWorkFlowName(WORKFLOW_NAME);
+
+		log.info("executes 2 tasks that should end with failed status and alert message");
+		WorkflowApi workflowApi = new WorkflowApi(components.apiClient());
+		WorkFlowExecutionResponseDTO workFlowResponseDTO = workflowApi.execute(workFlowRequestDTO);
+
+		assertThat(workFlowResponseDTO.getWorkFlowExecutionId()).isNotNull();
+		assertThat(workFlowResponseDTO.getWorkStatus()).isEqualTo(WorkStatusEnum.IN_PROGRESS);
+
+		log.info("FailedWithAlertMessageWorkFlow execution id: {}", workFlowResponseDTO.getWorkFlowExecutionId());
+
+		WorkFlowStatusResponseDTO workFlowStatusResponseDTO = WorkFlowServiceUtils.waitWorkflowStatusAsync(workflowApi,
+				workFlowResponseDTO.getWorkFlowExecutionId(), StatusEnum.FAILED);
+
+		assertThat(workFlowStatusResponseDTO.getWorkFlowExecutionId()).isNotNull();
+		assertThat(workFlowStatusResponseDTO.getStatus()).isEqualTo(StatusEnum.FAILED);
+		assertThat(workFlowStatusResponseDTO.getMessage()).isNull();
+
+		// verify the task status and message
+		assertThat(workFlowStatusResponseDTO.getWorks()).isNotNull();
+		assertThat(workFlowStatusResponseDTO.getWorks()).hasSize(2);
+
+		// first task - doNothingWorkFlowTask (fetched in reversed order)
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getName()).isEqualTo("doNothingAgainWorkFlowTask");
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getStatus())
+				.isEqualTo(WorkStatusResponseDTO.StatusEnum.COMPLETED);
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getMessage()).isNull();
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getAlertMessage()).isNull();
+
+		// second task - failedWithAlertMessageWorkFlowTask
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getName())
+				.isEqualTo("failedWithAlertMessageWorkFlowTask");
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getStatus())
+				.isEqualTo(WorkStatusResponseDTO.StatusEnum.FAILED);
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getMessage()).isNull();
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getAlertMessage())
+				.isEqualTo("[link](http://localhost:8080)");
+
+		log.info("******** FailedWithAlertMessageWorkFlow successfully ended: {} ********",
+				workFlowStatusResponseDTO.getStatus());
+	}
+
+	private static Consumer<WorkFlowDefinitionResponseDTO> getWorkFlowDefinitionResponseConsumer() {
+		return workFlowDefinition -> {
+			assertThat(workFlowDefinition.getId()).isNotNull();
+			assertThat(WORKFLOW_NAME).isEqualTo(workFlowDefinition.getName());
+			assertThat(workFlowDefinition.getProcessingType()).isEqualTo(ProcessingTypeEnum.SEQUENTIAL);
+			assertThat(workFlowDefinition.getType()).isEqualTo(TypeEnum.INFRASTRUCTURE);
+
+			assertThat(workFlowDefinition.getWorks()).isNotNull();
+			assertThat(workFlowDefinition.getWorks()).hasSize(2);
+			assertThat(workFlowDefinition.getWorks().get(1).getName()).isEqualTo("doNothingAgainWorkFlowTask");
+			assertThat(workFlowDefinition.getWorks().get(1).getWorkType())
+					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(workFlowDefinition.getWorks().get(1).getWorks()).isNullOrEmpty();
+			assertThat(workFlowDefinition.getWorks().get(1).getProcessingType()).isNull();
+			assertThat(workFlowDefinition.getWorks().get(1).getParameters()).isNotNull();
+			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("failedWithAlertMessageWorkFlowTask");
+		};
+	}
+
+}

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/PendingWithAlertMessageWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/PendingWithAlertMessageWorkFlowTest.java
@@ -1,0 +1,99 @@
+package com.redhat.parodos.flows.negative;
+
+import java.util.function.Consumer;
+
+import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
+import com.redhat.parodos.flows.common.WorkFlowTestBuilder.TestComponents;
+import com.redhat.parodos.sdk.api.WorkflowApi;
+import com.redhat.parodos.sdk.invoker.ApiException;
+import com.redhat.parodos.sdk.model.WorkDefinitionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO.ProcessingTypeEnum;
+import com.redhat.parodos.sdk.model.WorkFlowDefinitionResponseDTO.TypeEnum;
+import com.redhat.parodos.sdk.model.WorkFlowExecutionResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowExecutionResponseDTO.WorkStatusEnum;
+import com.redhat.parodos.sdk.model.WorkFlowRequestDTO;
+import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO;
+import com.redhat.parodos.sdk.model.WorkFlowStatusResponseDTO.StatusEnum;
+import com.redhat.parodos.sdk.model.WorkStatusResponseDTO;
+import com.redhat.parodos.sdkutils.WorkFlowServiceUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class PendingWithAlertMessageWorkFlowTest {
+
+	private static final String WORKFLOW_NAME = "pendingWithAlertMessageWorkFlow";
+
+	@Test
+	public void runSequentialFailedWorkFlow() throws ApiException {
+		log.info("******** Running The PendingWithAlertMessageWorkFlow ********");
+		TestComponents components = new WorkFlowTestBuilder().withDefaultProject()
+				.withWorkFlowDefinition(WORKFLOW_NAME, getWorkFlowDefinitionResponseConsumer()).build();
+
+		WorkFlowRequestDTO workFlowRequestDTO = new WorkFlowRequestDTO();
+		workFlowRequestDTO.setProjectId(components.project().getId());
+		workFlowRequestDTO.setWorkFlowName(WORKFLOW_NAME);
+
+		log.info("executes 2 tasks that should end with pending status and alert message");
+		WorkflowApi workflowApi = new WorkflowApi(components.apiClient());
+		WorkFlowExecutionResponseDTO workFlowResponseDTO = workflowApi.execute(workFlowRequestDTO);
+
+		assertThat(workFlowResponseDTO.getWorkFlowExecutionId()).isNotNull();
+		assertThat(workFlowResponseDTO.getWorkStatus()).isEqualTo(WorkStatusEnum.IN_PROGRESS);
+
+		log.info("PendingWithAlertMessageWorkFlow execution id: {}", workFlowResponseDTO.getWorkFlowExecutionId());
+
+		WorkFlowStatusResponseDTO workFlowStatusResponseDTO = WorkFlowServiceUtils.waitWorkflowStatusAsync(workflowApi,
+				workFlowResponseDTO.getWorkFlowExecutionId(), StatusEnum.PENDING);
+
+		assertThat(workFlowStatusResponseDTO.getWorkFlowExecutionId()).isNotNull();
+		assertThat(workFlowStatusResponseDTO.getStatus()).isEqualTo(StatusEnum.PENDING);
+		assertThat(workFlowStatusResponseDTO.getMessage()).isNull();
+
+		// verify the task status and message
+		assertThat(workFlowStatusResponseDTO.getWorks()).isNotNull();
+		assertThat(workFlowStatusResponseDTO.getWorks()).hasSize(2);
+
+		// first task - doNothingWorkFlowTask (fetched in reversed order)
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getName()).isEqualTo("doNothingWorkFlowTask");
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getStatus())
+				.isEqualTo(WorkStatusResponseDTO.StatusEnum.COMPLETED);
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getMessage()).isNull();
+		assertThat(workFlowStatusResponseDTO.getWorks().get(1).getAlertMessage()).isNull();
+
+		// second task - pendingWithAlertMessageWorkFlowTask
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getName())
+				.isEqualTo("pendingWithAlertMessageWorkFlowTask");
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getStatus())
+				.isEqualTo(WorkStatusResponseDTO.StatusEnum.PENDING);
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getMessage()).isNull();
+		assertThat(workFlowStatusResponseDTO.getWorks().get(0).getAlertMessage())
+				.isEqualTo("[link](http://localhost:8080)");
+
+		log.info("******** PendingWithAlertMessageWorkFlow successfully ended: {} ********",
+				workFlowStatusResponseDTO.getStatus());
+	}
+
+	private static Consumer<WorkFlowDefinitionResponseDTO> getWorkFlowDefinitionResponseConsumer() {
+		return workFlowDefinition -> {
+			assertThat(workFlowDefinition.getId()).isNotNull();
+			assertThat(WORKFLOW_NAME).isEqualTo(workFlowDefinition.getName());
+			assertThat(workFlowDefinition.getProcessingType()).isEqualTo(ProcessingTypeEnum.SEQUENTIAL);
+			assertThat(workFlowDefinition.getType()).isEqualTo(TypeEnum.INFRASTRUCTURE);
+
+			assertThat(workFlowDefinition.getWorks()).isNotNull();
+			assertThat(workFlowDefinition.getWorks()).hasSize(2);
+			assertThat(workFlowDefinition.getWorks().get(1).getName()).isEqualTo("doNothingWorkFlowTask");
+			assertThat(workFlowDefinition.getWorks().get(1).getWorkType())
+					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(workFlowDefinition.getWorks().get(1).getWorks()).isNullOrEmpty();
+			assertThat(workFlowDefinition.getWorks().get(1).getProcessingType()).isNull();
+			assertThat(workFlowDefinition.getWorks().get(1).getParameters()).isNotNull();
+			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("pendingWithAlertMessageWorkFlowTask");
+		};
+	}
+
+}

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployApplicationTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/deploy/DeployApplicationTask.java
@@ -135,7 +135,7 @@ public class DeployApplicationTask extends BaseWorkFlowTask {
 		}
 
 		workContext.put(DeployConstants.APPLICATION_HOSTNAMES, hostnames);
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private static Set<Path> loadManifests(String manifestsPath) throws IOException {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitArchiveTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitArchiveTask.java
@@ -73,7 +73,7 @@ public class GitArchiveTask extends BaseWorkFlowTask {
 			}
 		}
 
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private Repository getRepo(String path) throws IOException {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitBranchTask.java
@@ -77,7 +77,7 @@ public class GitBranchTask extends BaseWorkFlowTask {
 					"Cannot create the branch on the repository: %s".formatted(e.getMessage()), e));
 		}
 
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private Repository getRepo(String path) throws IOException {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCloneTask.java
@@ -74,7 +74,7 @@ public class GitCloneTask extends BaseWorkFlowTask {
 		workContext.put(GitConstants.CONTEXT_URI, gitUri);
 		workContext.put(GitConstants.CONTEXT_DESTINATION, destination);
 		workContext.put(GitConstants.CONTEXT_BRANCH, gitBranch);
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private String cloneRepo(String gitUri, String gitBranch, String credentials)

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitCommitTask.java
@@ -67,7 +67,7 @@ public class GitCommitTask extends BaseWorkFlowTask {
 			return new DefaultWorkReport(WorkStatus.FAILED, workContext,
 					new RuntimeException("Cannot create the commit on the repository: %s".formatted(e)));
 		}
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private Repository getRepo(String path) throws IOException {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitPushTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/git/GitPushTask.java
@@ -79,7 +79,7 @@ public class GitPushTask extends BaseWorkFlowTask {
 			}
 		}
 
-		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext, null);
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
 	}
 
 	private Repository getRepo(String path) throws IOException {

--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/jira/JiraTask.java
@@ -96,7 +96,7 @@ public class JiraTask extends BaseWorkFlowTask {
 		if (id.isBlank()) {
 			try {
 				JiraIssue issue = createIssue(new JiraIssue("", project, summary, description, "", List.of(comment)));
-				WorkReport report = new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext(), null);
+				WorkReport report = new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext());
 				report.getWorkContext().put("issue", issue);
 				return report;
 			}
@@ -114,7 +114,7 @@ public class JiraTask extends BaseWorkFlowTask {
 
 					var context = new WorkContext();
 					context.put("issue", issue);
-					return new DefaultWorkReport(WorkStatus.COMPLETED, context, null);
+					return new DefaultWorkReport(WorkStatus.COMPLETED, context);
 				}
 				if (!summary.isBlank() && !issue.summary.equals(summary)) {
 					issue.summary = summary;
@@ -134,7 +134,7 @@ public class JiraTask extends BaseWorkFlowTask {
 				}
 				var context = new WorkContext();
 				context.put("issue", issue);
-				return new DefaultWorkReport(WorkStatus.COMPLETED, context, null);
+				return new DefaultWorkReport(WorkStatus.COMPLETED, context);
 			}
 			catch (Exception e) {
 				return new DefaultWorkReport(WorkStatus.FAILED, workContext, e);

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
@@ -67,19 +67,6 @@ public class DefaultWorkReport implements WorkReport {
 		this.alertMessage = alertMessage;
 	}
 
-	/**
-	 * Create a new {@link DefaultWorkReport}.
-	 * @param status of work
-	 * @param error if any
-	 * @param message if any
-	 */
-	public DefaultWorkReport(WorkStatus status, WorkContext workContext, Throwable error, String message) {
-		this(status, workContext);
-		this.error = error;
-		this.message = message;
-	}
-
-
 	public WorkStatus getStatus() {
 		return status;
 	}

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
@@ -36,6 +36,8 @@ public class DefaultWorkReport implements WorkReport {
 
 	private Throwable error;
 
+	private String message;
+
 	/**
 	 * Create a new {@link DefaultWorkReport}.
 	 * @param status of work
@@ -53,6 +55,16 @@ public class DefaultWorkReport implements WorkReport {
 	public DefaultWorkReport(WorkStatus status, WorkContext workContext, Throwable error) {
 		this(status, workContext);
 		this.error = error;
+	}
+
+	/**
+	 * Create a new {@link DefaultWorkReport}.
+	 * @param status of work
+	 * @param message if any
+	 */
+	public DefaultWorkReport(WorkStatus status, WorkContext workContext, String message) {
+		this(status, workContext);
+		this.message = message;
 	}
 
 	public WorkStatus getStatus() {

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
@@ -67,6 +67,19 @@ public class DefaultWorkReport implements WorkReport {
 		this.alertMessage = alertMessage;
 	}
 
+	/**
+	 * Create a new {@link DefaultWorkReport}.
+	 * @param status of work
+	 * @param error if any
+	 * @param message if any
+	 */
+	public DefaultWorkReport(WorkStatus status, WorkContext workContext, Throwable error, String message) {
+		this(status, workContext);
+		this.error = error;
+		this.message = message;
+	}
+
+
 	public WorkStatus getStatus() {
 		return status;
 	}

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/DefaultWorkReport.java
@@ -36,7 +36,7 @@ public class DefaultWorkReport implements WorkReport {
 
 	private Throwable error;
 
-	private String message;
+	private String alertMessage;
 
 	/**
 	 * Create a new {@link DefaultWorkReport}.
@@ -60,11 +60,11 @@ public class DefaultWorkReport implements WorkReport {
 	/**
 	 * Create a new {@link DefaultWorkReport}.
 	 * @param status of work
-	 * @param message if any
+	 * @param alertMessage if any
 	 */
-	public DefaultWorkReport(WorkStatus status, WorkContext workContext, String message) {
+	public DefaultWorkReport(WorkStatus status, WorkContext workContext, String alertMessage) {
 		this(status, workContext);
-		this.message = message;
+		this.alertMessage = alertMessage;
 	}
 
 	public WorkStatus getStatus() {
@@ -81,9 +81,14 @@ public class DefaultWorkReport implements WorkReport {
 	}
 
 	@Override
+	public String getAlertMessage() {
+		return this.alertMessage;
+	}
+
+	@Override
 	public String toString() {
-		return "DefaultWorkReport {" + "status=" + status + ", context=" + workContext + ", error="
-				+ (error == null ? "''" : error) + '}';
+		return "DefaultWorkReport {" + "status=" + status + ", context=" + workContext + ", alertMessage='"
+				+ alertMessage + ", error=" + (error == null ? "''" : error) + '}';
 	}
 
 }

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/WorkReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/work/WorkReport.java
@@ -50,4 +50,9 @@ public interface WorkReport {
 	 */
 	WorkContext getWorkContext();
 
+	/**
+	 * Get alert message if any.
+	 */
+	String getAlertMessage();
+
 }

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
@@ -139,4 +139,9 @@ public class ParallelFlowReport implements WorkReport {
 		return workContext;
 	}
 
+	@Override
+	public String getAlertMessage() {
+		return null;
+	}
+
 }

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/workflow/ParallelFlowReport.java
@@ -26,6 +26,7 @@ package com.redhat.parodos.workflows.workflow;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
@@ -139,9 +140,16 @@ public class ParallelFlowReport implements WorkReport {
 		return workContext;
 	}
 
+	/**
+	 * Return the last alertMessage of partial reports, or null if there are no
+	 * alertMessage.
+	 * @return the last alertMessage
+	 */
+
 	@Override
 	public String getAlertMessage() {
-		return null;
+		return reports.stream().map(WorkReport::getAlertMessage).filter(Objects::nonNull)
+				.reduce((first, second) -> second).orElse(null);
 	}
 
 }

--- a/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
+++ b/workflow-engine/src/test/java/com/redhat/parodos/workflows/workflow/ParallelFlowReportTest.java
@@ -47,19 +47,19 @@ public class ParallelFlowReportTest {
 		WorkContext workContext = new WorkContext();
 
 		completedParallelFlowReport = new ParallelFlowReport();
-		completedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
-		completedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+		completedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_1"));
+		completedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_2"));
 
 		failedParallelFlowReport = new ParallelFlowReport();
 		failedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.FAILED, workContext, exception));
-		failedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+		failedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_1"));
 		failedParallelFlowReport.add(new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext));
 
 		progressParallelFlowReport = new ParallelFlowReport();
-		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
-		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_1"));
+		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_2"));
 		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext));
-		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext));
+		progressParallelFlowReport.add(new DefaultWorkReport(WorkStatus.COMPLETED, workContext, "alertMessage_3"));
 	}
 
 	@Test
@@ -79,6 +79,13 @@ public class ParallelFlowReportTest {
 		assertThat(completedParallelFlowReport.getReports()).hasSize(2);
 		assertThat(failedParallelFlowReport.getReports()).hasSize(3);
 		assertThat(progressParallelFlowReport.getReports()).hasSize(4);
+	}
+
+	@Test
+	public void testGetAlertMessage() {
+		assertThat(completedParallelFlowReport.getAlertMessage()).isEqualTo("alertMessage_2");
+		assertThat(failedParallelFlowReport.getAlertMessage()).isEqualTo("alertMessage_1");
+		assertThat(progressParallelFlowReport.getAlertMessage()).isEqualTo("alertMessage_3");
 	}
 
 }

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -23,6 +23,7 @@
         <freemarker.version>2.3.30</freemarker.version>
         <fabric8.version>6.5.1</fabric8.version>
         <move2kube.version>v1.0.3</move2kube.version>
+        <markdowngenerator.version>1.3.1.1</markdowngenerator.version>
     </properties>
     <dependencies>
         <dependency>
@@ -131,6 +132,11 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>5.7.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.steppschuh.markdowngenerator</groupId>
+            <artifactId>markdowngenerator</artifactId>
+            <version>${markdowngenerator.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -1,10 +1,12 @@
 package com.redhat.parodos.examples.move2kube.checker;
 
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 import com.google.common.base.Strings;
+import com.redhat.parodos.examples.move2kube.utils.Move2KubeUtils;
 import com.redhat.parodos.workflow.parameter.WorkParameter;
 import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
@@ -19,6 +21,7 @@ import dev.parodos.move2kube.client.model.Project;
 import dev.parodos.move2kube.client.model.ProjectOutputsValue;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.steppschuh.markdowngenerator.text.TextBuilder;
 
 @Slf4j
 public class TransformChecker extends BaseWorkFlowCheckerTask {
@@ -32,9 +35,12 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 	@Getter
 	protected static String projectContextKey = "move2KubeProjectID";
 
+	private final String server;
+
 	public TransformChecker(String server) {
 		client = new ApiClient();
 		client.setBasePath(server);
+		this.server = server;
 	}
 
 	@Override
@@ -56,7 +62,8 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 						new IllegalArgumentException("Cannot get the project transformation output from the list"));
 			}
 			if (!Objects.equals(output.getStatus(), "done")) {
-				return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
+						getMessage(server, workspaceID, projectID, transformID));
 			}
 		}
 		catch (ApiException e) {
@@ -78,6 +85,18 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 	@Override
 	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
 		return Collections.emptyList();
+	}
+
+	private String getMessage(String server, String workspaceID, String projectID, String transformId) {
+		return new TextBuilder()
+				.heading("Alert", 1)
+				.newParagraph()
+				.text("You need to complete some information for your transformation")
+				.newLine()
+				.text("Please check this")
+				.link("link", Move2KubeUtils.getPath(server, workspaceID, projectID, transformId))
+				.end()
+				.toString();
 	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -91,18 +91,13 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 		String path;
 		try {
 			path = Move2KubeUtils.getPath(server, workspaceID, projectID, transformId);
-		} catch (URISyntaxException e) {
+		}
+		catch (URISyntaxException e) {
 			path = "Cannot parse move2kube url " + server;
 		}
-		return new TextBuilder()
-				.heading("Alert", 1)
-				.newParagraph()
-				.text("You need to complete some information for your transformation")
-				.newLine()
-				.text("Please check this")
-				.link("link", path)
-				.end()
-				.toString();
+		return new TextBuilder().heading("Alert", 1).newParagraph()
+				.text("You need to complete some information for your transformation").newLine()
+				.text("Please check this").link("link", path).end().toString();
 	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -88,13 +88,19 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 	}
 
 	private String getMessage(String server, String workspaceID, String projectID, String transformId) {
+		String path;
+		try {
+			path = Move2KubeUtils.getPath(server, workspaceID, projectID, transformId);
+		} catch (URISyntaxException e) {
+			path = "Cannot parse move2kube url " + server;
+		}
 		return new TextBuilder()
 				.heading("Alert", 1)
 				.newParagraph()
 				.text("You need to complete some information for your transformation")
 				.newLine()
 				.text("Please check this")
-				.link("link", Move2KubeUtils.getPath(server, workspaceID, projectID, transformId))
+				.link("link", path)
 				.end()
 				.toString();
 	}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/checker/TransformChecker.java
@@ -63,7 +63,7 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 			}
 			if (!Objects.equals(output.getStatus(), "done")) {
 				return new DefaultWorkReport(WorkStatus.FAILED, workContext,
-						getMessage(server, workspaceID, projectID, transformID));
+						getMessage(workspaceID, projectID, transformID));
 			}
 		}
 		catch (ApiException e) {
@@ -87,10 +87,10 @@ public class TransformChecker extends BaseWorkFlowCheckerTask {
 		return Collections.emptyList();
 	}
 
-	private String getMessage(String server, String workspaceID, String projectID, String transformId) {
+	private String getMessage(String workspaceID, String projectID, String transformId) {
 		String path;
 		try {
-			path = Move2KubeUtils.getPath(server, workspaceID, projectID, transformId);
+			path = Move2KubeUtils.getPath(this.server, workspaceID, projectID, transformId);
 		}
 		catch (URISyntaxException e) {
 			path = "Cannot parse move2kube url " + server;

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/task/Move2KubeTransform.java
@@ -1,9 +1,9 @@
 package com.redhat.parodos.examples.move2kube.task;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 
+import com.redhat.parodos.examples.move2kube.utils.Move2KubeUtils;
 import com.redhat.parodos.workflow.task.infrastructure.Notifier;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.DefaultWorkReport;
@@ -82,11 +82,8 @@ public class Move2KubeTransform extends Move2KubeBase {
 	}
 
 	private boolean sendNotification(String userID, String workspaceID, String projectID, String outputID) {
-		String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
 		try {
-			URI baseUri = new URI(server);
-			URI url = new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null);
-
+			String url = Move2KubeUtils.getPath(server, workspaceID, projectID, outputID);
 			String message = String.format(
 					"You need to complete some information for your transformation in the following [url](%s)", url);
 

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
@@ -1,0 +1,21 @@
+package com.redhat.parodos.examples.move2kube.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public abstract class Move2KubeUtils {
+
+	private Move2KubeUtils() {
+	}
+
+	public static String getPath(String server, String workspaceID, String projectID, String outputID)
+			throws URISyntaxException {
+		String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
+		URI baseUri = new URI(server);
+		return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
@@ -8,14 +8,18 @@ import java.net.URISyntaxException;
  */
 public abstract class Move2KubeUtils {
 
-	private Move2KubeUtils() {
-	}
+    private Move2KubeUtils() {
+    }
 
-	public static String getPath(String server, String workspaceID, String projectID, String outputID)
-			throws URISyntaxException {
-		String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
-		URI baseUri = new URI(server);
-		return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
-	}
+    public static String getPath(String server, String workspaceID, String projectID, String outputID) {
+        String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
+        URI baseUri = null;
+        try {
+            baseUri = new URI(server);
+            return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
@@ -11,15 +11,10 @@ public abstract class Move2KubeUtils {
     private Move2KubeUtils() {
     }
 
-    public static String getPath(String server, String workspaceID, String projectID, String outputID) {
+    public static String getPath(String server, String workspaceID, String projectID, String outputID) throws URISyntaxException {
         String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
-        URI baseUri = null;
-        try {
-            baseUri = new URI(server);
-            return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
-        } catch (URISyntaxException e) {
-            return null;
-        }
+        URI baseUri = new URI(server);
+        return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
     }
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
@@ -8,13 +8,14 @@ import java.net.URISyntaxException;
  */
 public abstract class Move2KubeUtils {
 
-    private Move2KubeUtils() {
-    }
+	private Move2KubeUtils() {
+	}
 
-    public static String getPath(String server, String workspaceID, String projectID, String outputID) throws URISyntaxException {
-        String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
-        URI baseUri = new URI(server);
-        return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
-    }
+	public static String getPath(String server, String workspaceID, String projectID, String outputID)
+			throws URISyntaxException {
+		String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
+		URI baseUri = new URI(server);
+		return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
+	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/move2kube/utils/Move2KubeUtils.java
@@ -13,7 +13,7 @@ public abstract class Move2KubeUtils {
 
 	public static String getPath(String server, String workspaceID, String projectID, String outputID)
 			throws URISyntaxException {
-		String path = String.format("/workspaces/%s/projects/%s/outputs/%s", workspaceID, projectID, outputID);
+		String path = "/workspaces/%s/projects/%s/outputs/%s".formatted(workspaceID, projectID, outputID);
 		URI baseUri = new URI(server);
 		return new URI(baseUri.getScheme(), baseUri.getAuthority(), path, null, null).getPath();
 	}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/FailedWithAlertMessageWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/FailedWithAlertMessageWorkFlowConfiguration.java
@@ -1,0 +1,41 @@
+package com.redhat.parodos.examples.negative.simple;
+
+import com.redhat.parodos.examples.negative.simple.task.DoNothingWorkFlowTask;
+import com.redhat.parodos.examples.negative.simple.task.FailedWithAlertMessageWorkFlowTask;
+import com.redhat.parodos.workflow.annotation.Infrastructure;
+import com.redhat.parodos.workflows.workflow.SequentialFlow;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FailedWithAlertMessageWorkFlowConfiguration {
+
+	@Bean
+	FailedWithAlertMessageWorkFlowTask FailedWithAlertMessageWorkFlowTask() {
+		return new FailedWithAlertMessageWorkFlowTask();
+	}
+
+	@Bean(name = "doNothingAgainWorkFlowTask")
+	DoNothingWorkFlowTask doNothingWorkFlowTask() {
+		return new DoNothingWorkFlowTask();
+	}
+
+	@Bean(name = "failedWithAlertMessageWorkFlow")
+	@Infrastructure
+	WorkFlow failedWithAlertMessageWorkFlow(
+			@Qualifier("failedWithAlertMessageWorkFlowTask") FailedWithAlertMessageWorkFlowTask failedWithAlertMessageWorkFlowTask,
+			@Qualifier("doNothingAgainWorkFlowTask") DoNothingWorkFlowTask doNothingWorkFlowTask) {
+		// @formatter:off
+		return SequentialFlow
+				.Builder.aNewSequentialFlow()
+				.named("failedWithAlertMessageWorkFlow")
+				.execute(doNothingWorkFlowTask)
+				.then(failedWithAlertMessageWorkFlowTask)
+				.build();
+		// @formatter:on
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/PendingWithAlertMessageWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/PendingWithAlertMessageWorkFlowConfiguration.java
@@ -1,0 +1,41 @@
+package com.redhat.parodos.examples.negative.simple;
+
+import com.redhat.parodos.examples.negative.simple.task.DoNothingWorkFlowTask;
+import com.redhat.parodos.examples.negative.simple.task.PendingWithAlertMessageWorkFlowTask;
+import com.redhat.parodos.workflow.annotation.Infrastructure;
+import com.redhat.parodos.workflows.workflow.SequentialFlow;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PendingWithAlertMessageWorkFlowConfiguration {
+
+	@Bean
+	PendingWithAlertMessageWorkFlowTask pendingWithAlertMessageWorkFlowTask() {
+		return new PendingWithAlertMessageWorkFlowTask();
+	}
+
+	@Bean
+	DoNothingWorkFlowTask doNothingWorkFlowTask() {
+		return new DoNothingWorkFlowTask();
+	}
+
+	@Bean(name = "pendingWithAlertMessageWorkFlow")
+	@Infrastructure
+	WorkFlow pendingWithAlertMessageWorkFlow(
+			@Qualifier("pendingWithAlertMessageWorkFlowTask") PendingWithAlertMessageWorkFlowTask pendingWithAlertMessageWorkFlowTask,
+			@Qualifier("doNothingWorkFlowTask") DoNothingWorkFlowTask doNothingWorkFlowTask) {
+		// @formatter:off
+		return SequentialFlow
+				.Builder.aNewSequentialFlow()
+				.named("pendingWithAlertMessageWorkFlow")
+				.execute(doNothingWorkFlowTask)
+				.then(pendingWithAlertMessageWorkFlowTask)
+				.build();
+		// @formatter:on
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/DoNothingWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/DoNothingWorkFlowTask.java
@@ -1,0 +1,22 @@
+package com.redhat.parodos.examples.negative.simple.task;
+
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DoNothingWorkFlowTask extends BaseInfrastructureWorkFlowTask {
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		log.info("DoNothingWorkFlowTask execution should return COMPLETE");
+		return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/FailedWithAlertMessageWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/FailedWithAlertMessageWorkFlowTask.java
@@ -1,0 +1,22 @@
+package com.redhat.parodos.examples.negative.simple.task;
+
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class FailedWithAlertMessageWorkFlowTask extends BaseInfrastructureWorkFlowTask {
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		log.info("FailedWithAlertMessageWorkFlowTask execution should return FAILED");
+		return new DefaultWorkReport(WorkStatus.FAILED, workContext, "[link](http://localhost:8080)");
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/PendingWithAlertMessageWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/negative/simple/task/PendingWithAlertMessageWorkFlowTask.java
@@ -1,0 +1,22 @@
+package com.redhat.parodos.examples.negative.simple.task;
+
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PendingWithAlertMessageWorkFlowTask extends BaseInfrastructureWorkFlowTask {
+
+	@Override
+	public WorkReport execute(WorkContext workContext) {
+		log.info("FailedWithAlertMessageWorkFlowTask execution should return PENDING");
+		return new DefaultWorkReport(WorkStatus.PENDING, workContext, "[link](http://localhost:8080)");
+	}
+
+}

--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -1553,14 +1553,16 @@ components:
       example:
         workFlowName: workFlowName
         works:
-        - works:
+        - alertMessage: alertMessage
+          works:
           - null
           - null
           name: name
           message: message
           type: TASK
           status: FAILED
-        - works:
+        - alertMessage: alertMessage
+          works:
           - null
           - null
           name: name
@@ -1650,6 +1652,7 @@ components:
       type: object
     WorkStatusResponseDTO:
       example:
+        alertMessage: alertMessage
         works:
         - null
         - null
@@ -1658,6 +1661,8 @@ components:
         type: TASK
         status: FAILED
       properties:
+        alertMessage:
+          type: string
         message:
           type: string
         name:

--- a/workflow-service-sdk/docs/WorkStatusResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkStatusResponseDTO.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**alertMessage** | **String** |  |  [optional] |
 |**message** | **String** |  |  [optional] |
 |**name** | **String** |  |  [optional] |
 |**status** | [**StatusEnum**](#StatusEnum) |  |  [optional] |

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
@@ -39,6 +39,11 @@ import com.redhat.parodos.sdk.invoker.JSON;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class WorkStatusResponseDTO {
 
+	public static final String SERIALIZED_NAME_ALERT_MESSAGE = "alertMessage";
+
+	@SerializedName(SERIALIZED_NAME_ALERT_MESSAGE)
+	private String alertMessage;
+
 	public static final String SERIALIZED_NAME_MESSAGE = "message";
 
 	@SerializedName(SERIALIZED_NAME_MESSAGE)
@@ -175,6 +180,26 @@ public class WorkStatusResponseDTO {
 	public WorkStatusResponseDTO() {
 	}
 
+	public WorkStatusResponseDTO alertMessage(String alertMessage) {
+
+		this.alertMessage = alertMessage;
+		return this;
+	}
+
+	/**
+	 * Get alertMessage
+	 * @return alertMessage
+	 **/
+	@javax.annotation.Nullable
+
+	public String getAlertMessage() {
+		return alertMessage;
+	}
+
+	public void setAlertMessage(String alertMessage) {
+		this.alertMessage = alertMessage;
+	}
+
 	public WorkStatusResponseDTO message(String message) {
 
 		this.message = message;
@@ -292,7 +317,8 @@ public class WorkStatusResponseDTO {
 			return false;
 		}
 		WorkStatusResponseDTO workStatusResponseDTO = (WorkStatusResponseDTO) o;
-		return Objects.equals(this.message, workStatusResponseDTO.message)
+		return Objects.equals(this.alertMessage, workStatusResponseDTO.alertMessage)
+				&& Objects.equals(this.message, workStatusResponseDTO.message)
 				&& Objects.equals(this.name, workStatusResponseDTO.name)
 				&& Objects.equals(this.status, workStatusResponseDTO.status)
 				&& Objects.equals(this.type, workStatusResponseDTO.type)
@@ -301,13 +327,14 @@ public class WorkStatusResponseDTO {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(message, name, status, type, works);
+		return Objects.hash(alertMessage, message, name, status, type, works);
 	}
 
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("class WorkStatusResponseDTO {\n");
+		sb.append("    alertMessage: ").append(toIndentedString(alertMessage)).append("\n");
 		sb.append("    message: ").append(toIndentedString(message)).append("\n");
 		sb.append("    name: ").append(toIndentedString(name)).append("\n");
 		sb.append("    status: ").append(toIndentedString(status)).append("\n");
@@ -335,6 +362,7 @@ public class WorkStatusResponseDTO {
 	static {
 		// a set of all properties/fields (JSON key names)
 		openapiFields = new HashSet<String>();
+		openapiFields.add("alertMessage");
 		openapiFields.add("message");
 		openapiFields.add("name");
 		openapiFields.add("status");
@@ -371,6 +399,12 @@ public class WorkStatusResponseDTO {
 						"The field `%s` in the JSON string is not defined in the `WorkStatusResponseDTO` properties. JSON: %s",
 						entry.getKey(), jsonObj.toString()));
 			}
+		}
+		if ((jsonObj.get("alertMessage") != null && !jsonObj.get("alertMessage").isJsonNull())
+				&& !jsonObj.get("alertMessage").isJsonPrimitive()) {
+			throw new IllegalArgumentException(String.format(
+					"Expected the field `alertMessage` to be a primitive type in the JSON string but got `%s`",
+					jsonObj.get("alertMessage").toString()));
 		}
 		if ((jsonObj.get("message") != null && !jsonObj.get("message").isJsonNull())
 				&& !jsonObj.get("message").isJsonPrimitive()) {

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -1728,6 +1728,9 @@
       "WorkStatusResponseDTO" : {
         "type" : "object",
         "properties" : {
+          "alertMessage" : {
+            "type" : "string"
+          },
           "message" : {
             "type" : "string"
           },

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
@@ -146,6 +146,8 @@ public class WorkFlowTaskExecutionAspect {
 		if (report.getError() != null) {
 			workFlowTaskExecution.setMessage(report.getError().getMessage());
 		}
+
+		workFlowTaskExecution.setAlertMessage(report.getAlertMessage());
 		workFlowTaskExecution.setLastUpdateDate(new Date());
 		workFlowService.updateWorkFlowTask(workFlowTaskExecution);
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/dto/WorkStatusResponseDTO.java
@@ -49,6 +49,8 @@ public class WorkStatusResponseDTO {
 
 	private String message;
 
+	private String alertMessage;
+
 	@JsonProperty("works")
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkStatusResponseDTO> works;

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
@@ -58,8 +58,6 @@ public class WorkFlowExecution extends AbstractEntity {
 
 	private String message;
 
-	private String alertMessage;
-
 	@Column(updatable = false)
 	private Date startDate;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowExecution.java
@@ -58,6 +58,8 @@ public class WorkFlowExecution extends AbstractEntity {
 
 	private String message;
 
+	private String alertMessage;
+
 	@Column(updatable = false)
 	private Date startDate;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowTaskExecution.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/entity/WorkFlowTaskExecution.java
@@ -60,6 +60,8 @@ public class WorkFlowTaskExecution extends AbstractEntity {
 
 	private String message;
 
+	private String alertMessage;
+
 	@Column(updatable = false)
 	private Date startDate;
 

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceDelegate.java
@@ -184,9 +184,11 @@ public class WorkFlowServiceDelegate {
 
 		WorkStatus workStatus = WorkStatus.PENDING;
 		String message = null;
+		String alertMessage = null;
 
 		if (workFlowTaskExecutionOptional.isPresent()) {
 			message = workFlowTaskExecutionOptional.get().getMessage();
+			alertMessage = workFlowTaskExecutionOptional.get().getAlertMessage();
 			workStatus = WorkStatus.valueOf(workFlowTaskExecutionOptional.get().getStatus().name());
 			if (workFlowTaskDefinition.getWorkFlowCheckerMappingDefinition() != null) {
 				workStatus = Optional
@@ -202,7 +204,7 @@ public class WorkFlowServiceDelegate {
 		}
 
 		return WorkStatusResponseDTO.builder().name(workFlowTaskDefinition.getName()).type(WorkType.TASK)
-				.status(workStatus).message(message).build();
+				.status(workStatus).message(message).alertMessage(alertMessage).build();
 	}
 
 	private List<WorkStatusResponseDTO> nestWorkFlowWorksStatusDTO(

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -160,7 +160,7 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 		workFlowExecutor.execute(WorkFlowExecutor.ExecutionContext.builder().projectId(projectId).userId(user.getId())
 				.workFlowName(workflowName).workContext(workContext).executionId(workFlowExecution.getId())
 				.rollbackWorkFlowName(workFlowDefinitionResponseDTO.getRollbackWorkflow()).build());
-		return new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext, null);
+		return new DefaultWorkReport(WorkStatus.IN_PROGRESS, workContext);
 	}
 
 	@Override

--- a/workflow-service/src/main/resources/db/changelog/tables.xml
+++ b/workflow-service/src/main/resources/db/changelog/tables.xml
@@ -160,6 +160,7 @@
             </column>
             <column name="status" type="varchar(255)"/>
             <column name="message" type="varchar(4000)"/>
+            <column name="alertMessage" type="varchar(4000)"/>
             <column name="start_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="end_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="arguments" type="varchar(4000)"/>

--- a/workflow-service/src/main/resources/db/changelog/tables.xml
+++ b/workflow-service/src/main/resources/db/changelog/tables.xml
@@ -160,7 +160,6 @@
             </column>
             <column name="status" type="varchar(255)"/>
             <column name="message" type="varchar(4000)"/>
-            <column name="alertMessage" type="varchar(4000)"/>
             <column name="start_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="end_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="arguments" type="varchar(4000)"/>
@@ -198,6 +197,7 @@
             <column name="results" type="varchar(4000)"/>
             <column name="status" type="varchar(255)"/>
             <column name="message" type="varchar(4000)"/>
+            <column name="alert_message" type="varchar(4000)"/>
             <column name="start_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="end_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="last_update_date" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP"/>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to display alert message for tasks waiting user interference as describe in the [UI Design](https://www.figma.com/file/iu0HAOSoLOESA2GHyxuHLg/parados-mui?type=design&node-id=3942-4194&t=lDyCrRq9cdwbDmi2-0)

The field `alertMessage` has been added in `WorkStatusResponseDTO` class.

See example JSON:

```json
{
  "workFlowExecutionId": "0848cd36-511e-4283-ab97-a9d348acc377",
  "workFlowName": "pendingWithAlertMessageWorkFlow",
  "status": "PENDING",
  "message": null,
  "works": [
    {
      "name": "pendingWithAlertMessageWorkFlowTask",
      "type": "TASK",
      "status": "PENDING",
      "message": null,
      "alertMessage": "[link](http://localhost:8080)"
    },
    {
      "name": "doNothingWorkFlowTask",
      "type": "TASK",
      "status": "COMPLETED",
      "message": null,
      "alertMessage": null
    }
  ]
}
```

Co-Author:  Moti Asayag <masayag@redhat.com> @masayag 

**Which issue(s) this PR fixes** 
Fixes # [FLPATH-445](https://issues.redhat.com/browse/FLPATH-445)

**Change type**
- [x] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [x] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
