### PR TITLE
[FLPATH-294] Return Checkers in WorkFlowDefinitions

### DIFF
--- a/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/PrebuiltWorkFlowTest.java
@@ -2,6 +2,7 @@ package com.redhat.parodos.flows;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
@@ -79,12 +80,13 @@ public class PrebuiltWorkFlowTest {
 
 			assertNotNull(workFlowDefinition.getWorks());
 			assertEquals(1, workFlowDefinition.getWorks().size());
-			assertEquals("notificationTask", workFlowDefinition.getWorks().get(0).getName());
-			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK,
-					workFlowDefinition.getWorks().get(0).getWorkType());
-			assertTrue(CollectionUtils.isEmpty(workFlowDefinition.getWorks().get(0).getWorks()));
-			assertNull(workFlowDefinition.getWorks().get(0).getProcessingType());
-			assertNotNull(workFlowDefinition.getWorks().get(0).getParameters());
+			Optional<WorkDefinitionResponseDTO> firstWork = workFlowDefinition.getWorks().stream().findFirst();
+			assertTrue(firstWork.isPresent());
+			assertEquals("notificationTask", firstWork.get().getName());
+			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK, firstWork.get().getWorkType());
+			assertTrue(CollectionUtils.isEmpty(firstWork.get().getWorks()));
+			assertNull(firstWork.get().getProcessingType());
+			assertNotNull(firstWork.get().getParameters());
 		};
 	}
 

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/SimpleWorkFlowTest.java
@@ -90,19 +90,18 @@ public class SimpleWorkFlowTest {
 
 			assertNotNull(workFlowDefinition.getWorks());
 			assertEquals(2, workFlowDefinition.getWorks().size());
-			assertEquals("restCallTask", workFlowDefinition.getWorks().get(0).getName());
-			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK,
-					workFlowDefinition.getWorks().get(0).getWorkType());
-			assertTrue(CollectionUtils.isEmpty(workFlowDefinition.getWorks().get(0).getWorks()));
-			assertNull(workFlowDefinition.getWorks().get(0).getProcessingType());
-			assertNotNull(workFlowDefinition.getWorks().get(0).getParameters());
+			List<WorkDefinitionResponseDTO> works = workFlowDefinition.getWorks().stream().toList();
+			assertEquals("restCallTask", works.get(0).getName());
+			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK, works.get(0).getWorkType());
+			assertTrue(CollectionUtils.isEmpty(works.get(0).getWorks()));
+			assertNull(works.get(0).getProcessingType());
+			assertNotNull(works.get(0).getParameters());
 
-			assertEquals("loggingTask", workFlowDefinition.getWorks().get(1).getName());
-			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK,
-					workFlowDefinition.getWorks().get(1).getWorkType());
-			assertTrue(CollectionUtils.isEmpty(workFlowDefinition.getWorks().get(1).getWorks()));
-			assertNull(workFlowDefinition.getWorks().get(1).getProcessingType());
-			assertNotNull(workFlowDefinition.getWorks().get(1).getParameters());
+			assertEquals("loggingTask", works.get(1).getName());
+			assertEquals(WorkDefinitionResponseDTO.WorkTypeEnum.TASK, works.get(1).getWorkType());
+			assertTrue(CollectionUtils.isEmpty(works.get(1).getWorks()));
+			assertNull(works.get(1).getProcessingType());
+			assertNotNull(works.get(1).getParameters());
 		};
 	}
 

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/FailedWithAlertMessageWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/FailedWithAlertMessageWorkFlowTest.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.flows.negative;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
@@ -86,13 +87,13 @@ public class FailedWithAlertMessageWorkFlowTest {
 
 			assertThat(workFlowDefinition.getWorks()).isNotNull();
 			assertThat(workFlowDefinition.getWorks()).hasSize(2);
-			assertThat(workFlowDefinition.getWorks().get(1).getName()).isEqualTo("doNothingAgainWorkFlowTask");
-			assertThat(workFlowDefinition.getWorks().get(1).getWorkType())
-					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
-			assertThat(workFlowDefinition.getWorks().get(1).getWorks()).isNullOrEmpty();
-			assertThat(workFlowDefinition.getWorks().get(1).getProcessingType()).isNull();
-			assertThat(workFlowDefinition.getWorks().get(1).getParameters()).isNotNull();
-			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("failedWithAlertMessageWorkFlowTask");
+			List<WorkDefinitionResponseDTO> works = workFlowDefinition.getWorks().stream().toList();
+			assertThat(works.get(1).getName()).isEqualTo("doNothingAgainWorkFlowTask");
+			assertThat(works.get(1).getWorkType()).isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(works.get(1).getWorks()).isNullOrEmpty();
+			assertThat(works.get(1).getProcessingType()).isNull();
+			assertThat(works.get(1).getParameters()).isNotNull();
+			assertThat(works.get(0).getName()).isEqualTo("failedWithAlertMessageWorkFlowTask");
 		};
 	}
 

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/PendingWithAlertMessageWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/PendingWithAlertMessageWorkFlowTest.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.flows.negative;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
@@ -86,13 +87,13 @@ public class PendingWithAlertMessageWorkFlowTest {
 
 			assertThat(workFlowDefinition.getWorks()).isNotNull();
 			assertThat(workFlowDefinition.getWorks()).hasSize(2);
-			assertThat(workFlowDefinition.getWorks().get(1).getName()).isEqualTo("doNothingWorkFlowTask");
-			assertThat(workFlowDefinition.getWorks().get(1).getWorkType())
-					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
-			assertThat(workFlowDefinition.getWorks().get(1).getWorks()).isNullOrEmpty();
-			assertThat(workFlowDefinition.getWorks().get(1).getProcessingType()).isNull();
-			assertThat(workFlowDefinition.getWorks().get(1).getParameters()).isNotNull();
-			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("pendingWithAlertMessageWorkFlowTask");
+			List<WorkDefinitionResponseDTO> works = workFlowDefinition.getWorks().stream().toList();
+			assertThat(works.get(1).getName()).isEqualTo("doNothingWorkFlowTask");
+			assertThat(works.get(1).getWorkType()).isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(works.get(1).getWorks()).isNullOrEmpty();
+			assertThat(works.get(1).getProcessingType()).isNull();
+			assertThat(works.get(1).getParameters()).isNotNull();
+			assertThat(works.get(0).getName()).isEqualTo("pendingWithAlertMessageWorkFlowTask");
 		};
 	}
 

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/SequentialFailedWithExceptionWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/SequentialFailedWithExceptionWorkFlowTest.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.flows.negative;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 public class SequentialFailedWithExceptionWorkFlowTest {
@@ -77,12 +79,13 @@ public class SequentialFailedWithExceptionWorkFlowTest {
 
 			assertThat(workFlowDefinition.getWorks()).isNotNull();
 			assertThat(workFlowDefinition.getWorks()).hasSize(1);
-			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("failedWithExceptionWorkFlowTask");
-			assertThat(workFlowDefinition.getWorks().get(0).getWorkType())
-					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
-			assertThat(workFlowDefinition.getWorks().get(0).getWorks()).isNullOrEmpty();
-			assertThat(workFlowDefinition.getWorks().get(0).getProcessingType()).isNull();
-			assertThat(workFlowDefinition.getWorks().get(0).getParameters()).isNotNull();
+			Optional<WorkDefinitionResponseDTO> firstWork = workFlowDefinition.getWorks().stream().findFirst();
+			assertTrue(firstWork.isPresent());
+			assertThat(firstWork.get().getName()).isEqualTo("failedWithExceptionWorkFlowTask");
+			assertThat(firstWork.get().getWorkType()).isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(firstWork.get().getWorks()).isNullOrEmpty();
+			assertThat(firstWork.get().getProcessingType()).isNull();
+			assertThat(firstWork.get().getParameters()).isNotNull();
 		};
 	}
 

