### PR TITLE
Fix: warning `bases` is deprecated use `resources`

### DIFF
--- a/hack/manifests/testing/kustomization.yaml
+++ b/hack/manifests/testing/kustomization.yaml
@@ -1,9 +1,11 @@
-bases:
-- ../base
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ingress.yaml
 - ldap.yaml
 - postgres.yaml
+- ../base
 
 patchesStrategicMerge:
 - parodos-patch.yaml


### PR DESCRIPTION

**What this PR does / why we need it**:
The 'bases' field is no longer supported and has been replaced with the `resources` field in the Kustomization file.

**Which issue(s) this PR fixes** :
Fixes # [FLPATH-475](https://issues.redhat.com/browse/FLPATH-475)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
