### PR TITLE
Change clean phase for notification-service-sdk

### DIFF
--- a/notification-service-sdk/pom.xml
+++ b/notification-service-sdk/pom.xml
@@ -39,7 +39,7 @@
                 <executions>
                     <execution>
                         <id>skip-if-no-modifications</id>
-                        <phase>generate-test-sources</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
@@ -80,7 +80,7 @@
                     </execution>
                     <execution>
                         <id>auto-clean</id>
-                        <phase>process-test-sources</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>clean</goal>
                         </goals>


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit applies the same change of PR https://github.com/parodos-dev/parodos/pull/431 to `notification-service-sdk`

**Which issue(s) this PR fixes** :
Fixes # [FLPATH-461](https://issues.redhat.com//browse/FLPATH-461)

**Change type**
- [ ] New feature
- [x] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [x] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
