### PR TITLE
feat: multiple authn changes

### DIFF
--- a/hack/manifests/backstage/app-config.yaml
+++ b/hack/manifests/backstage/app-config.yaml
@@ -63,20 +63,22 @@ proxy:
     changeOrigin: true
     redirect: follow
     cache: 'no-cache'
+    allowedHeaders:
+      - Authorization
     headers:
       Content-Type: 'application/json'
       accept: 'application/json'
-      Authorization: 'Basic dGVzdDp0ZXN0'
 
   '/parodos-notifications':
     target: 'http://notification-service:8080/api/v1'
     changeOrigin: true
     redirect: follow
     cache: 'no-cache'
+    allowedHeaders:
+      - Authorization
     headers:
       Content-Type: 'application/json'
       accept: 'application/json'
-      Authorization: 'Basic dGVzdDp0ZXN0'
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/workflow-service/src/main/resources/application-dev.yml
+++ b/workflow-service/src/main/resources/application-dev.yml
@@ -9,12 +9,12 @@ spring:
       base-dn: dc=springframework,dc=org
       port: 8389
     connection:
-      userDNPatterns: "uid={0},ou=people"
-      groupSearchBase: "ou=groups"
-      url: "ldap://ldap:389/dc=parodos,dc=dev"
-      passwordAttribute: "userPassword"
-      managerDN: "cn=admin,dc=parodos,dc=dev"
-      managerPassword: "admin"
+      userDNPatterns: "${LDAP_USERDNPATTERNS:uid={0},ou=people}"
+      groupSearchBase: "${LDAP_GROUP_SEARCH_BASE:ou=groups}"
+      url: "${LDAP_URL:ldap://ldap:389/dc=parodos,dc=dev}"
+      passwordAttribute: "${LDAP_PASSWORD_ATTRIBUTE:userPassword}"
+      managerDN: "${LDAP_MANAGER_DN:cn=admin,dc=parodos,dc=dev}"
+      managerPassword: "${LDAP_MANAGER_PASSWORD:admin}"
   lifecycle:
     timeout-per-shutdown-phase: "25s"
 

--- a/workflow-service/src/main/resources/application-local.yml
+++ b/workflow-service/src/main/resources/application-local.yml
@@ -9,12 +9,12 @@ spring:
       base-dn: dc=springframework,dc=org
       port: 8389
     connection:
-      userDNPatterns: "uid={0},ou=people"
-      groupSearchBase: "ou=groups"
-      url: "ldap://localhost:8389/dc=springframework,dc=org"
-      passwordAttribute: "userPassword"
-      managerDN: null
-      managerPassword: null
+      userDNPatterns: "${LDAP_USERDNPATTERNS:uid={0},ou=people}"
+      groupSearchBase: "${LDAP_GROUP_SEARCH_BASE:ou=groups}"
+      url: "${LDAP_URL:ldap://localhost:8389/dc=springframework,dc=org}"
+      passwordAttribute: "${LDAP_PASSWORD_ATTRIBUTE:userPassword}"
+      managerDN: "${LDAP_MANAGER_DN:}"
+      managerPassword: "${LDAP_MANAGER_PASSWORD:}"
   lifecycle:
     timeout-per-shutdown-phase: "25s"
   cloud:


### PR DESCRIPTION
These changes are not definitive, and it's just a quick fix for a user POC. The idea is still moving to openid.

- Using LDAP env variables in the config makes it easy for users to move things around.
- Disable example app-config to be able to log in as multiple users.
