### PR TITLE
Fix: `patchesStrategicMerge` is deprecated use `patches`

### DIFF
--- a/hack/manifests/testing/kustomization.yaml
+++ b/hack/manifests/testing/kustomization.yaml
@@ -7,13 +7,14 @@ resources:
 - postgres.yaml
 - ../base
 
-patchesStrategicMerge:
-- parodos-patch.yaml
+patches:
+- path: parodos-patch-workflow-service.yaml
+- path: parodos-patch-workflow-service-config.yaml
+- path: parodos-patch-notification-service-config.yaml
 
 images:
 - name: quay.io/parodos-dev/workflow-service:main
   newTag: test
-
 - name: quay.io/parodos-dev/notification-service:main
   newTag: test
 

--- a/hack/manifests/testing/parodos-patch-notification-service-config.yaml
+++ b/hack/manifests/testing/parodos-patch-notification-service-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notification-service-config
+data:
+  SPRING_PROFILES_ACTIVE: "local"

--- a/hack/manifests/testing/parodos-patch-workflow-service-config.yaml
+++ b/hack/manifests/testing/parodos-patch-workflow-service-config.yaml
@@ -1,14 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: workflow-service
-spec:
-  template:
-    spec:
-      containers:
-      - name: workflow-service
-        imagePullPolicy: IfNotPresent
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,10 +9,3 @@ data:
   DATASOURCE_PASSWORD: "parodos"
   SPRING_PROFILES_ACTIVE: "dev"
   NOTIFICATION_SERVER_URL: "http://notification-service.default.svc.cluster.local:8080"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: notification-service-config
-data:
-  SPRING_PROFILES_ACTIVE: "local"

--- a/hack/manifests/testing/parodos-patch-workflow-service.yaml
+++ b/hack/manifests/testing/parodos-patch-workflow-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: workflow-service
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What this PR does / why we need it**:
The `patchesStrategicMerge` field is no longer supported and has been replaced with the `patches` field in the Kustomization file.

**Which issue(s) this PR fixes** 
Fixes # [FLPATH-477](https://issues.redhat.com/browse/FLPATH-477)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
