### PR TITLE
Retain alert message only for not-completed tasks

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/aspect/WorkFlowTaskExecutionAspect.java
@@ -147,7 +147,8 @@ public class WorkFlowTaskExecutionAspect {
 			workFlowTaskExecution.setMessage(report.getError().getMessage());
 		}
 
-		workFlowTaskExecution.setAlertMessage(report.getAlertMessage());
+		workFlowTaskExecution
+			.setAlertMessage(report.getStatus() != WorkStatus.COMPLETED ? report.getAlertMessage() : null);
 		workFlowTaskExecution.setLastUpdateDate(new Date());
 		workFlowService.updateWorkFlowTask(workFlowTaskExecution);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When a task is completed, the alert message can be spared.

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
