### PR TITLE
FLPATH-544: `prebuilt-tasks` module must NOT depend on `workflow-service-sdk`

### DIFF
--- a/prebuilt-tasks/pom.xml
+++ b/prebuilt-tasks/pom.xml
@@ -218,6 +218,36 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.3.0</version> <!-- Adjust version as needed -->
+                <executions>
+                    <execution>
+                        <id>enforce-no-unwanted-dependency</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!--
+                                         IMPORTANT NOTE: This module (prebuilt-tasks) must not depend on workflow-service-sdk,
+                                         as it is already dependent on workflow-service. workflow-service depends on
+                                         prebuilt-tasks. Adding workflow-service-sdk here will create a circular
+                                         dependency, and workflow-service won't be able to generate the openapi.json file anymore.
+                                          -->
+                                        <exclude>dev.parodos:workflow-service-sdk</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The `prebuilt-tasks` module must not depend on `workflow-service-sdk`, as it is already dependent on `workflow-service`. `workflow-service` depends on `prebuilt-tasks`. Adding `workflow-service-sdk` dependency in `prebuilt-tasks` will create a circular dependency, and `workflow-service` won't be able to generate the `openapi.json` file anymore.

This PR introduces a check that will now prevent the build from succeeding if there is a dependency on `workflow-service-sdk`.


**Which issue(s) this PR fixes** 
Fixes # [FLPATH-544](https://issues.redhat.com/browse/FLPATH-544)

**Change type**
- [ ] New feature
- [ ] Bug fix
- [ ] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
