### PR TITLE
feat: append manifests to release

### DIFF
--- a/.github/workflows/release_append.yaml
+++ b/.github/workflows/release_append.yaml
@@ -1,0 +1,32 @@
+name: Push manifest to release
+on:
+  release:
+    types: ["created"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Publish binaries
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup kubectl
+      uses: azure/setup-kubectl@v1
+      with:
+        version: 'v1.27.0'
+
+    - name: Build
+      run: |
+        make release-manifests
+
+    - name: Upload manifest to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: manifests.yaml
+        asset_name: manifests.yaml
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ workflow-service-sdk/.travis.yml
 ##############################
 notification-service-sdk/.openapi-generator
 
+
+##############################
+## Release manifests
+##############################
+manifests.yaml
+hack/manifests/release

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,9 @@ git-tag: ## tag commit and prepare for image release
 
 release-all: update-version release git-release git-tag build-images tag-images push-images bump-version install bump-git-commit
 
+release-manifests:
+	./hack/scripts/release.sh $(RELEASE_VERSION)
+
 ##@ Run
 .PHONY: docker-run docker-stop
 

--- a/hack/scripts/release.sh
+++ b/hack/scripts/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export VERSION=${1:-1.0}
+
+echo "Writing manifests for ${VERSION}";
+
+BASE_PATH=$(dirname "$0")
+RELEASE_PATH="$BASE_PATH/../manifests/release/"
+mkdir -p $RELEASE_PATH || echo "Already exists"
+
+cat > $RELEASE_PATH/kustomization.yaml <<EOF
+kind: Kustomization
+bases:
+- ../backstage/
+
+images:
+- name: quay.io/parodos-dev/workflow-service:main
+  newTag: "$VERSION"
+
+- name: quay.io/parodos-dev/notification-service:main
+  newTag: "$VERSION"
+
+- name: quay.io/parodos-dev/backstage-parodos:latest-openshift
+  newTag: "$VERSION-openshift"
+EOF
+
+
+kubectl kustomize $RELEASE_PATH > manifests.yaml


### PR DESCRIPTION
When a new release is created, this GitHub action will automatically push to the release the manifests with the correct images for Parodos and backstage with the plugin.
