### PR TITLE
[FLPATH-507] Throw exceptions when validating workflow

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/common/controller/ControllerExceptionHandler.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/controller/ControllerExceptionHandler.java
@@ -11,6 +11,9 @@ import com.redhat.parodos.common.exceptions.IllegalWorkFlowStateException;
 import com.redhat.parodos.common.exceptions.OperationDeniedException;
 import com.redhat.parodos.common.exceptions.ResourceAlreadyExistsException;
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
+import com.redhat.parodos.common.exceptions.UnregisteredWorkFlowException;
+import com.redhat.parodos.common.exceptions.WorkFlowNotFoundException;
+import com.redhat.parodos.common.exceptions.WorkFlowWrongTypeException;
 import com.redhat.parodos.workflow.exceptions.WorkflowExecutionException;
 
 import org.springframework.http.HttpStatus;
@@ -73,6 +76,30 @@ public class ControllerExceptionHandler {
 	public ErrorMessageDTO workflowExecutionException(WorkflowExecutionException ex, WebRequest request) {
 		return new ErrorMessageDTO(HttpStatus.INTERNAL_SERVER_ERROR.value(), new Date(), ex.getMessage(),
 				"Workflow execution exception");
+	}
+
+	@ExceptionHandler(value = { WorkFlowWrongTypeException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public ErrorMessageDTO workFlowWrongTypeException(WorkFlowWrongTypeException ex, WebRequest request) {
+		return new ErrorMessageDTO(HttpStatus.BAD_REQUEST.value(), new Date(), ex.getMessage(),
+				"Workflow wrong type exception");
+	}
+
+	@ExceptionHandler(value = { UnregisteredWorkFlowException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public ErrorMessageDTO unregisteredWorkFlowException(UnregisteredWorkFlowException ex, WebRequest request) {
+		return new ErrorMessageDTO(HttpStatus.BAD_REQUEST.value(), new Date(), ex.getMessage(),
+				"Un-registered Workflow exception");
+	}
+
+	@ExceptionHandler(value = { WorkFlowNotFoundException.class })
+	@ResponseBody
+	@ResponseStatus(value = HttpStatus.NOT_FOUND)
+	public ErrorMessageDTO workFlowNotFoundException(WorkFlowNotFoundException ex, WebRequest request) {
+		return new ErrorMessageDTO(HttpStatus.NOT_FOUND.value(), new Date(), ex.getMessage(),
+				"Workflow not found exception");
 	}
 
 	record ErrorMessageDTO(int status, Date date, String message, String description) {

--- a/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/UnregisteredWorkFlowException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/UnregisteredWorkFlowException.java
@@ -1,0 +1,13 @@
+package com.redhat.parodos.common.exceptions;
+
+public class UnregisteredWorkFlowException extends RuntimeException {
+
+	public UnregisteredWorkFlowException(String msg) {
+		super(msg);
+	}
+
+	public UnregisteredWorkFlowException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/WorkFlowNotFoundException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/WorkFlowNotFoundException.java
@@ -1,0 +1,13 @@
+package com.redhat.parodos.common.exceptions;
+
+public class WorkFlowNotFoundException extends RuntimeException {
+
+	public WorkFlowNotFoundException(String msg) {
+		super(msg);
+	}
+
+	public WorkFlowNotFoundException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/WorkFlowWrongTypeException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/common/exceptions/WorkFlowWrongTypeException.java
@@ -1,0 +1,13 @@
+package com.redhat.parodos.common.exceptions;
+
+public class WorkFlowWrongTypeException extends RuntimeException {
+
+	public WorkFlowWrongTypeException(String msg) {
+		super(msg);
+	}
+
+	public WorkFlowWrongTypeException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/controller/WorkFlowController.java
@@ -22,7 +22,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
 import com.redhat.parodos.workflow.context.WorkContextDelegate;
-import com.redhat.parodos.workflow.exceptions.WorkflowExecutionException;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowContextResponseDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowExecutionResponseDTO;
@@ -34,7 +33,6 @@ import com.redhat.parodos.workflow.execution.validation.PubliclyVisible;
 import com.redhat.parodos.workflow.task.log.service.WorkFlowLogService;
 import com.redhat.parodos.workflow.utils.WorkContextUtils;
 import com.redhat.parodos.workflows.work.WorkReport;
-import com.redhat.parodos.workflows.work.WorkStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -89,10 +87,6 @@ public class WorkFlowController {
 	public ResponseEntity<WorkFlowExecutionResponseDTO> execute(
 			@RequestBody @Valid WorkFlowRequestDTO workFlowRequestDTO) {
 		WorkReport workReport = workFlowService.execute(workFlowRequestDTO);
-		if (workReport.getStatus() == WorkStatus.FAILED) {
-			throw new WorkflowExecutionException(
-					"Workflow execution for %s failed".formatted(workFlowRequestDTO.getWorkFlowName()));
-		}
 		return ResponseEntity.ok(WorkFlowExecutionResponseDTO.builder()
 				.workFlowExecutionId(WorkContextUtils.getMainExecutionId(workReport.getWorkContext()))
 				.workStatus(workReport.getStatus()).build());
@@ -126,10 +120,6 @@ public class WorkFlowController {
 	@PostMapping("/{workFlowExecutionId}/restart")
 	public ResponseEntity<WorkFlowExecutionResponseDTO> restartWorkFlow(@PathVariable UUID workFlowExecutionId) {
 		WorkReport workReport = workFlowService.restart(workFlowExecutionId);
-		if (workReport.getStatus() == WorkStatus.FAILED) {
-			throw new WorkflowExecutionException(
-					"Restart of workflow execution %s failed".formatted(workFlowExecutionId));
-		}
 		return ResponseEntity.ok(WorkFlowExecutionResponseDTO.builder()
 				.workFlowExecutionId(WorkContextUtils.getMainExecutionId(workReport.getWorkContext()))
 				.workStatus(workReport.getStatus()).build());

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImpl.java
@@ -29,6 +29,9 @@ import javax.annotation.PreDestroy;
 import com.redhat.parodos.common.exceptions.IllegalWorkFlowStateException;
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
 import com.redhat.parodos.common.exceptions.ResourceType;
+import com.redhat.parodos.common.exceptions.UnregisteredWorkFlowException;
+import com.redhat.parodos.common.exceptions.WorkFlowNotFoundException;
+import com.redhat.parodos.common.exceptions.WorkFlowWrongTypeException;
 import com.redhat.parodos.project.dto.response.ProjectResponseDTO;
 import com.redhat.parodos.project.service.ProjectService;
 import com.redhat.parodos.security.SecurityUtils;
@@ -142,10 +145,7 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 		User user = userService.getUserEntityByUsername(SecurityUtils.getUsername());
 		String workflowName = workFlowRequestDTO.getWorkFlowName();
 		WorkFlow workFlow = workFlowDelegate.getWorkFlowByName(workflowName);
-		String validationFailedMsg = validateWorkflow(workflowName, workFlow);
-		if (validationFailedMsg != null) {
-			return new DefaultWorkReport(WorkStatus.FAILED, new WorkContext(), new Throwable(validationFailedMsg));
-		}
+		validateWorkflow(workflowName, workFlow);
 
 		WorkFlowDefinitionResponseDTO workFlowDefinitionResponseDTO = workFlowDefinitionService
 				.getWorkFlowDefinitionByName(workflowName);
@@ -442,26 +442,25 @@ public class WorkFlowServiceImpl implements WorkFlowService {
 		return workFlowRepository.findRunningCheckersById(mainWorkFlow.getId());
 	}
 
-	private String validateWorkflow(String workflowName, WorkFlow workFlow) {
+	private void validateWorkflow(String workflowName, WorkFlow workFlow) {
 		// validate if workflow exists
 		if (workFlow == null) {
 			log.error("workflow '{}' is not found!", workflowName);
-			return String.format("workflow '%s' cannot be found!", workflowName);
+			throw new WorkFlowNotFoundException(String.format("workflow '%s' cannot be found!", workflowName));
 		}
 
 		// validate if workflow is main
 		WorkFlowDefinition workFlowDefinition = workFlowDefinitionRepository.findFirstByName(workflowName);
 		if (workFlowDefinition == null) {
-			return String.format("workflow '%s' is not registered!", workflowName);
+			throw new UnregisteredWorkFlowException(String.format("workflow '%s' is not registered!", workflowName));
 		}
 
 		if (workFlowWorkRepository.findFirstByWorkDefinitionId(workFlowDefinition.getId()) != null) {
 			log.error("workflow '{}' is not main workflow!", workflowName);
-			return String.format("workflow '%s' is not main workflow!", workflowName);
+			throw new WorkFlowWrongTypeException(String.format("workflow '%s' is not main workflow!", workflowName));
 		}
 
 		// TODO: validate required parameters from definition
-		return null;
 	}
 
 	@PreDestroy

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/controller/WorkFlowControllerTest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.ControllerMockClient;
+import com.redhat.parodos.common.exceptions.WorkFlowNotFoundException;
 import com.redhat.parodos.workflow.enums.WorkType;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowCheckerTaskRequestDTO;
 import com.redhat.parodos.workflow.execution.dto.WorkFlowRequestDTO;
@@ -15,7 +16,6 @@ import com.redhat.parodos.workflow.execution.dto.WorkStatusResponseDTO;
 import com.redhat.parodos.workflow.execution.service.WorkFlowLogServiceImpl;
 import com.redhat.parodos.workflow.execution.service.WorkFlowServiceImpl;
 import com.redhat.parodos.workflow.version.WorkFlowVersionService;
-import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -110,12 +110,12 @@ class WorkFlowControllerTest extends ControllerMockClient {
 		ObjectMapper objectMapper = new ObjectMapper();
 		String json = objectMapper.writeValueAsString(workFlowRequestDTO);
 
-		WorkReport workReport = new DefaultWorkReport(WorkStatus.FAILED, new WorkContext(), new Throwable());
-		when(this.workFlowService.execute(any())).thenReturn(workReport);
+		// Mock the validation of the WorkFlow: not found error is thrown
+		when(this.workFlowService.execute(any())).thenThrow(new WorkFlowNotFoundException("Test"));
 
 		// when
 		this.mockMvc.perform(this.postRequestWithValidCredentials("/api/v1/workflows").content(json))
-				.andExpect(MockMvcResultMatchers.status().isInternalServerError());
+				.andExpect(MockMvcResultMatchers.status().isNotFound());
 
 		// then
 		verify(this.workFlowService, times(1)).execute(any());

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
@@ -9,6 +9,9 @@ import java.util.UUID;
 
 import com.redhat.parodos.common.exceptions.IllegalWorkFlowStateException;
 import com.redhat.parodos.common.exceptions.ResourceNotFoundException;
+import com.redhat.parodos.common.exceptions.UnregisteredWorkFlowException;
+import com.redhat.parodos.common.exceptions.WorkFlowNotFoundException;
+import com.redhat.parodos.common.exceptions.WorkFlowWrongTypeException;
 import com.redhat.parodos.project.dto.response.ProjectResponseDTO;
 import com.redhat.parodos.project.service.ProjectService;
 import com.redhat.parodos.user.entity.User;
@@ -128,15 +131,10 @@ class WorkFlowServiceImplTest {
 		when(this.workFlowDelegate.getWorkFlowByName(any())).thenReturn(null);
 
 		// when
-		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
-				.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build());
-
-		// then
-		assertNotNull(report);
-		assertEquals(report.getStatus().toString(), "FAILED");
-		assertNotNull(report.getError());
-
-		assertNotNull(report.getWorkContext());
+		assertThat(assertThrows(WorkFlowNotFoundException.class,
+				() -> this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
+						.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build())))
+								.hasMessage("workflow '%s' cannot be found!".formatted(TEST_WORKFLOW_NAME));
 
 		verify(this.workFlowDelegate, times(1)).getWorkFlowByName(any());
 		verify(this.workFlowDelegate, times(0)).initWorkFlowContext(any(), any());
@@ -377,15 +375,11 @@ class WorkFlowServiceImplTest {
 		when(this.workFlowDelegate.getWorkFlowByName(TEST_WORKFLOW_NAME)).thenReturn(workFlow);
 
 		// when
-		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
-				.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build());
-
+		assertThat(assertThrows(WorkFlowWrongTypeException.class,
+				() -> this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
+						.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build())))
+								.hasMessage("workflow '%s' is not main workflow!".formatted(TEST_WORKFLOW_NAME));
 		// then
-		assertNotNull(report);
-		assertEquals(report.getStatus().toString(), "FAILED");
-		assertNotNull(report.getError());
-
-		assertNotNull(report.getWorkContext());
 
 		verify(this.workFlowDelegate, times(1)).getWorkFlowByName(any());
 		verify(this.workFlowDelegate, times(0)).initWorkFlowContext(any(), any());
@@ -402,15 +396,10 @@ class WorkFlowServiceImplTest {
 		when(this.workFlowDelegate.getWorkFlowByName(TEST_WORKFLOW_NAME)).thenReturn(workFlow);
 
 		// when
-		WorkReport report = this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
-				.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build());
-
-		// then
-		assertNotNull(report);
-		assertEquals(report.getStatus().toString(), "FAILED");
-		assertNotNull(report.getError());
-
-		assertNotNull(report.getWorkContext());
+		assertThat(assertThrows(UnregisteredWorkFlowException.class,
+				() -> this.workFlowService.execute(WorkFlowRequestDTO.builder().projectId(UUID.randomUUID())
+						.works(List.of()).workFlowName(TEST_WORKFLOW_NAME).build())))
+								.hasMessage("workflow '%s' is not registered!".formatted(TEST_WORKFLOW_NAME));
 
 		verify(this.workFlowDelegate, times(1)).getWorkFlowByName(any());
 		verify(this.workFlowDelegate, never()).initWorkFlowContext(any(), any());


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- If the PR includes auto generated code, make sure to add this code in different commit (last commit), to make the review process easier.
-->

**What this PR does / why we need it**:
When executing a workFlow, if the validation of the request failed, the workflow was not executed and a report with FAILED status was returned. Hence, the controller had to test the report status and return a `WorkflowExecutionException`
Now the exceptions are thrown directly when validating the workFlow in the WorkFlowService, this allows to have better and more meaningful response.

Fixes #[FLPATH-507](https://issues.redhat.com//browse/FLPATH-507)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [x] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
