### PR TITLE
Add exception for invalid HTTP methods

### DIFF
--- a/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/rest/RestWorkFlowTask.java
+++ b/prebuilt-tasks/src/main/java/com/redhat/parodos/tasks/rest/RestWorkFlowTask.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.tasks.rest;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -66,7 +67,9 @@ public class RestWorkFlowTask extends BaseWorkFlowTask {
 			url = getRequiredParameterValue("url");
 			String method = getRequiredParameterValue("method");
 
-			HttpMethod httpMethod = HttpMethod.valueOf(method.toUpperCase());
+			HttpMethod httpMethod = Arrays.stream(HttpMethod.values())
+					.filter(m -> m.name().equals(method.toUpperCase())).findFirst()
+					.orElseThrow(() -> new IllegalArgumentException("Invalid HTTP method: " + method));
 
 			ResponseEntity<String> responseEntity = restService.exchange(url, httpMethod,
 					buildRequestEntity(workContext));

--- a/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/rest/RestWorkFlowTaskTest.java
+++ b/prebuilt-tasks/src/test/java/com/redhat/parodos/tasks/rest/RestWorkFlowTaskTest.java
@@ -10,7 +10,6 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -66,8 +65,6 @@ public class RestWorkFlowTaskTest {
 	}
 
 	@Test
-	@Disabled
-	// FIXME
 	public void invalidMethod() {
 		map.put("url", "http://localhost");
 		map.put("method", "drop");


### PR DESCRIPTION
**What this PR does / why we need it**:
`RestWorkFlowTask.execute` checks if provided input string method is available in HttpMethods.values(). Otherwise, it throws an `IllegalArgumentExecption`.

**Which issue(s) this PR fixes**:
Fixes: Partially fixes test disabled in PR #493 


**Change type**
- [ ] New feature
- [x] Bug fix
- [x] Unit tests
- [ ] Integration tests
- [ ] CI
- [ ] Documentation
- [ ] Auto-generated SDK code

**Impacted services**
- [ ] Workflow Service
- [ ] Notification Service

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