--- a/integration-tests/src/test/java/com/redhat/parodos/flows/negative/SequentialFailedWorkFlowTest.java
+++ b/integration-tests/src/test/java/com/redhat/parodos/flows/negative/SequentialFailedWorkFlowTest.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.flows.negative;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.redhat.parodos.flows.common.WorkFlowTestBuilder;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 public class SequentialFailedWorkFlowTest {
@@ -74,12 +76,13 @@ public class SequentialFailedWorkFlowTest {
 
 			assertThat(workFlowDefinition.getWorks()).isNotNull();
 			assertThat(workFlowDefinition.getWorks()).hasSize(1);
-			assertThat(workFlowDefinition.getWorks().get(0).getName()).isEqualTo("failedWorkFlowTask");
-			assertThat(workFlowDefinition.getWorks().get(0).getWorkType())
-					.isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
-			assertThat(workFlowDefinition.getWorks().get(0).getWorks()).isNullOrEmpty();
-			assertThat(workFlowDefinition.getWorks().get(0).getProcessingType()).isNull();
-			assertThat(workFlowDefinition.getWorks().get(0).getParameters()).isNotNull();
+			Optional<WorkDefinitionResponseDTO> firstWork = workFlowDefinition.getWorks().stream().findFirst();
+			assertTrue(firstWork.isPresent());
+			assertThat(firstWork.get().getName()).isEqualTo("failedWorkFlowTask");
+			assertThat(firstWork.get().getWorkType()).isEqualTo(WorkDefinitionResponseDTO.WorkTypeEnum.TASK);
+			assertThat(firstWork.get().getWorks()).isNullOrEmpty();
+			assertThat(firstWork.get().getProcessingType()).isNull();
+			assertThat(firstWork.get().getParameters()).isNotNull();
 		};
 	}
 

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/WorkType.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/enums/WorkType.java
@@ -24,6 +24,6 @@ package com.redhat.parodos.workflow.enums;
  */
 public enum WorkType {
 
-	TASK, WORKFLOW
+	TASK, WORKFLOW, CHECKER
 
 }

--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -1242,10 +1242,12 @@ components:
       type: object
     WorkDefinitionResponseDTO:
       example:
+        cronExpression: cronExpression
         outputs:
         - EXCEPTION
         - EXCEPTION
         processingType: SEQUENTIAL
+        workFlowCheckerMappingDefinitionId: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
         works:
         - null
         - null
@@ -1258,6 +1260,8 @@ components:
             key: "{}"
       properties:
         author:
+          type: string
+        cronExpression:
           type: string
         id:
           format: uuid
@@ -1284,6 +1288,9 @@ components:
           - SEQUENTIAL
           - PARALLEL
           - OTHER
+          type: string
+        workFlowCheckerMappingDefinitionId:
+          format: uuid
           type: string
         workType:
           enum:
@@ -1420,10 +1427,12 @@ components:
         cronExpression: cronExpression
         processingType: SEQUENTIAL
         works:
-        - outputs:
+        - cronExpression: cronExpression
+          outputs:
           - EXCEPTION
           - EXCEPTION
           processingType: SEQUENTIAL
+          workFlowCheckerMappingDefinitionId: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           works:
           - null
           - null
@@ -1434,10 +1443,12 @@ components:
           parameters:
             key:
               key: "{}"
-        - outputs:
+        - cronExpression: cronExpression
+          outputs:
           - EXCEPTION
           - EXCEPTION
           processingType: SEQUENTIAL
+          workFlowCheckerMappingDefinitionId: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           works:
           - null
           - null

--- a/workflow-service-sdk/api/openapi.yaml
+++ b/workflow-service-sdk/api/openapi.yaml
@@ -1289,11 +1289,13 @@ components:
           enum:
           - TASK
           - WORKFLOW
+          - CHECKER
           type: string
         works:
           items:
             $ref: '#/components/schemas/WorkDefinitionResponseDTO'
           type: array
+          uniqueItems: true
       type: object
     WorkFlowCheckerTaskRequestDTO:
       example:
@@ -1415,6 +1417,7 @@ components:
       type: object
     WorkFlowDefinitionResponseDTO:
       example:
+        cronExpression: cronExpression
         processingType: SEQUENTIAL
         works:
         - outputs:
@@ -1463,6 +1466,8 @@ components:
         createDate:
           format: date-time
           type: string
+        cronExpression:
+          type: string
         fallbackWorkflow:
           type: string
         id:
@@ -1498,6 +1503,7 @@ components:
           items:
             $ref: '#/components/schemas/WorkDefinitionResponseDTO'
           type: array
+          uniqueItems: true
       type: object
     WorkFlowExecutionResponseDTO:
       example:
@@ -1880,6 +1886,7 @@ components:
           enum:
           - TASK
           - WORKFLOW
+          - CHECKER
           type: string
         workName:
           type: string
@@ -1917,6 +1924,7 @@ components:
           enum:
           - TASK
           - WORKFLOW
+          - CHECKER
           type: string
         works:
           items:

--- a/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
@@ -8,11 +8,13 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**author** | **String** |  |  [optional] |
+|**cronExpression** | **String** |  |  [optional] |
 |**id** | **UUID** |  |  [optional] |
 |**name** | **String** |  |  [optional] |
 |**outputs** | [**List&lt;OutputsEnum&gt;**](#List&lt;OutputsEnum&gt;) |  |  [optional] |
 |**parameters** | **Map&lt;String, Map&lt;String, Object&gt;&gt;** |  |  [optional] |
 |**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional] |
