### PR TITLE
Fix bug in context arguments merge

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/ContextArgumentsMerger.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/ContextArgumentsMerger.java
@@ -1,0 +1,76 @@
+package com.redhat.parodos.workflow.execution.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
+import com.redhat.parodos.workflows.work.WorkContext;
+
+public abstract class ContextArgumentsMerger {
+
+	private ContextArgumentsMerger() {
+	}
+
+	/**
+	 * Merge arguments from source workflow to target context by the following precedence:
+	 * <ol>
+	 * <li>Target workflow arguments</li>
+	 * <li>Source workflow arguments from its context by key
+	 * WORKFLOW_EXECUTION_ARGUMENTS</li>
+	 * <li>Source workflow arguments</li>
+	 * </ol>
+	 * @param sourceWorkFlow source workflow
+	 * @param targetContext target context
+	 */
+	public static void mergeArguments(WorkFlowExecution sourceWorkFlow, WorkContext targetContext) {
+		Map<String, String> mergedArgs = new HashMap<>();
+		mergeSourceWorkFlowArguments(sourceWorkFlow, mergedArgs);
+		mergeSourceWorkFlowContextArguments(sourceWorkFlow, mergedArgs);
+		mergeTargetContextArguments(targetContext, mergedArgs);
+
+		// write merged arguments to target WorkContext
+		WorkContextDelegate.write(targetContext, WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION,
+				WorkContextDelegate.Resource.ARGUMENTS, mergedArgs);
+	}
+
+	private static void mergeSourceWorkFlowArguments(WorkFlowExecution sourceWorkflow, Map<String, String> mergedArgs) {
+		if (sourceWorkflow.getArguments() == null) {
+			return;
+		}
+
+		Map<String, String> sourceArgs = WorkFlowDTOUtil.readStringAsObject(sourceWorkflow.getArguments(),
+				new TypeReference<HashMap<String, String>>() {
+				}, null);
+		mergeArguments(mergedArgs, sourceArgs);
+	}
+
+	private static void mergeSourceWorkFlowContextArguments(WorkFlowExecution sourceWorkflow,
+			Map<String, String> mergedArgs) {
+		Map<String, String> sourceContextArgs = convertArguments(
+				WorkContextDelegate.read(sourceWorkflow.getWorkFlowExecutionContext().getWorkContext(),
+						WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION, WorkContextDelegate.Resource.ARGUMENTS));
+		mergeArguments(mergedArgs, sourceContextArgs);
+	}
+
+	private static void mergeTargetContextArguments(WorkContext targetContext, Map<String, String> mergedArgs) {
+		Map<String, String> targetContextArgs = convertArguments(WorkContextDelegate.read(targetContext,
+				WorkContextDelegate.ProcessType.WORKFLOW_EXECUTION, WorkContextDelegate.Resource.ARGUMENTS));
+		mergeArguments(mergedArgs, targetContextArgs);
+	}
+
+	private static void mergeArguments(Map<String, String> mergedArgs, Map<String, String> arguments) {
+		if (arguments != null) {
+			mergedArgs.putAll(arguments);
+		}
+	}
+
+	private static HashMap<String, String> convertArguments(Object arguments) {
+		return new ObjectMapper().convertValue(arguments, new TypeReference<>() {
+		});
+	}
+
+}

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/ContextArgumentsMergerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/ContextArgumentsMergerTest.java
@@ -1,0 +1,72 @@
+package com.redhat.parodos.workflow.execution.service;
+
+import java.util.Map;
+
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
+import com.redhat.parodos.workflow.execution.entity.WorkFlowExecutionContext;
+import com.redhat.parodos.workflows.work.WorkContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+class ContextArgumentsMergerTest {
+
+	@Test
+	void mergeArguments_shouldMergeArgumentsCorrectly() {
+		// given
+		// prepare source context
+		WorkFlowExecution sourceWorkFlow = mock(WorkFlowExecution.class);
+		when(sourceWorkFlow.getArguments()).thenReturn("{\"key1\":\"value1\"}");
+		WorkFlowExecutionContext sourceWorkFlowExecutionContext = mock(WorkFlowExecutionContext.class);
+		when(sourceWorkFlow.getWorkFlowExecutionContext()).thenReturn(sourceWorkFlowExecutionContext);
+		WorkContext sourceWorkContext = mock(WorkContext.class);
+		when(sourceWorkFlowExecutionContext.getWorkContext()).thenReturn(sourceWorkContext);
+		when(sourceWorkContext.get("WORKFLOW_EXECUTION_ARGUMENTS"))
+				.thenReturn(Map.of("key1", "valueX", "key2", "value2"));
+
+		// prepare target context
+		WorkContext targetContext = new WorkContext();
+		targetContext.put("WORKFLOW_EXECUTION_ARGUMENTS", Map.of("key1", "valueY"));
+
+		// when
+		ContextArgumentsMerger.mergeArguments(sourceWorkFlow, targetContext);
+
+		// then
+		Object workflowExecutionArguments = targetContext.getContext().get("WORKFLOW_EXECUTION_ARGUMENTS");
+		assertThat(workflowExecutionArguments).isInstanceOf(Map.class);
+		Map<String, String> workflowExecutionArgumentsMap;
+		workflowExecutionArgumentsMap = (Map) workflowExecutionArguments;
+		assertThat(workflowExecutionArgumentsMap).containsAllEntriesOf(Map.of("key1", "valueY", "key2", "value2"));
+	}
+
+	@Test
+	void mergeArguments_noArgumentsInSourceContext() {
+		// given
+		// prepare source context
+		WorkFlowExecution sourceWorkFlow = mock(WorkFlowExecution.class);
+		when(sourceWorkFlow.getArguments()).thenReturn(null);
+		WorkFlowExecutionContext sourceWorkFlowExecutionContext = mock(WorkFlowExecutionContext.class);
+		when(sourceWorkFlow.getWorkFlowExecutionContext()).thenReturn(sourceWorkFlowExecutionContext);
+		WorkContext sourceWorkContext = mock(WorkContext.class);
+		when(sourceWorkFlowExecutionContext.getWorkContext()).thenReturn(sourceWorkContext);
+		when(sourceWorkContext.get("WORKFLOW_EXECUTION_ARGUMENTS")).thenReturn(null);
+
+		// prepare target context
+		WorkContext targetContext = new WorkContext();
+		targetContext.put("WORKFLOW_EXECUTION_ARGUMENTS", Map.of("key1", "value1"));
+
+		// when
+		ContextArgumentsMerger.mergeArguments(sourceWorkFlow, targetContext);
+
+		// then
+		Object workflowExecutionArguments = targetContext.getContext().get("WORKFLOW_EXECUTION_ARGUMENTS");
+		assertThat(workflowExecutionArguments).isInstanceOf(Map.class);
+		Map<String, String> workflowExecutionArgumentsMap;
+		workflowExecutionArgumentsMap = (Map) workflowExecutionArguments;
+		assertThat(workflowExecutionArgumentsMap).containsAllEntriesOf(Map.of("key1", "value1"));
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes a bug that caused only the first argument to be stored in the target work context.
In addition, the precedence of the merged arguments is defined as:
* Target workflow arguments
* Source workflow arguments from their context by key WORKFLOW_EXECUTION_ARGUMENTS
* Source workflow arguments

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (FLPATH-xxxx)*:
Fixes #[FLPATH-458](https://issues.redhat.com//browse/FLPATH-458)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