+|**workFlowCheckerMappingDefinitionId** | **UUID** |  |  [optional] |
 |**workType** | [**WorkTypeEnum**](#WorkTypeEnum) |  |  [optional] |
 |**works** | [**Set&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
 

--- a/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkDefinitionResponseDTO.md
@@ -14,7 +14,7 @@
 |**parameters** | **Map&lt;String, Map&lt;String, Object&gt;&gt;** |  |  [optional] |
 |**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional] |
 |**workType** | [**WorkTypeEnum**](#WorkTypeEnum) |  |  [optional] |
-|**works** | [**List&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
+|**works** | [**Set&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
 
 
 
@@ -45,6 +45,7 @@
 |---- | -----|
 | TASK | &quot;TASK&quot; |
 | WORKFLOW | &quot;WORKFLOW&quot; |
+| CHECKER | &quot;CHECKER&quot; |
 
 
 

--- a/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkFlowDefinitionResponseDTO.md
@@ -9,6 +9,7 @@
 |------------ | ------------- | ------------- | -------------|
 |**author** | **String** |  |  [optional] |
 |**createDate** | **Date** |  |  [optional] |
+|**cronExpression** | **String** |  |  [optional] |
 |**fallbackWorkflow** | **String** |  |  [optional] |
 |**id** | **UUID** |  |  [optional] |
 |**modifyDate** | **Date** |  |  [optional] |
@@ -17,7 +18,7 @@
 |**processingType** | [**ProcessingTypeEnum**](#ProcessingTypeEnum) |  |  [optional] |
 |**properties** | [**WorkFlowPropertiesDefinitionDTO**](WorkFlowPropertiesDefinitionDTO.md) |  |  [optional] |
 |**type** | [**TypeEnum**](#TypeEnum) |  |  [optional] |
-|**works** | [**List&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
+|**works** | [**Set&lt;WorkDefinitionResponseDTO&gt;**](WorkDefinitionResponseDTO.md) |  |  [optional] |
 
 
 

--- a/workflow-service-sdk/docs/WorkRequestDTO.md
+++ b/workflow-service-sdk/docs/WorkRequestDTO.md
@@ -20,6 +20,7 @@
 |---- | -----|
 | TASK | &quot;TASK&quot; |
 | WORKFLOW | &quot;WORKFLOW&quot; |
+| CHECKER | &quot;CHECKER&quot; |
 
 
 

--- a/workflow-service-sdk/docs/WorkStatusResponseDTO.md
+++ b/workflow-service-sdk/docs/WorkStatusResponseDTO.md
@@ -34,6 +34,7 @@
 |---- | -----|
 | TASK | &quot;TASK&quot; |
 | WORKFLOW | &quot;WORKFLOW&quot; |
+| CHECKER | &quot;CHECKER&quot; |
 
 
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -188,7 +189,9 @@ public class WorkDefinitionResponseDTO {
 
 		TASK("TASK"),
 
-		WORKFLOW("WORKFLOW");
+		WORKFLOW("WORKFLOW"),
+
+		CHECKER("CHECKER");
 
 		private String value;
 
@@ -239,7 +242,7 @@ public class WorkDefinitionResponseDTO {
 	public static final String SERIALIZED_NAME_WORKS = "works";
 
 	@SerializedName(SERIALIZED_NAME_WORKS)
-	private List<WorkDefinitionResponseDTO> works;
+	private Set<WorkDefinitionResponseDTO> works;
 
 	public WorkDefinitionResponseDTO() {
 	}
@@ -393,7 +396,7 @@ public class WorkDefinitionResponseDTO {
 		this.workType = workType;
 	}
 
-	public WorkDefinitionResponseDTO works(List<WorkDefinitionResponseDTO> works) {
+	public WorkDefinitionResponseDTO works(Set<WorkDefinitionResponseDTO> works) {
 
 		this.works = works;
 		return this;
@@ -401,7 +404,7 @@ public class WorkDefinitionResponseDTO {
 
 	public WorkDefinitionResponseDTO addWorksItem(WorkDefinitionResponseDTO worksItem) {
 		if (this.works == null) {
-			this.works = new ArrayList<>();
+			this.works = new LinkedHashSet<>();
 		}
 		this.works.add(worksItem);
 		return this;
@@ -412,11 +415,11 @@ public class WorkDefinitionResponseDTO {
 	 * @return works
 	 **/
 	@javax.annotation.Nullable
-	public List<WorkDefinitionResponseDTO> getWorks() {
+	public Set<WorkDefinitionResponseDTO> getWorks() {
 		return works;
 	}
 
-	public void setWorks(List<WorkDefinitionResponseDTO> works) {
+	public void setWorks(Set<WorkDefinitionResponseDTO> works) {
 		this.works = works;
 	}
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkDefinitionResponseDTO.java
@@ -48,6 +48,11 @@ public class WorkDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_AUTHOR)
 	private String author;
 
+	public static final String SERIALIZED_NAME_CRON_EXPRESSION = "cronExpression";
+
+	@SerializedName(SERIALIZED_NAME_CRON_EXPRESSION)
+	private String cronExpression;
+
 	public static final String SERIALIZED_NAME_ID = "id";
 
 	@SerializedName(SERIALIZED_NAME_ID)
@@ -181,6 +186,11 @@ public class WorkDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_PROCESSING_TYPE)
 	private ProcessingTypeEnum processingType;
 
+	public static final String SERIALIZED_NAME_WORK_FLOW_CHECKER_MAPPING_DEFINITION_ID = "workFlowCheckerMappingDefinitionId";
+
+	@SerializedName(SERIALIZED_NAME_WORK_FLOW_CHECKER_MAPPING_DEFINITION_ID)
+	private UUID workFlowCheckerMappingDefinitionId;
+
 	/**
 	 * Gets or Sets workType
 	 */
@@ -264,6 +274,25 @@ public class WorkDefinitionResponseDTO {
 
 	public void setAuthor(String author) {
 		this.author = author;
+	}
+
+	public WorkDefinitionResponseDTO cronExpression(String cronExpression) {
+
+		this.cronExpression = cronExpression;
+		return this;
+	}
+
+	/**
+	 * Get cronExpression
+	 * @return cronExpression
+	 **/
+	@javax.annotation.Nullable
+	public String getCronExpression() {
+		return cronExpression;
+	}
+
+	public void setCronExpression(String cronExpression) {
+		this.cronExpression = cronExpression;
 	}
 
 	public WorkDefinitionResponseDTO id(UUID id) {
@@ -377,6 +406,25 @@ public class WorkDefinitionResponseDTO {
 		this.processingType = processingType;
 	}
 
+	public WorkDefinitionResponseDTO workFlowCheckerMappingDefinitionId(UUID workFlowCheckerMappingDefinitionId) {
+
+		this.workFlowCheckerMappingDefinitionId = workFlowCheckerMappingDefinitionId;
+		return this;
+	}
+
+	/**
+	 * Get workFlowCheckerMappingDefinitionId
+	 * @return workFlowCheckerMappingDefinitionId
+	 **/
+	@javax.annotation.Nullable
+	public UUID getWorkFlowCheckerMappingDefinitionId() {
+		return workFlowCheckerMappingDefinitionId;
+	}
+
+	public void setWorkFlowCheckerMappingDefinitionId(UUID workFlowCheckerMappingDefinitionId) {
+		this.workFlowCheckerMappingDefinitionId = workFlowCheckerMappingDefinitionId;
+	}
+
 	public WorkDefinitionResponseDTO workType(WorkTypeEnum workType) {
 
 		this.workType = workType;
@@ -433,18 +481,22 @@ public class WorkDefinitionResponseDTO {
 		}
 		WorkDefinitionResponseDTO workDefinitionResponseDTO = (WorkDefinitionResponseDTO) o;
 		return Objects.equals(this.author, workDefinitionResponseDTO.author)
+				&& Objects.equals(this.cronExpression, workDefinitionResponseDTO.cronExpression)
 				&& Objects.equals(this.id, workDefinitionResponseDTO.id)
 				&& Objects.equals(this.name, workDefinitionResponseDTO.name)
 				&& Objects.equals(this.outputs, workDefinitionResponseDTO.outputs)
 				&& Objects.equals(this.parameters, workDefinitionResponseDTO.parameters)
 				&& Objects.equals(this.processingType, workDefinitionResponseDTO.processingType)
+				&& Objects.equals(this.workFlowCheckerMappingDefinitionId,
+						workDefinitionResponseDTO.workFlowCheckerMappingDefinitionId)
 				&& Objects.equals(this.workType, workDefinitionResponseDTO.workType)
 				&& Objects.equals(this.works, workDefinitionResponseDTO.works);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(author, id, name, outputs, parameters, processingType, workType, works);
+		return Objects.hash(author, cronExpression, id, name, outputs, parameters, processingType,
+				workFlowCheckerMappingDefinitionId, workType, works);
 	}
 
 	@Override
@@ -452,11 +504,14 @@ public class WorkDefinitionResponseDTO {
 		StringBuilder sb = new StringBuilder();
 		sb.append("class WorkDefinitionResponseDTO {\n");
 		sb.append("    author: ").append(toIndentedString(author)).append("\n");
+		sb.append("    cronExpression: ").append(toIndentedString(cronExpression)).append("\n");
 		sb.append("    id: ").append(toIndentedString(id)).append("\n");
 		sb.append("    name: ").append(toIndentedString(name)).append("\n");
 		sb.append("    outputs: ").append(toIndentedString(outputs)).append("\n");
 		sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
 		sb.append("    processingType: ").append(toIndentedString(processingType)).append("\n");
+		sb.append("    workFlowCheckerMappingDefinitionId: ")
+				.append(toIndentedString(workFlowCheckerMappingDefinitionId)).append("\n");
 		sb.append("    workType: ").append(toIndentedString(workType)).append("\n");
 		sb.append("    works: ").append(toIndentedString(works)).append("\n");
 		sb.append("}");
@@ -482,11 +537,13 @@ public class WorkDefinitionResponseDTO {
 		// a set of all properties/fields (JSON key names)
 		openapiFields = new HashSet<String>();
 		openapiFields.add("author");
+		openapiFields.add("cronExpression");
 		openapiFields.add("id");
 		openapiFields.add("name");
 		openapiFields.add("outputs");
 		openapiFields.add("parameters");
 		openapiFields.add("processingType");
+		openapiFields.add("workFlowCheckerMappingDefinitionId");
 		openapiFields.add("workType");
 		openapiFields.add("works");
 
@@ -530,6 +587,12 @@ public class WorkDefinitionResponseDTO {
 					String.format("Expected the field `author` to be a primitive type in the JSON string but got `%s`",
 							jsonObj.get("author").toString()));
 		}
+		if ((jsonObj.get("cronExpression") != null && !jsonObj.get("cronExpression").isJsonNull())
+				&& !jsonObj.get("cronExpression").isJsonPrimitive()) {
+			throw new IllegalArgumentException(String.format(
+					"Expected the field `cronExpression` to be a primitive type in the JSON string but got `%s`",
+					jsonObj.get("cronExpression").toString()));
+		}
 		if ((jsonObj.get("id") != null && !jsonObj.get("id").isJsonNull()) && !jsonObj.get("id").isJsonPrimitive()) {
 			throw new IllegalArgumentException(
 					String.format("Expected the field `id` to be a primitive type in the JSON string but got `%s`",
@@ -552,6 +615,13 @@ public class WorkDefinitionResponseDTO {
 			throw new IllegalArgumentException(String.format(
 					"Expected the field `processingType` to be a primitive type in the JSON string but got `%s`",
 					jsonObj.get("processingType").toString()));
+		}
+		if ((jsonObj.get("workFlowCheckerMappingDefinitionId") != null
+				&& !jsonObj.get("workFlowCheckerMappingDefinitionId").isJsonNull())
+				&& !jsonObj.get("workFlowCheckerMappingDefinitionId").isJsonPrimitive()) {
+			throw new IllegalArgumentException(String.format(
+					"Expected the field `workFlowCheckerMappingDefinitionId` to be a primitive type in the JSON string but got `%s`",
+					jsonObj.get("workFlowCheckerMappingDefinitionId").toString()));
 		}
 		if ((jsonObj.get("workType") != null && !jsonObj.get("workType").isJsonNull())
 				&& !jsonObj.get("workType").isJsonPrimitive()) {

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
@@ -13,11 +13,10 @@
 package com.redhat.parodos.sdk.model;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -57,6 +56,11 @@ public class WorkFlowDefinitionResponseDTO {
 
 	@SerializedName(SERIALIZED_NAME_FALLBACK_WORKFLOW)
 	private String fallbackWorkflow;
+
+	public static final String SERIALIZED_NAME_CRON_EXPRESSION = "cronExpression";
+
+	@SerializedName(SERIALIZED_NAME_CRON_EXPRESSION)
+	private String cronExpression;
 
 	public static final String SERIALIZED_NAME_ID = "id";
 
@@ -204,7 +208,7 @@ public class WorkFlowDefinitionResponseDTO {
 	public static final String SERIALIZED_NAME_WORKS = "works";
 
 	@SerializedName(SERIALIZED_NAME_WORKS)
-	private List<WorkDefinitionResponseDTO> works;
+	private Set<WorkDefinitionResponseDTO> works;
 
 	public WorkFlowDefinitionResponseDTO() {
 	}
@@ -264,6 +268,25 @@ public class WorkFlowDefinitionResponseDTO {
 
 	public void setFallbackWorkflow(String fallbackWorkflow) {
 		this.fallbackWorkflow = fallbackWorkflow;
+	}
+
+	public WorkFlowDefinitionResponseDTO cronExpression(String cronExpression) {
+
+		this.cronExpression = cronExpression;
+		return this;
+	}
+
+	/**
+	 * Get cronExpression
+	 * @return cronExpression
+	 **/
+	@javax.annotation.Nullable
+	public String getCronExpression() {
+		return cronExpression;
+	}
+
+	public void setCronExpression(String cronExpression) {
+		this.cronExpression = cronExpression;
 	}
 
 	public WorkFlowDefinitionResponseDTO id(UUID id) {
@@ -407,7 +430,7 @@ public class WorkFlowDefinitionResponseDTO {
 		this.type = type;
 	}
 
-	public WorkFlowDefinitionResponseDTO works(List<WorkDefinitionResponseDTO> works) {
+	public WorkFlowDefinitionResponseDTO works(Set<WorkDefinitionResponseDTO> works) {
 
 		this.works = works;
 		return this;
@@ -415,7 +438,7 @@ public class WorkFlowDefinitionResponseDTO {
 
 	public WorkFlowDefinitionResponseDTO addWorksItem(WorkDefinitionResponseDTO worksItem) {
 		if (this.works == null) {
-			this.works = new ArrayList<>();
+			this.works = new LinkedHashSet<>();
 		}
 		this.works.add(worksItem);
 		return this;
@@ -426,11 +449,11 @@ public class WorkFlowDefinitionResponseDTO {
 	 * @return works
 	 **/
 	@javax.annotation.Nullable
-	public List<WorkDefinitionResponseDTO> getWorks() {
+	public Set<WorkDefinitionResponseDTO> getWorks() {
 		return works;
 	}
 
-	public void setWorks(List<WorkDefinitionResponseDTO> works) {
+	public void setWorks(Set<WorkDefinitionResponseDTO> works) {
 		this.works = works;
 	}
 
@@ -445,6 +468,7 @@ public class WorkFlowDefinitionResponseDTO {
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = (WorkFlowDefinitionResponseDTO) o;
 		return Objects.equals(this.author, workFlowDefinitionResponseDTO.author)
 				&& Objects.equals(this.createDate, workFlowDefinitionResponseDTO.createDate)
+				&& Objects.equals(this.cronExpression, workFlowDefinitionResponseDTO.cronExpression)
 				&& Objects.equals(this.fallbackWorkflow, workFlowDefinitionResponseDTO.fallbackWorkflow)
 				&& Objects.equals(this.id, workFlowDefinitionResponseDTO.id)
 				&& Objects.equals(this.modifyDate, workFlowDefinitionResponseDTO.modifyDate)
@@ -458,8 +482,8 @@ public class WorkFlowDefinitionResponseDTO {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(author, createDate, fallbackWorkflow, id, modifyDate, name, parameters, processingType,
-				properties, type, works);
+		return Objects.hash(author, createDate, cronExpression, id, modifyDate, name, parameters, processingType,
+				properties, rollbackWorkflow, type, works);
 	}
 
 	@Override
@@ -469,6 +493,7 @@ public class WorkFlowDefinitionResponseDTO {
 		sb.append("    author: ").append(toIndentedString(author)).append("\n");
 		sb.append("    createDate: ").append(toIndentedString(createDate)).append("\n");
 		sb.append("    fallbackWorkflow: ").append(toIndentedString(fallbackWorkflow)).append("\n");
+		sb.append("    cronExpression: ").append(toIndentedString(cronExpression)).append("\n");
 		sb.append("    id: ").append(toIndentedString(id)).append("\n");
 		sb.append("    modifyDate: ").append(toIndentedString(modifyDate)).append("\n");
 		sb.append("    name: ").append(toIndentedString(name)).append("\n");
@@ -501,6 +526,7 @@ public class WorkFlowDefinitionResponseDTO {
 		openapiFields = new HashSet<String>();
 		openapiFields.add("author");
 		openapiFields.add("createDate");
+		openapiFields.add("cronExpression");
 		openapiFields.add("fallbackWorkflow");
 		openapiFields.add("id");
 		openapiFields.add("modifyDate");
@@ -551,6 +577,12 @@ public class WorkFlowDefinitionResponseDTO {
 			throw new IllegalArgumentException(
 					String.format("Expected the field `author` to be a primitive type in the JSON string but got `%s`",
 							jsonObj.get("author").toString()));
+		}
+		if ((jsonObj.get("cronExpression") != null && !jsonObj.get("cronExpression").isJsonNull())
+				&& !jsonObj.get("cronExpression").isJsonPrimitive()) {
+			throw new IllegalArgumentException(String.format(
+					"Expected the field `cronExpression` to be a primitive type in the JSON string but got `%s`",
+					jsonObj.get("cronExpression").toString()));
 		}
 		if ((jsonObj.get("fallbackWorkflow") != null && !jsonObj.get("fallbackWorkflow").isJsonNull())
 				&& !jsonObj.get("fallbackWorkflow").isJsonPrimitive()) {

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkFlowDefinitionResponseDTO.java
@@ -52,15 +52,15 @@ public class WorkFlowDefinitionResponseDTO {
 	@SerializedName(SERIALIZED_NAME_CREATE_DATE)
 	private Date createDate;
 
-	public static final String SERIALIZED_NAME_FALLBACK_WORKFLOW = "fallbackWorkflow";
-
-	@SerializedName(SERIALIZED_NAME_FALLBACK_WORKFLOW)
-	private String fallbackWorkflow;
-
 	public static final String SERIALIZED_NAME_CRON_EXPRESSION = "cronExpression";
 
 	@SerializedName(SERIALIZED_NAME_CRON_EXPRESSION)
 	private String cronExpression;
+
+	public static final String SERIALIZED_NAME_FALLBACK_WORKFLOW = "fallbackWorkflow";
+
+	@SerializedName(SERIALIZED_NAME_FALLBACK_WORKFLOW)
+	private String fallbackWorkflow;
 
 	public static final String SERIALIZED_NAME_ID = "id";
 
@@ -251,25 +251,6 @@ public class WorkFlowDefinitionResponseDTO {
 		this.createDate = createDate;
 	}
 
-	public WorkFlowDefinitionResponseDTO fallbackWorkflow(String fallbackWorkflow) {
-
-		this.fallbackWorkflow = fallbackWorkflow;
-		return this;
-	}
-
-	/**
-	 * Get fallbackWorkflow
-	 * @return fallbackWorkflow
-	 **/
-	@javax.annotation.Nullable
-	public String getFallbackWorkflow() {
-		return fallbackWorkflow;
-	}
-
-	public void setFallbackWorkflow(String fallbackWorkflow) {
-		this.fallbackWorkflow = fallbackWorkflow;
-	}
-
 	public WorkFlowDefinitionResponseDTO cronExpression(String cronExpression) {
 
 		this.cronExpression = cronExpression;
@@ -287,6 +268,25 @@ public class WorkFlowDefinitionResponseDTO {
 
 	public void setCronExpression(String cronExpression) {
 		this.cronExpression = cronExpression;
+	}
+
+	public WorkFlowDefinitionResponseDTO fallbackWorkflow(String fallbackWorkflow) {
+
+		this.fallbackWorkflow = fallbackWorkflow;
+		return this;
+	}
+
+	/**
+	 * Get fallbackWorkflow
+	 * @return fallbackWorkflow
+	 **/
+	@javax.annotation.Nullable
+	public String getFallbackWorkflow() {
+		return fallbackWorkflow;
+	}
+
+	public void setFallbackWorkflow(String fallbackWorkflow) {
+		this.fallbackWorkflow = fallbackWorkflow;
 	}
 
 	public WorkFlowDefinitionResponseDTO id(UUID id) {
@@ -482,8 +482,8 @@ public class WorkFlowDefinitionResponseDTO {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(author, createDate, cronExpression, id, modifyDate, name, parameters, processingType,
-				properties, rollbackWorkflow, type, works);
+		return Objects.hash(author, createDate, cronExpression, fallbackWorkflow, id, modifyDate, name, parameters,
+				processingType, properties, type, works);
 	}
 
 	@Override
@@ -492,8 +492,8 @@ public class WorkFlowDefinitionResponseDTO {
 		sb.append("class WorkFlowDefinitionResponseDTO {\n");
 		sb.append("    author: ").append(toIndentedString(author)).append("\n");
 		sb.append("    createDate: ").append(toIndentedString(createDate)).append("\n");
-		sb.append("    fallbackWorkflow: ").append(toIndentedString(fallbackWorkflow)).append("\n");
 		sb.append("    cronExpression: ").append(toIndentedString(cronExpression)).append("\n");
+		sb.append("    fallbackWorkflow: ").append(toIndentedString(fallbackWorkflow)).append("\n");
 		sb.append("    id: ").append(toIndentedString(id)).append("\n");
 		sb.append("    modifyDate: ").append(toIndentedString(modifyDate)).append("\n");
 		sb.append("    name: ").append(toIndentedString(name)).append("\n");

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkRequestDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkRequestDTO.java
@@ -52,7 +52,9 @@ public class WorkRequestDTO {
 
 		TASK("TASK"),
 
-		WORKFLOW("WORKFLOW");
+		WORKFLOW("WORKFLOW"),
+
+		CHECKER("CHECKER");
 
 		private String value;
 

--- a/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
+++ b/workflow-service-sdk/src/main/java/com/redhat/parodos/sdk/model/WorkStatusResponseDTO.java
@@ -124,7 +124,9 @@ public class WorkStatusResponseDTO {
 
 		TASK("TASK"),
 
-		WORKFLOW("WORKFLOW");
+		WORKFLOW("WORKFLOW"),
+
+		CHECKER("CHECKER");
 
 		private String value;
 

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -1688,7 +1688,7 @@
           },
           "workType" : {
             "type" : "string",
-            "enum" : [ "TASK", "WORKFLOW" ]
+            "enum" : [ "TASK", "WORKFLOW", "CHECKER" ]
           },
           "works" : {
             "type" : "array",
@@ -1729,6 +1729,9 @@
             "type" : "string",
             "format" : "date-time"
           },
+          "cronExpression" : {
+            "type" : "string"
+          },
           "fallbackWorkflow" : {
             "type" : "string"
           },
@@ -1764,6 +1767,7 @@
             "enum" : [ "ASSESSMENT", "CHECKER", "INFRASTRUCTURE", "ESCALATION" ]
           },
           "works" : {
+            "uniqueItems" : true,
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/WorkDefinitionResponseDTO"
@@ -2006,7 +2010,7 @@
           },
           "type" : {
             "type" : "string",
-            "enum" : [ "TASK", "WORKFLOW" ]
+            "enum" : [ "TASK", "WORKFLOW", "CHECKER" ]
           },
           "workName" : {
             "type" : "string"
@@ -2037,7 +2041,7 @@
           },
           "type" : {
             "type" : "string",
-            "enum" : [ "TASK", "WORKFLOW" ]
+            "enum" : [ "TASK", "WORKFLOW", "CHECKER" ]
           },
           "works" : {
             "type" : "array",

--- a/workflow-service/generated/openapi/openapi.json
+++ b/workflow-service/generated/openapi/openapi.json
@@ -1659,6 +1659,9 @@
           "author" : {
             "type" : "string"
           },
+          "cronExpression" : {
+            "type" : "string"
+          },
           "id" : {
             "type" : "string",
             "format" : "uuid"
@@ -1686,11 +1689,16 @@
             "type" : "string",
             "enum" : [ "SEQUENTIAL", "PARALLEL", "OTHER" ]
           },
+          "workFlowCheckerMappingDefinitionId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
           "workType" : {
             "type" : "string",
             "enum" : [ "TASK", "WORKFLOW", "CHECKER" ]
           },
           "works" : {
+            "uniqueItems" : true,
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/WorkDefinitionResponseDTO"

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -15,10 +15,9 @@
  */
 package com.redhat.parodos.workflow.definition.dto;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -63,14 +62,17 @@ public class WorkDefinitionResponseDTO {
 
 	private String author;
 
-	private Set<WorkDefinitionResponseDTO> works;
+	private LinkedHashSet<WorkDefinitionResponseDTO> works;
 
 	private Map<String, Map<String, Object>> parameters;
 
 	private List<WorkFlowTaskOutput> outputs;
 
-	@JsonIgnore
-	private UUID checkerWorkId;
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private UUID workFlowCheckerMappingDefinitionId;
+
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private String cronExpression;
 
 	@JsonIgnore
 	private Integer numberOfWorkUnits;
@@ -92,8 +94,8 @@ public class WorkDefinitionResponseDTO {
 	public static WorkDefinitionResponseDTO fromWorkFlowDefinitionEntity(WorkFlowDefinition wd,
 			List<WorkFlowWorkDefinition> dependencies) {
 		return WorkDefinitionResponseDTO.builder().id(wd.getId()).workType(WorkType.WORKFLOW).name(wd.getName())
-				.parameterFromString(wd.getParameters()).processingType(wd.getProcessingType()).works(new HashSet<>())
-				.numberOfWorkUnits(dependencies.size()).build();
+				.parameterFromString(wd.getParameters()).processingType(wd.getProcessingType())
+				.works(new LinkedHashSet<>()).numberOfWorkUnits(dependencies.size()).build();
 	}
 
 	public static WorkDefinitionResponseDTO fromWorkFlowTaskDefinition(WorkFlowTaskDefinition wdt) {
@@ -103,15 +105,18 @@ public class WorkDefinitionResponseDTO {
 				}, List.of())).numberOfWorkUnits(0);
 
 		if (wdt.getWorkFlowCheckerMappingDefinition() != null) {
-			builder = builder.checkerWorkId(wdt.getWorkFlowCheckerMappingDefinition().getId());
+			builder = builder.workFlowCheckerMappingDefinitionId(wdt.getWorkFlowCheckerMappingDefinition().getId());
 		}
 
 		return builder.build();
 	}
 
 	public static WorkDefinitionResponseDTO fromWorkFlowCheckerMappingDefinition(WorkFlowCheckerMappingDefinition wcd) {
-		return WorkDefinitionResponseDTO.builder().workType(WorkType.CHECKER).numberOfWorkUnits(wcd.getTasks().size())
-				.checkerWorkId(wcd.getCheckWorkFlow().getCheckerWorkFlowDefinition().getId()).build();
+		return WorkDefinitionResponseDTO.builder().id(wcd.getCheckWorkFlow().getId())
+				.name(wcd.getCheckWorkFlow().getName()).parameterFromString(wcd.getCheckWorkFlow().getParameters())
+				.processingType(wcd.getCheckWorkFlow().getProcessingType()).workType(WorkType.CHECKER)
+				.numberOfWorkUnits(wcd.getCheckWorkFlow().getNumberOfWorks()).cronExpression(wcd.getCronExpression())
+				.build();
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -16,9 +16,9 @@
 package com.redhat.parodos.workflow.definition.dto;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -68,10 +68,13 @@ public class WorkFlowDefinitionResponseDTO {
 	private WorkFlowPropertiesDefinitionDTO properties;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private List<WorkDefinitionResponseDTO> works;
+	private Set<WorkDefinitionResponseDTO> works;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String fallbackWorkflow;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String cronExpression;
 
 	public static class WorkFlowDefinitionResponseDTOBuilder {
 
@@ -88,15 +91,20 @@ public class WorkFlowDefinitionResponseDTO {
 	}
 
 	public static WorkFlowDefinitionResponseDTO fromEntity(WorkFlowDefinition workFlowDefinition,
-			List<WorkDefinitionResponseDTO> works) {
-		return WorkFlowDefinitionResponseDTO.builder().id(workFlowDefinition.getId()).name(workFlowDefinition.getName())
+			Set<WorkDefinitionResponseDTO> works) {
+		WorkFlowDefinitionResponseDTOBuilder builder = WorkFlowDefinitionResponseDTO.builder()
+				.id(workFlowDefinition.getId()).name(workFlowDefinition.getName())
 				.properties(WorkFlowPropertiesDefinitionDTO.fromEntity(workFlowDefinition.getProperties()))
 				.parameterFromString(workFlowDefinition.getParameters()).author(workFlowDefinition.getAuthor())
 				.createDate(workFlowDefinition.getCreateDate()).modifyDate(workFlowDefinition.getModifyDate())
 				.type(workFlowDefinition.getType()).processingType(workFlowDefinition.getProcessingType()).works(works)
 				.fallbackWorkflow(Optional.ofNullable(workFlowDefinition.getFallbackWorkFlowDefinition())
-						.map(WorkFlowDefinition::getName).orElse(null))
-				.build();
+						.map(WorkFlowDefinition::getName).orElse(null));
+
+		if (workFlowDefinition.getCheckerWorkFlowDefinition() != null) {
+			builder = builder.cronExpression(workFlowDefinition.getCheckerWorkFlowDefinition().getCronExpression());
+		}
+		return builder.build();
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
@@ -16,6 +16,7 @@
 package com.redhat.parodos.workflow.definition.dto.converter;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,11 +36,11 @@ import org.modelmapper.spi.MappingContext;
  */
 
 public class WorkFlowTaskDefinitionDTOConverter
-		implements Converter<List<WorkFlowTaskDefinition>, List<WorkDefinitionResponseDTO>> {
+		implements Converter<List<WorkFlowTaskDefinition>, Set<WorkDefinitionResponseDTO>> {
 
 	@Override
-	public List<WorkDefinitionResponseDTO> convert(
-			MappingContext<List<WorkFlowTaskDefinition>, List<WorkDefinitionResponseDTO>> context) {
+	public Set<WorkDefinitionResponseDTO> convert(
+			MappingContext<List<WorkFlowTaskDefinition>, Set<WorkDefinitionResponseDTO>> context) {
 		ObjectMapper objectMapper = new ObjectMapper();
 		List<WorkFlowTaskDefinition> source = context.getSource();
 		return source.stream().map(workFlowTaskDefinition -> {
@@ -52,7 +53,7 @@ public class WorkFlowTaskDefinitionDTOConverter
 			catch (JsonProcessingException e) {
 				throw new WorkflowDefinitionException(e);
 			}
-		}).collect(Collectors.toList());
+		}).collect(Collectors.toSet());
 	}
 
 }

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
@@ -16,8 +16,8 @@
 package com.redhat.parodos.workflow;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -113,14 +113,13 @@ class WorkFlowDelegateTest {
 	}
 
 	private WorkFlowDefinitionResponseDTO sampleWorkflowDefinitionResponse() {
-		return WorkFlowDefinitionResponseDTO
-				.builder().name(
-						TEST_WORKFLOW_NAME)
-				.works(Set.of(WorkDefinitionResponseDTO.builder().name(TEST_SUB_WORKFLOW_NAME)
-						.workType(WorkType.WORKFLOW).works(Set.of(WorkDefinitionResponseDTO.builder()
-								.name(TEST_TASK_NAME).workType(WorkType.TASK).build()))
-						.build()))
-				.build();
+		LinkedHashSet<WorkDefinitionResponseDTO> workFlowWorks = new LinkedHashSet<>();
+		LinkedHashSet<WorkDefinitionResponseDTO> taskWorks = new LinkedHashSet<>();
+
+		taskWorks.add(WorkDefinitionResponseDTO.builder().name(TEST_TASK_NAME).workType(WorkType.TASK).build());
+		workFlowWorks.add(WorkDefinitionResponseDTO.builder().name(TEST_SUB_WORKFLOW_NAME).workType(WorkType.WORKFLOW)
+				.works(taskWorks).build());
+		return WorkFlowDefinitionResponseDTO.builder().name(TEST_WORKFLOW_NAME).works(workFlowWorks).build();
 	}
 
 }

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/WorkFlowDelegateTest.java
@@ -17,6 +17,7 @@ package com.redhat.parodos.workflow;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -115,8 +116,8 @@ class WorkFlowDelegateTest {
 		return WorkFlowDefinitionResponseDTO
 				.builder().name(
 						TEST_WORKFLOW_NAME)
-				.works(List.of(WorkDefinitionResponseDTO.builder().name(TEST_SUB_WORKFLOW_NAME)
-						.workType(WorkType.WORKFLOW).works(List.of(WorkDefinitionResponseDTO.builder()
+				.works(Set.of(WorkDefinitionResponseDTO.builder().name(TEST_SUB_WORKFLOW_NAME)
+						.workType(WorkType.WORKFLOW).works(Set.of(WorkDefinitionResponseDTO.builder()
 								.name(TEST_TASK_NAME).workType(WorkType.TASK).build()))
 						.build()))
 				.build();

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
@@ -1,6 +1,7 @@
 package com.redhat.parodos.workflow.definition.controller;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import com.redhat.parodos.ControllerMockClient;
@@ -167,7 +168,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = new WorkFlowDefinitionResponseDTO();
 		workFlowDefinitionResponseDTO.setName(name);
 		workFlowDefinitionResponseDTO.setId(UUID.randomUUID());
-		workFlowDefinitionResponseDTO.setWorks(List.of(createSampleWorkFlowTaskDefinition("task1")));
+		workFlowDefinitionResponseDTO.setWorks(Set.of(createSampleWorkFlowTaskDefinition("task1")));
 		return workFlowDefinitionResponseDTO;
 	}
 

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
+import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
@@ -53,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -248,10 +250,11 @@ class WorkFlowDefinitionServiceImplTest {
 
 		verify(this.workFlowDefinitionRepository, times(1)).findFirstByName(any());
 		when(this.workFlowDefinitionRepository.findFirstByName(any())).thenReturn(sampleWorkFlowDefinition(TEST));
-
+		Optional<WorkDefinitionResponseDTO> firstWork = result.getWorks().stream().findFirst();
+		assertTrue(firstWork.isPresent());
 		assertEquals(result.getWorks().size(), 1);
-		assertEquals(result.getWorks().get(0).getName(), "SubWorkFlow");
-		assertEquals(result.getWorks().get(0).getWorkType(), WorkType.WORKFLOW);
+		assertEquals(firstWork.get().getName(), "SubWorkFlow");
+		assertEquals(firstWork.get().getWorkType(), WorkType.WORKFLOW);
 	}
 
 	@Test

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.redhat.parodos.common.exceptions.IllegalWorkFlowStateException;
@@ -164,7 +165,7 @@ class WorkFlowServiceImplTest {
 		workFlowExecution.setId(UUID.randomUUID());
 		when(this.workFlowRepository.save(any())).thenReturn(workFlowExecution);
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = WorkFlowDefinitionResponseDTO.builder()
-				.name(TEST_WORKFLOW_NAME).works(List.of()).build();
+				.name(TEST_WORKFLOW_NAME).works(Set.of()).build();
 		when(this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST_WORKFLOW_NAME))
 				.thenReturn(workFlowDefinitionResponseDTO);
 		when(this.userService.getUserEntityByUsername("test-user")).thenReturn(user);
@@ -206,7 +207,7 @@ class WorkFlowServiceImplTest {
 		UUID invokingExecutionId = UUID.randomUUID();
 		when(this.workFlowRepository.findById(invokingExecutionId)).thenReturn(Optional.empty());
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = WorkFlowDefinitionResponseDTO.builder()
-				.name(TEST_WORKFLOW_NAME).works(List.of()).build();
+				.name(TEST_WORKFLOW_NAME).works(Set.of()).build();
 		when(this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST_WORKFLOW_NAME))
 				.thenReturn(workFlowDefinitionResponseDTO);
 		when(this.userService.getUserEntityByUsername("test-user")).thenReturn(user);
@@ -264,7 +265,7 @@ class WorkFlowServiceImplTest {
 		// @formatter:on
 		when(this.workFlowRepository.findById(invokingExecutionId)).thenReturn(Optional.of(invokingWorkFlowExecution));
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = WorkFlowDefinitionResponseDTO.builder()
-				.name(TEST_WORKFLOW_NAME).works(List.of()).build();
+				.name(TEST_WORKFLOW_NAME).works(Set.of()).build();
 		when(this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST_WORKFLOW_NAME))
 				.thenReturn(workFlowDefinitionResponseDTO);
 		when(this.userService.getUserEntityByUsername("test-user")).thenReturn(user);
@@ -331,7 +332,7 @@ class WorkFlowServiceImplTest {
 		// @formatter:on
 		when(this.workFlowRepository.findById(invokingExecutionId)).thenReturn(Optional.of(invokingWorkFlowExecution));
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = WorkFlowDefinitionResponseDTO.builder()
-				.name(TEST_WORKFLOW_NAME).works(List.of()).build();
+				.name(TEST_WORKFLOW_NAME).works(Set.of()).build();
 		when(this.workFlowDefinitionService.getWorkFlowDefinitionByName(TEST_WORKFLOW_NAME))
 				.thenReturn(workFlowDefinitionResponseDTO);
 		when(this.userService.getUserEntityByUsername("test-user")).thenReturn(user);


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- If the PR includes auto generated code, make sure to add this code in different commit (last commit), to make the review process easier.
-->

**What this PR does / why we need it**:
Currently, when WorkFlowDefinition are requested (`/api/v1/workflowdefinitions`), the checkers associated to tasks are not returned.
This PR introduces changes so those checkers are returned.
The way the work units of each WorfFlowDefinition are built has been refactored (see `WorkFlowDefinitionServiceImpl`)
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story (FLPATH-xxxx)*:
Fixes #[FLPATH-294](https://issues.redhat.com//browse/FLPATH-294)

**Change type**
- [x] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
